### PR TITLE
Fix 'state.zs' error with CUDA backend

### DIFF
--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -28,9 +28,10 @@ HUGE_R = 1.0e40
 
 # NOTE in Fortran these are columns
 @gtstencil()
-def dp_ref_compute(ak: sd, bk: sd, dp_ref: sd):
+def dp_ref_compute(ak: sd, bk: sd, phis: sd, dp_ref: sd, zs: sd, rgrav: float):
     with computation(PARALLEL), interval(...):
         dp_ref = ak[0, 0, 1] - ak + (bk[0, 0, 1] - bk) * 1.0e5
+        zs = phis * rgrav
 
 
 @gtstencil()
@@ -150,14 +151,19 @@ def compute(state, comm):
         state.dp_ref = utils.make_storage_from_shape(
             state.ak.shape, grid.default_origin()
         )
+        state.zs = utils.make_storage_from_shape(
+            state.ak.shape, grid.default_origin()
+        )
         dp_ref_compute(
             state.ak,
             state.bk,
+            state.phis,
             state.dp_ref,
+            state.zs,
+            rgrav,
             origin=grid.default_origin(),
             domain=grid.domain_shape_standard(),
         )
-        state.zs = state.phis * rgrav
     n_con = get_n_con()
 
     for it in range(n_split):

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -151,9 +151,7 @@ def compute(state, comm):
         state.dp_ref = utils.make_storage_from_shape(
             state.ak.shape, grid.default_origin()
         )
-        state.zs = utils.make_storage_from_shape(
-            state.ak.shape, grid.default_origin()
-        )
+        state.zs = utils.make_storage_from_shape(state.ak.shape, grid.default_origin())
         dp_ref_compute(
             state.ak,
             state.bk,

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -29,8 +29,9 @@ HUGE_R = 1.0e40
 # NOTE in Fortran these are columns
 @gtstencil()
 def dp_ref_compute(ak: sd, bk: sd, phis: sd, dp_ref: sd, zs: sd, rgrav: float):
-    with computation(PARALLEL), interval(...):
+    with computation(PARALLEL), interval(0, -1):
         dp_ref = ak[0, 0, 1] - ak + (bk[0, 0, 1] - bk) * 1.0e5
+    with computation(PARALLEL), interval(...):
         zs = phis * rgrav
 
 
@@ -160,7 +161,7 @@ def compute(state, comm):
             state.zs,
             rgrav,
             origin=grid.default_origin(),
-            domain=grid.domain_shape_standard(),
+            domain=grid.domain_shape_standard(add=(0, 0, 1)),
         )
     n_con = get_n_con()
 


### PR DESCRIPTION
## Purpose

The purpose of this PR is to resolve an error in `dyn_core` that occurs with a GPU backend when the `zs` storage is dynamically added to the `state` object, e.g.,
```python
state.zs = state.phis * rgrav
```

## Code changes:

- Allocate the `state.zs` storage before calling the stencil,
```python
state.zs = utils.make_storage_from_shape(
    state.ak.shape, grid.default_origin()
)
```
- Moving the computation inside the stencil,
```python
def dp_ref_compute(ak: sd, bk: sd, phis: sd, dp_ref: sd, zs: sd, rgrav: float):
    with computation(PARALLEL), interval(...):
        dp_ref = ak[0, 0, 1] - ak + (bk[0, 0, 1] - bk) * 1.0e5
        zs = phis * rgrav
```
