### PR TITLE
Enable debug_mode on GT backends by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ common options for our tests, which you can add to `TEST_ARGS`:
 $ export FV3_STENCIL_REBUILD_FLAG=False
 ```
 
-FV3Core has certain backends that use a C++ compiler. GT4Py, by default, will instruct it to heavily optimize the generated code using and skip adding debug symbols. FV3Core on the other hand, by default will add debug symbols and will not use optimization. This means stencils using C++ backends will be ready to execute faster, but could be less efficient. If the goal is to test FV3Core performance, you will want to set:
+FV3Core has certain backends that use a C++ compiler. GT4Py, by default, will instruct it to heavily optimize the generated code, and will skip adding debug symbols. FV3Core on the other hand, defaults to a development mode, adding debug symbols disabling C++ optimizations. This means stencils using C++ backends will be ready to execute faster, but could be less efficient. If the goal is to test FV3Core performance, you will want to set:
 
 ```shell
 $ export FV3_CPP_DEBUG_MODE=False

--- a/README.md
+++ b/README.md
@@ -122,10 +122,18 @@ common options for our tests, which you can add to `TEST_ARGS`:
 
 * `-m` - will let you run only certain groups of tests. For example, `-m=parallel` will run only parallel stencils, while `-m=sequential` will run only stencils that operate on one rank at a time.
 
+### Development and performance-related options
+
 **NOTE:** FV3 is current assumed to be by default in a "development mode", where stencils are checked each time they execute for code changes (which can trigger regeneration). This process is somewhat expensive, so there is an option to put FV3 in a performance mode by telling it that stencils should not automatically be rebuilt:
 
 ```shell
 $ export FV3_STENCIL_REBUILD_FLAG=False
+```
+
+FV3Core has certain backends that use a C++ compiler. GT4Py, by default, will instruct it to heavily optimize the generated code using and skip adding debug symbols. FV3Core on the other hand, by default will add debug symbols and will not use optimization. This means stencils using C++ backends will be ready to execute faster, but could be less efficient. If the goal is to test FV3Core performance, you will want to set:
+
+```shell
+$ export FV3_CPP_DEBUG_MODE=False
 ```
 
 ## Porting a new stencil

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -222,7 +222,7 @@ class FV3StencilObject:
             }
 
             if stencil_kwargs["backend"].startswith("gt"):
-                stencil_kwargs["debug_mode"] = global_config.get_debug()
+                stencil_kwargs["debug_mode"] = global_config.get_cpp_debug()
 
             # gtscript.stencil always returns a new class instance even if it
             # used the cached module.

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -221,6 +221,9 @@ class FV3StencilObject:
                 **self.backend_kwargs,
             }
 
+            if stencil_kwargs["backend"].startswith("gt"):
+                stencil_kwargs["debug_mode"] = global_config.get_debug()
+
             # gtscript.stencil always returns a new class instance even if it
             # used the cached module.
             self.stencil_object = gtscript.stencil(

--- a/fv3core/utils/global_config.py
+++ b/fv3core/utils/global_config.py
@@ -24,5 +24,15 @@ def get_rebuild() -> bool:
     return _REBUILD
 
 
-_BACKEND = None  # Options: numpy, gtx86, gtcuda, debug
+def set_cpp_debug(flag: bool):
+    global _CPP_DEBUG_MODE
+    _CPP_DEBUG_MODE = flag
+
+
+def get_cpp_debug() -> bool:
+    return _CPP_DEBUG_MODE
+
+
+_BACKEND = None  # Options: numpy, gtx86, gtmc, gtcuda, debug
 _REBUILD = getenv_bool("FV3_STENCIL_REBUILD_FLAG", "True")
+_CPP_DEBUG_MODE = getenv_bool("FV3_CPP_DEBUG_MODE", "True")


### PR DESCRIPTION
Passes `debug_mode=True` to the stencil decorator calls when using GT backends unless `FV3_CPP_DEBUG_MODE=False` is set in the shell.