### PR TITLE
Tests/gt4py in fv3core

### DIFF
--- a/.jenkins/actions/update_gt4py.sh
+++ b/.jenkins/actions/update_gt4py.sh
@@ -8,5 +8,4 @@ make -C docker build_gt4py
 make gt4py_tests_gpu
 make tests
 make tests_mpi
-# TODO uncomment when verify the above works
 make -C docker push_gt4py

--- a/.jenkins/actions/update_gt4py.sh
+++ b/.jenkins/actions/update_gt4py.sh
@@ -5,7 +5,7 @@ set -x
 export CUDA=y
 make pull_environment
 make -C docker build_gt4py
-make container_gt4py_tests
+make gt4py_tests_gpu
 make tests
 make tests_mpi
 # TODO uncomment when verify the above works

--- a/.jenkins/actions/update_gt4py.sh
+++ b/.jenkins/actions/update_gt4py.sh
@@ -2,9 +2,11 @@
 set -e
 set -x
 # Run when we change the gt4py source code
-
+export CUDA=y
 make pull_environment
 make -C docker build_gt4py
+make container_gt4py_tests
 make tests
 make tests_mpi
-make -C docker push_gt4py
+# TODO uncomment when verify the above works
+#make -C docker push_gt4py

--- a/.jenkins/actions/update_gt4py.sh
+++ b/.jenkins/actions/update_gt4py.sh
@@ -9,4 +9,4 @@ make gt4py_tests_gpu
 make tests
 make tests_mpi
 # TODO uncomment when verify the above works
-#make -C docker push_gt4py
+make -C docker push_gt4py

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ lint:
 
 gt4py_tests_gpu:
 	CUDA=y make build && \
-        docker run $(CUDA_FLAGS) $(FV3_IMAGE) python3 -m pytest -x gt4py
+        docker run --gpus all $(FV3_IMAGE) python3 -m pytest -x gt4py
 
 .PHONY: update_submodules build_environment build dev dev_tests dev_tests_mpi flake8 lint get_test_data unpack_test_data \
 	 list_test_data_options pull_environment pull_test_data push_environment \

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,9 @@ list_test_data_options:
 lint:
 	pre-commit run --all-files
 
+container_gt4py_tests:
+	CUDA=y make build && \
+        docker run $(CUDA_FLAGS) $(FV3_IMAGE) python3 -m pytest -x gt4py
 
 .PHONY: update_submodules build_environment build dev dev_tests dev_tests_mpi flake8 lint get_test_data unpack_test_data \
 	 list_test_data_options pull_environment pull_test_data push_environment \

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ list_test_data_options:
 lint:
 	pre-commit run --all-files
 
-container_gt4py_tests:
+gt4py_tests_gpu:
 	CUDA=y make build && \
         docker run $(CUDA_FLAGS) $(FV3_IMAGE) python3 -m pytest -x gt4py
 

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ lint:
 
 gt4py_tests_gpu:
 	CUDA=y make build && \
-        docker run --gpus all $(FV3_IMAGE) python3 -m pytest -x gt4py
+        docker run --gpus all $(FV3_IMAGE) python3 -m pytest -x gt4py/
 
 .PHONY: update_submodules build_environment build dev dev_tests dev_tests_mpi flake8 lint get_test_data unpack_test_data \
 	 list_test_data_options pull_environment pull_test_data push_environment \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,6 @@ ARG GT4PY_OPTIONALS=""
 
 RUN if [ ! -z `echo $GT4PY_OPTIONALS | grep cuda` ] ; then pip install cupy-cuda102==7.7.0 ; else echo Not installing cuda ; fi
 RUN pip install  --no-cache-dir -c /constraints.txt "/gt4py${GT4PY_OPTIONALS}" && \
-    rm -rf /gt4py && \
     python3 -m gt4py.gt_src_manager install
 
 # This environment flag sets rebuild=False in gtscript.stencil calls

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ ARG CPPFLAGS="-I${BOOST_HOME} -I${BOOST_HOME}/boost"
 ARG GT4PY_OPTIONALS=""
 
 RUN if [ ! -z `echo $GT4PY_OPTIONALS | grep cuda` ] ; then pip install cupy-cuda102==7.7.0 ; else echo Not installing cuda ; fi
-RUN pip install  --no-cache-dir -c /constraints.txt "/gt4py${GT4PY_OPTIONALS}" && \
+RUN pip install -e --no-cache-dir -c /constraints.txt "/gt4py${GT4PY_OPTIONALS}" && \
     python3 -m gt4py.gt_src_manager install
 
 # This environment flag sets rebuild=False in gtscript.stencil calls


### PR DESCRIPTION
When we update gt4py:develop, we first run the gt4py tests, and if those pass, run the fv3core tests. But, before the gt4py tests were run directly in a virtualenv on gcp and daint. and then the fv3core tests ran in the docker image. We wanted to do this anyways because we already had a difference in python being used (3.6 vs 3.8) in the environments and risk the gt4py not behaving correctly in the image even though all the tests pass. A cuda problem on GCP that doesn't appear to come up in the image motivated us to do this step now to unblock gt4py:develop progress. 
Here we add the option to run the gt4py tests (including the cuda ones) using the image and a change to the jenkins action to enable this. Some manual changes will need to happen after this is merged as well. This was tested (without the pushing of the new gt4py) here https://jenkins.ginko.ch/job/TEST-gt4py-in-fv3core-gpu/3/console