### PR TITLE
Fixes for compile-time regions

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -133,20 +133,17 @@ def gtstencil(definition=None, **stencil_kwargs) -> Callable[..., None]:
                 stencil_kwargs["rebuild"] = global_config.get_rebuild()
                 stencil_kwargs["backend"] = global_config.get_backend()
 
-                # Add externals
-                final_origin = spec.grid.compute_origin(
-                    add=(*stencil_kwargs.get("origin_shift", (0, 0)), 0)
-                )
-                splitters = spec.grid.splitters(origin=final_origin)
+                if "origin" in kwargs:
+                    axis_offsets = spec.grid.axis_offsets(origin=final_origin)
+                else:
+                    axis_offsets = {}
+
                 stencil_kwargs["externals"] = {
                     "namelist": spec.namelist,
                     "grid": spec.grid,
-                    **splitters,
+                    **axis_offsets,
                     **stencil_kwargs.get("externals", dict()),
                 }
-
-                # Filter out "origin_shift"
-                stencil_kwargs.pop("origin_shift", None)
 
                 # Generate stencil
                 build_info = {}

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -135,7 +135,7 @@ def gtstencil(definition=None, **stencil_kwargs) -> Callable[..., None]:
 
             if not isinstance(first_storage, gt4py.storage.storage.Storage):
                 raise TypeError(
-                    "First stencil argument should be a gt4py.stoage.storage.Storage."
+                    "First stencil argument should be a gt4py.storage.storage.Storage."
                 )
 
             origin: Sequence[int, ...]

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -133,11 +133,10 @@ def gtstencil(definition=None, **stencil_kwargs) -> Callable[..., None]:
                 stencil_kwargs["rebuild"] = global_config.get_rebuild()
                 stencil_kwargs["backend"] = global_config.get_backend()
 
-                if "origin" in kwargs:
-                    axis_offsets = spec.grid.axis_offsets(origin=final_origin)
-                else:
-                    axis_offsets = {}
+                if not "origin" in kwargs:
+                    raise ValueError("Stencils require origin specification")
 
+                axis_offsets = spec.grid.axis_offsets(origin=kwargs["origin"])
                 stencil_kwargs["externals"] = {
                     "namelist": spec.namelist,
                     "grid": spec.grid,

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -133,16 +133,15 @@ def gtstencil(definition=None, **stencil_kwargs) -> Callable[..., None]:
                 stencil_kwargs["rebuild"] = global_config.get_rebuild()
                 stencil_kwargs["backend"] = global_config.get_backend()
 
-                if not "origin" in kwargs:
-                    raise ValueError("Stencils require origin specification")
-
-                axis_offsets = spec.grid.axis_offsets(origin=kwargs["origin"])
                 stencil_kwargs["externals"] = {
                     "namelist": spec.namelist,
                     "grid": spec.grid,
-                    **axis_offsets,
                     **stencil_kwargs.get("externals", dict()),
                 }
+                origin = kwargs.get("origin", None)
+                if origin is not None:
+                    axis_offsets = spec.grid.axis_offsets(origin=origin)
+                    stencil_kwargs.update(axis_offsets)
 
                 # Generate stencil
                 build_info = {}

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -141,7 +141,7 @@ def gtstencil(definition=None, **stencil_kwargs) -> Callable[..., None]:
                 origin = kwargs.get("origin", None)
                 if origin is not None:
                     axis_offsets = spec.grid.axis_offsets(origin=origin)
-                    stencil_kwargs.update(axis_offsets)
+                    stencil_kwargs["externals"].update(axis_offsets)
 
                 # Generate stencil
                 build_info = {}

--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -55,7 +55,7 @@ def nonhydro_y_fluxes(delp: sd, pt: sd, w: sd, vtc: sd):
     return fy, fy1, fy2
 
 
-@gtstencil(origin_shift=(-1, -1))
+@gtstencil()
 def transportdelp(
     delp: sd, pt: sd, utc: sd, vtc: sd, w: sd, rarea: sd, delpc: sd, ptc: sd, wc: sd
 ):

--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -35,6 +35,7 @@ def absolute_vorticity(vort: sd, fC: sd, rarea_c: sd):
         vort[0, 0, 0] = fC + rarea_c * vort
 
 
+@gtscript.function
 def nonhydro_x_fluxes(delp: sd, pt: sd, w: sd, utc: sd):
     fx1 = delp[-1, 0, 0] if utc > 0.0 else delp
     fx = pt[-1, 0, 0] if utc > 0.0 else pt
@@ -45,6 +46,7 @@ def nonhydro_x_fluxes(delp: sd, pt: sd, w: sd, utc: sd):
     return fx, fx1, fx2
 
 
+@gtscript.function
 def nonhydro_y_fluxes(delp: sd, pt: sd, w: sd, vtc: sd):
     fy1 = delp[0, -1, 0] if vtc > 0.0 else delp
     fy = pt[0, -1, 0] if vtc > 0.0 else pt

--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -35,7 +35,6 @@ def absolute_vorticity(vort: sd, fC: sd, rarea_c: sd):
         vort[0, 0, 0] = fC + rarea_c * vort
 
 
-@gtscript.function
 def nonhydro_x_fluxes(delp: sd, pt: sd, w: sd, utc: sd):
     fx1 = delp[-1, 0, 0] if utc > 0.0 else delp
     fx = pt[-1, 0, 0] if utc > 0.0 else pt
@@ -46,7 +45,6 @@ def nonhydro_x_fluxes(delp: sd, pt: sd, w: sd, utc: sd):
     return fx, fx1, fx2
 
 
-@gtscript.function
 def nonhydro_y_fluxes(delp: sd, pt: sd, w: sd, vtc: sd):
     fy1 = delp[0, -1, 0] if vtc > 0.0 else delp
     fy = pt[0, -1, 0] if vtc > 0.0 else pt
@@ -57,7 +55,7 @@ def nonhydro_y_fluxes(delp: sd, pt: sd, w: sd, vtc: sd):
     return fy, fy1, fy2
 
 
-@gtstencil()
+@gtstencil(origin_shift=(-1, -1))
 def transportdelp(
     delp: sd, pt: sd, utc: sd, vtc: sd, w: sd, rarea: sd, delpc: sd, ptc: sd, wc: sd
 ):
@@ -137,7 +135,7 @@ def divergence_corner(
         rarea_c: inverse cell areas on c-grid (input)
         divg_d: divergence on d-grid (output)
     """
-    from __splitters__ import i_end, i_start, j_end, j_start
+    from __externals__ import i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
         uf = (
@@ -177,7 +175,7 @@ def circulation_cgrid(uc: sd, vc: sd, dxc: sd, dyc: sd, vort_c: sd):
         dyc: grid spacing in y-dir (input)
         vort_c: C-grid vorticity (output)
     """
-    from __splitters__ import i_end, i_start, j_end, j_start
+    from __externals__ import i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
         fx = dxc * uc

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -411,7 +411,7 @@ def damp_vertical_wind(w, heat_s, diss_e, dt, column_namelist):
 
 @gtstencil()
 def ubke(uc: sd, vc: sd, cosa: sd, rsina: sd, ut: sd, ub: sd, dt4: float, dt5: float):
-    from __splitters__ import i_end, i_start, j_end, j_start
+    from __externals__ import i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
         ub = dt5 * (uc[0, -1, 0] + uc - (vc[-1, 0, 0] + vc) * cosa) * rsina
@@ -424,7 +424,7 @@ def ubke(uc: sd, vc: sd, cosa: sd, rsina: sd, ut: sd, ub: sd, dt4: float, dt5: f
 
 @gtstencil()
 def vbke(vc: sd, uc: sd, cosa: sd, rsina: sd, vt: sd, vb: sd, dt4: float, dt5: float):
-    from __splitters__ import i_end, i_start, j_end, j_start
+    from __externals__ import i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
         vb = dt5 * (vc[-1, 0, 0] + vc - (uc[0, -1, 0] + uc) * cosa) * rsina

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -151,7 +151,7 @@ def compute(state, comm):
         state.dp_ref = utils.make_storage_from_shape(
             state.ak.shape, grid.default_origin()
         )
-        dp_ref_compute(state.ak, state.bk, state.dp_ref, origin=grid.compute_origin())
+        dp_ref_compute(state.ak, state.bk, state.dp_ref)
         state.zs = state.phis * rgrav
     n_con = get_n_con()
 

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -151,7 +151,7 @@ def compute(state, comm):
         state.dp_ref = utils.make_storage_from_shape(
             state.ak.shape, grid.default_origin()
         )
-        dp_ref_compute(state.ak, state.bk, state.dp_ref)
+        dp_ref_compute(state.ak, state.bk, state.dp_ref, origin=grid.compute_origin())
         state.zs = state.phis * rgrav
     n_con = get_n_con()
 

--- a/fv3core/stencils/ke_c_sw.py
+++ b/fv3core/stencils/ke_c_sw.py
@@ -9,7 +9,7 @@ from fv3core.decorators import gtstencil
 sd = utils.sd
 
 
-@gtstencil(origin_shift=(-1, -1))
+@gtstencil()
 def update_vorticity_and_kinetic_energy(
     ke: sd,
     vort: sd,

--- a/fv3core/stencils/ke_c_sw.py
+++ b/fv3core/stencils/ke_c_sw.py
@@ -9,7 +9,7 @@ from fv3core.decorators import gtstencil
 sd = utils.sd
 
 
-@gtstencil()
+@gtstencil(origin_shift=(-1, -1))
 def update_vorticity_and_kinetic_energy(
     ke: sd,
     vort: sd,
@@ -29,8 +29,7 @@ def update_vorticity_and_kinetic_energy(
     cos_sg4: sd,
     dt2: float,
 ):
-    from __externals__ import namelist
-    from __splitters__ import i_end, i_start, j_end, j_start
+    from __externals__ import i_end, i_start, j_end, j_start, namelist
 
     with computation(PARALLEL), interval(...):
         assert __INLINED(namelist.grid_type < 3)

--- a/fv3core/stencils/vorticitytransport_cgrid.py
+++ b/fv3core/stencils/vorticitytransport_cgrid.py
@@ -22,8 +22,7 @@ def update_zonal_velocity(
     rdxc: sd,
     dt2: float,
 ):
-    from __externals__ import namelist
-    from __splitters__ import i_end, i_start
+    from __externals__ import i_end, i_start, namelist
 
     with computation(PARALLEL), interval(...):
         assert __INLINED(namelist.grid_type < 3)
@@ -48,8 +47,7 @@ def update_meridional_velocity(
     rdyc: sd,
     dt2: float,
 ):
-    from __externals__ import namelist
-    from __splitters__ import j_end, j_start
+    from __externals__ import j_end, j_start, namelist
 
     with computation(PARALLEL), interval(...):
         assert __INLINED(namelist.grid_type < 3)
@@ -58,6 +56,7 @@ def update_meridional_velocity(
         tmp_flux = dt2 * (velocity - velocity_c * cosa) / sina
         with parallel(region[:, j_start], region[:, j_end + 1]):
             tmp_flux = dt2 * velocity
+
         flux = vorticity[0, 0, 0] if tmp_flux > 0.0 else vorticity[1, 0, 0]
         velocity_c = velocity_c - tmp_flux * flux + rdyc * (ke[0, -1, 0] - ke)
 

--- a/fv3core/utils/corners.py
+++ b/fv3core/utils/corners.py
@@ -85,18 +85,18 @@ def fill_4corners(q, direction, grid):
     origin = (grid.is_ - extent, grid.js - extent, 0)
     domain = (grid.nic + 2 * extent, grid.njc + 2 * extent, q.shape[2])
 
-    splitters = grid.splitters(origin=origin)
+    axis_offsets = grid.axis_offsets(origin=origin)
 
     kwargs = {"origin": origin, "domain": domain}
 
     if direction == "x":
         stencil = gtstencil(
-            definition=definition, externals={"func": fill_4corners_x, **splitters}
+            definition=definition, externals={"func": fill_4corners_x, **axis_offsets}
         )
         stencil(q, **kwargs)
     elif direction == "y":
         stencil = gtstencil(
-            definition=definition, externals={"func": fill_4corners_y, **splitters}
+            definition=definition, externals={"func": fill_4corners_y, **axis_offsets}
         )
         stencil(q, **kwargs)
     else:

--- a/fv3core/utils/corners.py
+++ b/fv3core/utils/corners.py
@@ -8,9 +8,8 @@ from fv3core.decorators import gtstencil
 sd = utils.sd
 
 
-@gtscript.function
 def fill_4corners_x(q: sd):
-    from __splitters__ import i_end, i_start, j_end, j_start
+    from __externals__ import i_end, i_start, j_end, j_start
 
     # copy field
     q_out = q
@@ -42,9 +41,8 @@ def fill_4corners_x(q: sd):
     return q_out
 
 
-@gtscript.function
 def fill_4corners_y(q: sd):
-    from __splitters__ import i_end, i_start, j_end, j_start
+    from __externals__ import i_end, i_start, j_end, j_start
 
     # copy field
     q_out = q
@@ -87,16 +85,19 @@ def fill_4corners(q, direction, grid):
     origin = (grid.is_ - extent, grid.js - extent, 0)
     domain = (grid.nic + 2 * extent, grid.njc + 2 * extent, q.shape[2])
 
-    kwargs = {
-        "origin": origin,
-        "domain": domain,
-    }
+    splitters = grid.splitters(origin=origin)
+
+    kwargs = {"origin": origin, "domain": domain}
 
     if direction == "x":
-        stencil = gtstencil(definition=definition, externals={"func": fill_4corners_x})
+        stencil = gtstencil(
+            definition=definition, externals={"func": fill_4corners_x, **splitters}
+        )
         stencil(q, **kwargs)
     elif direction == "y":
-        stencil = gtstencil(definition=definition, externals={"func": fill_4corners_y})
+        stencil = gtstencil(
+            definition=definition, externals={"func": fill_4corners_y, **splitters}
+        )
         stencil(q, **kwargs)
     else:
         raise ValueError("Direction not recognized. Specify either x or y")

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -99,10 +99,18 @@ class Grid:
         if origin is None:
             origin = self.compute_origin()
         return {
-            "i_start": self.is_ - self.global_is + (self.is_ - origin[0]),
-            "i_end": self.npx + self.halo - 2 - self.global_is + (self.is_ - origin[0]),
-            "j_start": self.js - self.global_js + (self.js - origin[1]),
-            "j_end": self.npy + self.halo - 2 - self.global_js + (self.js - origin[1]),
+            "i_start": self.is_ - self.global_is + (self.is_ - origin[0])
+            if self.west_edge
+            else None,
+            "i_end": self.npx + self.halo - 2 - self.global_is + (self.is_ - origin[0])
+            if self.east_edge
+            else None,
+            "j_start": self.js - self.global_js + (self.js - origin[1])
+            if self.south_edge
+            else None,
+            "j_end": self.npy + self.halo - 2 - self.global_js + (self.js - origin[1])
+            if self.north_edge
+            else None,
         }
 
     def make_quantity(

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -89,8 +89,8 @@ class Grid:
             )
         return self._quantity_factory
 
-    def splitters(self, *, origin=None):
-        """Return the splitters relative to origin.
+    def axis_offsets(self, *, origin=None):
+        """Return the axis offsets relative to origin.
 
         Args:
             origin: The compute origin


### PR DESCRIPTION
This is meant to be tested with a new `VCM/gt4py:develop` branch.

* Removes `splitters` in calls
* `__splitters__` are merged into `__externals__`
* Functions that use the axis offsets are now undecorated
* Axis offsets are set to None if not on the processor owned grid