### PR TITLE
Lint all files with make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,14 +186,7 @@ list_test_data_options:
 	gsutil ls $(REGRESSION_DATA_STORAGE_BUCKET)/$(FORTRAN_SERIALIZED_DATA_VERSION)
 
 lint:
-	pre-commit run
-	# pre-commit runs black for now. Will also run flake8 eventually.
-	# black --diff --check $(PYTHON_FILES) $(PYTHON_INIT_FILES)
-	# disable flake8 tests for now, re-enable when dycore is "running"
-	#@flake8 $(PYTHON_FILES)
-	# ignore unused import error in __init__.py files
-	#@flake8 --ignore=F401 $(PYTHON_INIT_FILES)
-	# @echo "LINTING SUCCESSFUL"
+	pre-commit run --all-files
 
 .PHONY: update_submodules build_environment build dev dev_tests dev_tests_mpi flake8 lint get_test_data unpack_test_data \
 	 list_test_data_options pull_environment pull_test_data push_environment \


### PR DESCRIPTION
`make lint` should operate on all files for simplicity. Some developers who choose not to install git hooks were getting in a state where the target did not correct all changes, since they had committed in a dirty state.