### PR TITLE
quick fix to be able to build fv3core again after pip changes broke it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,12 @@ update_submodules:
 
 constraints.txt: requirements.txt requirements_wrapper.txt requirements_lint.txt
 	pip-compile $^ --output-file constraints.txt
-
+	sed -i '' '/^git+https/d' constraints.txt
 # Image build instructions have moved to docker/Makefile but are kept here for backwards-compatibility
 
 build_environment: update_submodules
 	$(MAKE) -C docker build_core_deps
 
-build_wrapped_environment: update_submodules
-	$(MAKE) -C docker build_deps
 
 build_wrapped_environment:
 	$(MAKE) -C external/fv3gfs-wrapper build-docker
@@ -88,9 +86,6 @@ build_wrapped: update_submodules
 
 pull_environment_if_needed:
 	$(MAKE) -C docker pull_core_deps_if_needed
-
-pull_wrapped_environment_if_needed:
-	$(MAKE) -C docker pull_deps_if_needed
 
 pull_wrapped_environment_if_needed:
 	if [ -z $(shell docker images -q $(WRAPPER_INSTALL_IMAGE)) ]; then \

--- a/constraints.txt
+++ b/constraints.txt
@@ -25,7 +25,6 @@ f90nml==1.2               # via -r requirements.txt, fv3config
 fasteners==0.15           # via zarr
 filelock==3.0.12          # via virtualenv
 fsspec==0.8.4             # via -r requirements_wrapper.txt, fv3config, gcsfs
-git+https://github.com/VulcanClimateModeling/fv3config.git@a0799928824a4f10617cf4615e8837c81ccb1f2d  # via -r requirements.txt
 gcsfs==0.7.1              # via -r requirements_wrapper.txt, fv3config
 google-auth-oauthlib==0.4.1  # via gcsfs
 google-auth==1.22.1       # via gcsfs, google-auth-oauthlib
@@ -37,7 +36,6 @@ iniconfig==1.1.1          # via pytest
 jinja2==2.11.2            # via -r requirements_wrapper.txt
 markupsafe==1.1.1         # via jinja2
 monotonic==1.5            # via fasteners
-git+https://github.com/mpi4py/mpi4py.git@aac3d8f2a56f3d74a75ad32ac0554d63e7ef90ab  # via -r requirements.txt
 multidict==4.7.6          # via aiohttp, yarl
 netcdf4==1.5.4            # via -r requirements.txt
 nodeenv==1.5.0            # via pre-commit
@@ -79,7 +77,3 @@ xarray==0.16.1            # via -r requirements.txt
 yarl==1.5.1               # via aiohttp
 zarr==2.5.0               # via -r requirements.txt
 zipp==3.3.0               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip
-# setuptools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=gt4py_image /gt4py /gt4py
 ENV BOOST_HOME=/usr/include/boost
 ARG CPPFLAGS="-I${BOOST_HOME} -I${BOOST_HOME}/boost"
 ARG GT4PY_OPTIONALS=""
-RUN pip install --no-cache-dir -c /constraints.txt "/gt4py${GT4PY_OPTIONALS}" && \
+RUN pip install --use-deprecated=legacy-resolver --no-cache-dir -c /constraints.txt "/gt4py${GT4PY_OPTIONALS}" && \
     rm -rf /gt4py && \
     python3 -m gt4py.gt_src_manager install
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,6 +22,6 @@ do
         pip install -e "$package" -c /constraints.txt
     fi
 done
-pip install -e /fv3core -c /constraints.txt
+pip install --use-deprecated=legacy-resolver -e /fv3core -c /constraints.txt
 
 exec "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,6 @@ zarr
 cftime
 git+https://github.com/mpi4py/mpi4py.git@aac3d8f2a56f3d74a75ad32ac0554d63e7ef90ab
 pip-tools
-pip
-setuptools
 wheel
 netCDF4
 hypothesis


### PR DESCRIPTION
There have been deprecation warnings for months about breaking pip install changes, and today they finally happened and broke our build in several ways. Here is a quick step to getting this repo usable again. 
We can probably remove the legacy-resolver once we update gt4py to not require pytest5.2 and attrs19.1

Also added a step to the Makefile constraints.txt endpoint to remove the git+https lines from the constraints files (egg=name does not seem to fix the error). pip-compile will probably do this for us in the near future I am guessing, at which point we can remove this line. Or maybe we will learn another way to handle it. 

Also removed some Makefile endpoints that appeared to be duplicates, likely from some merging issue. 