### PR TITLE
Remove unnecessary zero assigns in 'fix_neg_cloud'

### DIFF
--- a/fv3core/stencils/neg_adj3.py
+++ b/fv3core/stencils/neg_adj3.py
@@ -187,7 +187,6 @@ def fix_neg_cloud(dp: sd, qcld: sd):
             qcld = 0.0
     with computation(FORWARD):
         with interval(-2, -1):
-            dq = 0.0
             if qcld[0, 0, 1] < 0.0 and qcld > 0:
                 dq = (
                     -qcld * dp
@@ -196,7 +195,6 @@ def fix_neg_cloud(dp: sd, qcld: sd):
                 )
                 qcld = qcld - dq / dp
         with interval(-1, None):
-            dq = 0.0
             if qcld < 0 and qcld[0, 0, -1] > 0.0:
                 dq = (
                     -qcld * dp


### PR DESCRIPTION
## Purpose

This PR is a hot fix for a temporary demotion issue in the `neg_ad3.fix_neg_cloud` stencil that removes unnecessary zero value initializations of the `dq` temporary to resolve an issue in the `gt4py` GridTools backends.

## Code changes:

- Remove `dq = 0.0` statements in `neg_ad3.fix_neg_cloud`
