### PR TITLE
Refactor heat_damping in D_SW

### DIFF
--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -146,7 +146,7 @@ def heat_damping_term(ub, vb, gx, gy, rsin2, cosa_s, u2, v2, du2, dv2):
 
 
 @gtstencil()
-def heat_damping(
+def heat_source_from_vorticity_damping(
     ub: FloatField,
     vb: FloatField,
     ut: FloatField,
@@ -228,7 +228,7 @@ def heat_from_damping(
     diss_est,
     kinetic_energy_fraction_to_damp,
 ):
-    heat_damping(
+    heat_source_from_vorticity_damping(
         ub,
         vb,
         ut,

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -167,8 +167,8 @@ def heat_damping(
     Calculates heat source from vorticity damping implied by energy conservation.
 
     Args:
-        ub (inout)
-        vb (inout)
+        ub (in)
+        vb (in)
         ut (in)
         vt (in)
         u (in)
@@ -185,17 +185,17 @@ def heat_damping(
         do_skeb (in)
     """
     with computation(PARALLEL), interval(...):
-        ub[0, 0, 0] = (ub + vt) * rdx
+        ubt = (ub + vt) * rdx
         fy = u * rdx
-        gy = fy * ub
-        vb[0, 0, 0] = (vb - ut) * rdy
+        gy = fy * ubt
+        vbt = (vb - ut) * rdy
         fx = v * rdy
-        gx = fx * vb
+        gx = fx * vbt
         u2 = fy + fy[0, 1, 0]
-        du2 = ub + ub[0, 1, 0]
+        du2 = ubt + ubt[0, 1, 0]
         v2 = fx + fx[1, 0, 0]
-        dv2 = vb + vb[1, 0, 0]
-        dampterm = heat_damping_term(ub, vb, gx, gy, rsin2, cosa_s, u2, v2, du2, dv2)
+        dv2 = vbt + vbt[1, 0, 0]
+        dampterm = heat_damping_term(ubt, vbt, gx, gy, rsin2, cosa_s, u2, v2, du2, dv2)
         heat_source[0, 0, 0] = delp * (heat_source - damp * dampterm)
         diss_est[0, 0, 0] = diss_est - dampterm if do_skeb == 1 else diss_est
 


### PR DESCRIPTION
This PR refactors the heat damping code in D_SW in the following ways:

- two stencils over 3 calls are combined into one stencil. While it would be nice to split that stencil into routines, I cannot determine a meaningful name to split them over, since it's not very clear what the code is doing
- Added a docstring with intents, and at least one variable definition
- Converted four storages into temporaries: fx, fy, gx, and gy. gx and gy are still defined as storages since they are used in another routine (probably also can be converted to temporaries later)
- Converted ub and vb from inout to in within stencil. Since tests pass, these are not actually used after heat is calculated