### PR TITLE
Improve timing for gtx86 and update plotting

### DIFF
--- a/examples/standalone/benchmarks/plotting.py
+++ b/examples/standalone/benchmarks/plotting.py
@@ -43,18 +43,18 @@ if __name__ == "__main__":
                     plt.plot(
                         [
                             datetime.strptime(
-                                e["setup"]["timestamp"], "%d/%m/%Y %H:%M:%S"
+                                elememt["setup"]["timestamp"], "%d/%m/%Y %H:%M:%S"
                             )
-                            for e in specific
+                            for elememt in specific
                         ],
                         [
-                            e["times"][line]["mean"]
+                            elememt["times"][line]["mean"]
                             / (
-                                (e["setup"]["timesteps"] - 1)
+                                (elememt["setup"]["timesteps"] - 1)
                                 if plottype == "mainLoop"
                                 else 1
                             )
-                            for e in specific
+                            for elememt in specific
                         ],
                         "--o",
                         label=line + " " + backend,
@@ -62,27 +62,27 @@ if __name__ == "__main__":
                     plt.fill_between(
                         [
                             datetime.strptime(
-                                e["setup"]["timestamp"], "%d/%m/%Y %H:%M:%S"
+                                elememt["setup"]["timestamp"], "%d/%m/%Y %H:%M:%S"
                             )
-                            for e in specific
+                            for elememt in specific
                         ],
                         [
-                            e["times"][line]["maximum"]
+                            elememt["times"][line]["maximum"]
                             / (
-                                (e["setup"]["timesteps"] - 1)
+                                (elememt["setup"]["timesteps"] - 1)
                                 if plottype == "mainLoop"
                                 else 1
                             )
-                            for e in specific
+                            for elememt in specific
                         ],
                         [
-                            e["times"][line]["minimum"]
+                            elememt["times"][line]["minimum"]
                             / (
-                                (e["setup"]["timesteps"] - 1)
+                                (elememt["setup"]["timesteps"] - 1)
                                 if plottype == "mainLoop"
                                 else 1
                             )
-                            for e in specific
+                            for elememt in specific
                         ],
                         alpha=0.3,
                     )

--- a/examples/standalone/benchmarks/plotting.py
+++ b/examples/standalone/benchmarks/plotting.py
@@ -18,6 +18,12 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    # setup what to plot
+    plots = {}
+    plots["mainLoop"] = ["mainloop", "DynCore", "Remapping", "TracerAdvection"]
+    plots["initializationTotal"] = ["initialization", "total"]
+    backends = ["python/gtx86", "python/numpy", "fortran", "python/gtcuda"]
+
     # collect and sort the data
     alldata = []
     for subdir, dirs, files in os.walk(args.data_dir):
@@ -29,17 +35,13 @@ if __name__ == "__main__":
     alldata.sort(
         key=lambda k: datetime.strptime(k["setup"]["timestamp"], "%d/%m/%Y %H:%M:%S")
     )
-    for plottype in ["mainLoop", "initializationTotal"]:
-        data = (
-            ["mainloop", "DynCore", "Remapping", "TracerAdvection"]
-            if plottype == "mainLoop"
-            else ["initialization", "total"]
-        )
+
+    for plottype, timers in plots.items():
         plt.figure()
-        for backend in ["python/gtx86", "python/numpy", "fortran", "python/gtcuda"]:
+        for backend in backends:
             specific = [x for x in alldata if x["setup"]["version"] == backend]
             if specific:
-                for line in data:
+                for time in timers:
                     plt.plot(
                         [
                             datetime.strptime(
@@ -48,7 +50,7 @@ if __name__ == "__main__":
                             for elememt in specific
                         ],
                         [
-                            elememt["times"][line]["mean"]
+                            elememt["times"][time]["mean"]
                             / (
                                 (elememt["setup"]["timesteps"] - 1)
                                 if plottype == "mainLoop"
@@ -57,7 +59,7 @@ if __name__ == "__main__":
                             for elememt in specific
                         ],
                         "--o",
-                        label=line + " " + backend,
+                        label=time + " " + backend,
                     )
                     plt.fill_between(
                         [
@@ -67,7 +69,7 @@ if __name__ == "__main__":
                             for elememt in specific
                         ],
                         [
-                            elememt["times"][line]["maximum"]
+                            elememt["times"][time]["maximum"]
                             / (
                                 (elememt["setup"]["timesteps"] - 1)
                                 if plottype == "mainLoop"
@@ -76,7 +78,7 @@ if __name__ == "__main__":
                             for elememt in specific
                         ],
                         [
-                            elememt["times"][line]["minimum"]
+                            elememt["times"][time]["minimum"]
                             / (
                                 (elememt["setup"]["timesteps"] - 1)
                                 if plottype == "mainLoop"

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -79,10 +79,11 @@ echo "    Slurm output dir: $ROOT_DIR"
 cp buildenv/submit.daint.slurm .
 sed s/\<NAME\>/standalone/g submit.daint.slurm -i
 sed s/\<NTASKS\>/$ranks/g submit.daint.slurm -i
-sed s/\<NTASKSPERNODE\>/$ranks/g submit.daint.slurm -i
-sed s/\<CPUSPERTASK\>/1/g submit.daint.slurm -i
-sed s/#SBATCH\ --output=\<OUTFILE\>//g submit.daint.slurm -i
+sed s/\<NTASKSPERNODE\>/1/g submit.daint.slurm -i
+sed s/\<CPUSPERTASK\>/12/g submit.daint.slurm -i
+sed s/--output=\<OUTFILE\>/--hint=nomultithread/g submit.daint.slurm -i
 sed s/00:45:00/03:30:00/g submit.daint.slurm -i
+sed s/cscsci/normal/g submit.daint.slurm -i
 sed s/\<G2G\>//g submit.daint.slurm -i
 sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun vcm_1.0/bin/python examples/standalone/runfile/dynamics.py test_data/ $timesteps $backend#g" submit.daint.slurm
 

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -79,14 +79,14 @@ echo "    Slurm output dir: $ROOT_DIR"
 
 # Adapt batch script:
 cp buildenv/submit.daint.slurm .
-sed s/\<NAME\>/standalone/g submit.daint.slurm -i
-sed s/\<NTASKS\>/$ranks/g submit.daint.slurm -i
-sed s/\<NTASKSPERNODE\>/1/g submit.daint.slurm -i
-sed s/\<CPUSPERTASK\>/nthreads/g submit.daint.slurm -i
-sed s/--output=\<OUTFILE\>/--hint=nomultithread/g submit.daint.slurm -i
-sed s/00:45:00/03:30:00/g submit.daint.slurm -i
-sed s/cscsci/normal/g submit.daint.slurm -i
-sed s/\<G2G\>//g submit.daint.slurm -i
+sed -i s/\<NAME\>/standalone/g submit.daint.slurm
+sed -i s/\<NTASKS\>/$ranks/g submit.daint.slurm
+sed -i s/\<NTASKSPERNODE\>/1/g submit.daint.slurm
+sed -i s/\<CPUSPERTASK\>/$nthreads/g submit.daint.slurm
+sed -i s/--output=\<OUTFILE\>/--hint=nomultithread/g submit.daint.slurm
+sed -i s/00:45:00/03:30:00/g submit.daint.slurm
+sed -i s/cscsci/normal/g submit.daint.slurm
+sed -i s/\<G2G\>//g submit.daint.slurm
 sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun vcm_1.0/bin/python examples/standalone/runfile/dynamics.py test_data/ $timesteps $backend#g" submit.daint.slurm
 
 # execute on a gpu node

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -67,10 +67,12 @@ cp test_data/*.yml test_data/input.yml
 git clone https://github.com/VulcanClimateModeling/buildenv/
 source buildenv/machineEnvironment.sh
 source buildenv/env.${host}.sh
+nthreads=12
 
 echo "Configuration overview:"
 echo "    Timesteps:        $timesteps"
 echo "    Ranks:            $ranks"
+echo "    Threads per rank: $nthreads"
 echo "    Input data dir:   $data_path"
 echo "    Output dir:       $target_dir"
 echo "    Slurm output dir: $ROOT_DIR"
@@ -80,7 +82,7 @@ cp buildenv/submit.daint.slurm .
 sed s/\<NAME\>/standalone/g submit.daint.slurm -i
 sed s/\<NTASKS\>/$ranks/g submit.daint.slurm -i
 sed s/\<NTASKSPERNODE\>/1/g submit.daint.slurm -i
-sed s/\<CPUSPERTASK\>/12/g submit.daint.slurm -i
+sed s/\<CPUSPERTASK\>/nthreads/g submit.daint.slurm -i
 sed s/--output=\<OUTFILE\>/--hint=nomultithread/g submit.daint.slurm -i
 sed s/00:45:00/03:30:00/g submit.daint.slurm -i
 sed s/cscsci/normal/g submit.daint.slurm -i

--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -49,7 +49,7 @@ def set_experiment_info(experiment_name, time_step, backend):
             pathlib.Path(__file__).parent.absolute(), search_parent_directories=True
         ).head.object.hexsha
     except git.InvalidGitRepositoryError:
-        sha = "6ac5225202279ae3ff2e5bebb224b817"
+        sha = "hash not found"
     now = datetime.now()
     dt_string = now.strftime("%d/%m/%Y %H:%M:%S")
     experiment["setup"] = {}
@@ -69,6 +69,7 @@ def gather_timing_statistics(timer, experiment, comm, root=0):
         if is_root:
             print(name)
             experiment["times"][name] = {}
+            experiment["times"][name]["hits"] = int(timer.hits[name])
         for label, op in [
             ("minimum", MPI.MIN),
             ("maximum", MPI.MAX),


### PR DESCRIPTION
## Purpose

This PR improves how we measure timings for the gtx86 backend on daint and improves the plotting script:

## Code changes:

- Use 12 threads per rank, no hyperthreading and 1 rank per node on daint
- As a result we switch to the normal partition for this run
- In order to ensure compatibility with the fortran generated performance numbers we now also write out the hit-counts
- Fixes the key values to adapt the new naming 
- Plotting time per timestep for the main loop
- 
## Checklist
Before submitting this PR, please make sure:

- [X] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [X] Docstrings and type hints are added to new and updated routines, as appropriate
