### PR TITLE
Add `format_source` option to disable `black` formatting

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -217,6 +217,7 @@ class FV3StencilObject:
                     **axis_offsets,
                     **self._passed_externals,
                 },
+                "format_source": global_config.get_format_source(),
                 "build_info": new_build_info,
                 **self.backend_kwargs,
             }

--- a/fv3core/utils/global_config.py
+++ b/fv3core/utils/global_config.py
@@ -24,5 +24,15 @@ def get_rebuild() -> bool:
     return _REBUILD
 
 
+def set_format_source(flag: bool):
+    global _FORMAT_SOURCE
+    _FORMAT_SOURCE = flag
+
+
+def get_format_source() -> bool:
+    return _FORMAT_SOURCE
+
+
 _BACKEND = None  # Options: numpy, gtx86, gtcuda, debug
 _REBUILD = getenv_bool("FV3_STENCIL_REBUILD_FLAG", "True")
+_FORMAT_SOURCE = getenv_bool("FV3_STENCIL_FORMAT_SOURCE", "False")


### PR DESCRIPTION
This PR adds a `format_source` option to the `global_config` and modifies the decorator to set it in `stencil_kwargs`. The default value is `False` to save time when building tests.