### PR TITLE
add 128 data path and run for fewer timesteps

### DIFF
--- a/.jenkins/actions/run_performance.sh
+++ b/.jenkins/actions/run_performance.sh
@@ -6,11 +6,14 @@ ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
 test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 
-if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
-    data_path="/project/s1053/fv3core_serialized_test_data/7.2.3/c96_6ranks_baroclinic"
-fi
 if [ "$experiment" = "c12_6ranks_standard" ]; then
     data_path="/project/s1053/fv3core_serialized_test_data/7.0.0/c12_6ranks_standard"
 fi
+if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
+    data_path="/project/s1053/fv3core_serialized_test_data/7.2.3/c96_6ranks_baroclinic"
+fi
+if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
+    data_path="/project/s1053/fv3core_serialized_test_data/7.2.3/c128_6ranks_baroclinic"
+fi
 
-$ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 60 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path
+$ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path

--- a/.jenkins/actions/run_performance.sh
+++ b/.jenkins/actions/run_performance.sh
@@ -3,17 +3,19 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
+TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data/"
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
 test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 
+
 if [ "$experiment" = "c12_6ranks_standard" ]; then
-    data_path="/project/s1053/fv3core_serialized_test_data/7.0.0/c12_6ranks_standard"
+    data_path="${TESTDATA_PATH}7.0.0/c12_6ranks_standard"
 fi
 if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
-    data_path="/project/s1053/fv3core_serialized_test_data/7.2.3/c96_6ranks_baroclinic"
+    data_path="${TESTDATA_PATH}7.2.3/c96_6ranks_baroclinic"
 fi
 if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
-    data_path="/project/s1053/fv3core_serialized_test_data/7.2.3/c128_6ranks_baroclinic"
+    data_path="${TESTDATA_PATH}7.2.3/c128_6ranks_baroclinic"
 fi
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path


### PR DESCRIPTION
## Purpose

This PR adds the working c128 dataset to the jenkins-script for performance checks. 

## Code changes:

- The .jenkins files now also point to c128 data if this is the experiment chosen

## Infrastructure changes:

- The only change is we're enabling c128 tests in https://jenkins.ginko.ch/job/fv3core-performance-test/ 

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)

