### PR TITLE
Add 'ignore_near_zero_errors' fields to overrides/standard.yaml

### DIFF
--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -135,6 +135,10 @@ def process_override(threshold_overrides, testobj, test_name, backend):
                 testobj.max_error = float(match["max_error"])
             if "near_zero" in match:
                 testobj.near_zero = float(match["near_zero"])
+            if "ignore_near_zero_errors" in match:
+                testobj.ignore_near_zero_errors = {
+                    field: True for field in match["ignore_near_zero_errors"]
+                }
         elif len(matches) > 1:
             raise Exception(
                 "misconfigured threshold overrides file, more than 1 specification for "

--- a/tests/translate/overrides/standard.yaml
+++ b/tests/translate/overrides/standard.yaml
@@ -22,6 +22,8 @@ MapN_Tracer_2d:
   - backend: gtcuda
     max_error: 2e-7
     near_zero: 2.5e-15
+    ignore_near_zero_errors:
+      - qtracers
 
 NH_P_Grad:
   - backend: gtcuda
@@ -35,19 +37,29 @@ Remapping_Part1:
   - backend: gtcuda
     max_error: 5e-6
     near_zero: 3.5e-15
+    ignore_near_zero_errors:
+      - q_con
+      - qtracers
 
 Remapping:
   - backend: gtcuda
     near_zero: 5e-6
+    ignore_near_zero_errors:
+      - q_con
+      - tracers
 
 UpdateDzC:
   - backend: gtcuda
     max_error: 5e-10
     near_zero: 4.5e-15
+    ignore_near_zero_errors:
+      - ws
 
 UpdateDzD:
   - backend: gtcuda
     max_error: 5e-10
+    ignore_near_zero_errors:
+      - wsd
 
 FVSubgridZ:
   - backend: gtcuda


### PR DESCRIPTION
This PR adds the option to set `ignore_near_zero_errors` field names in the `overrides/standard.yaml` file by updating `test_translate.process_overrides`, and adding the appropriate field names for the `gtcuda` backend.