### PR TITLE
Run black before flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,4 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    - id: check-toml
-    - id: check-yaml
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
-    - id: flake8
-
 -   repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:
@@ -17,3 +8,12 @@ repos:
     rev: v5.4.2
     hooks:
     - id: isort
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    - id: check-toml
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+    - id: flake8


### PR DESCRIPTION
Running black before flake8 fixes many of the errors that flake8 would have flagged, causing you to have to re-run the checks again.