### PR TITLE
remove helper function mult_frac

### DIFF
--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -34,23 +34,17 @@ def flux_y(cy: sd, dya: sd, dx: sd, sin_sg4: sd, sin_sg2: sd, yfx: sd):
         )
 
 
-@gtscript.function
-def mult_frac(var, frac):
-    var_tmp = var
-    return var_tmp * frac
-
-
 @gtstencil()
-def cmax_split_vars(
+def cmax_multiply_by_frac(
     cxd: sd, xfx: sd, mfxd: sd, cyd: sd, yfx: sd, mfyd: sd, frac: float
 ):
     with computation(PARALLEL), interval(...):
-        cxd = mult_frac(cxd, frac)
-        xfx = mult_frac(xfx, frac)
-        mfxd = mult_frac(mfxd, frac)
-        cyd = mult_frac(cyd, frac)
-        yfx = mult_frac(yfx, frac)
-        mfyd = mult_frac(mfyd, frac)
+        cxd = cxd * frac
+        xfx = xfx * frac
+        mfxd = mfxd * frac
+        cyd = cyd * frac
+        yfx = yfx * frac
+        mfyd = mfyd * frac
 
 
 @gtstencil()
@@ -154,17 +148,17 @@ def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
     frac = 1.0
     if nsplt > 1.0:
         frac = 1.0 / nsplt
-    cmax_split_vars(
-        cxd,
-        xfx,
-        mfxd,
-        cyd,
-        yfx,
-        mfyd,
-        frac,
-        origin=grid.default_origin(),
-        domain=grid.domain_shape_buffer_1cell(),
-    )
+        cmax_multiply_by_frac(
+            cxd,
+            xfx,
+            mfxd,
+            cyd,
+            yfx,
+            mfyd,
+            frac,
+            origin=grid.default_origin(),
+            domain=grid.domain_shape_buffer_1cell(),
+        )
 
     # complete HALO update on q
     for qname in utils.tracer_variables[0:nq]:

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -38,6 +38,7 @@ def flux_y(cy: sd, dya: sd, dx: sd, sin_sg4: sd, sin_sg2: sd, yfx: sd):
 def cmax_multiply_by_frac(
     cxd: sd, xfx: sd, mfxd: sd, cyd: sd, yfx: sd, mfyd: sd, frac: float
 ):
+    """multiply all other inputs in-place by frac."""
     with computation(PARALLEL), interval(...):
         cxd = cxd * frac
         xfx = xfx * frac


### PR DESCRIPTION
## Purpose

Helper function `mult_frac` was previously needed because we couldn't write `a = <expression involving a>`. This has since been fixed in gt4py, so we can remove the helper function.

Also renamed cmax_split_vars to cmax_multiply_by_frac to more clearly describe what the stencil does.

I have not spent the time trying to add a docstring to cmax_split_vars, because I expect it to be changed when we merge this stencil with adjacent stencils, and this documentation would take much more time than this code change took.

## Code changes:

- Removed `mult_frac` from tracer_2d_1l.py
- Renamed cmax_split_vars to cmax_multiply_by_frac

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes