### PR TITLE
Add automerge github action

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,0 +1,29 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_COMMIT_MESSAGE: pull-request-title-and-description
+          MERGE_METHOD: squash


### PR DESCRIPTION
## Purpose

Our tests take a little long to run, and there can be a delay between when a test finishes and when we remember to merge it.

This PR, once merged, allows you to label a github PR as "automerge". If you do, that PR will merge automatically when its tests pass if it has received github-required reviews. This will allow us to "set and forget" PRs which are ready for merge and have been reviewed, but have minor changes which re-trigger the tests.

## Infrastructure changes:

- Add the automerge github action, copied from the fv3net repository

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes

It is very optional to use this, and I do not think we need to add an entry to the README about it.