### PR TITLE
Disable use of debug queue

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -97,7 +97,7 @@ if grep -q "parallel" <<< "${script}"; then
 	    sed -i 's|<NTASKS>|<NTASKS>\n#SBATCH \-\-hint=multithread\n#SBATCH --ntasks-per-core=2|g' ${scheduler_script}
 	    sed -i 's|45|30|g' ${scheduler_script}
 	    if [ "$NUM_RANKS" -gt "6" ];then
-            #sed -i 's|cscsci|debug|g' ${scheduler_script}
+            sed -i 's|cscsci|normal|g' ${scheduler_script}
         fi
 	    sed -i 's|<NTASKS>|"'${NUM_RANKS}'"|g' ${scheduler_script}
 	    sed -i 's|<NTASKSPERNODE>|"24"|g' ${scheduler_script}

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -97,7 +97,7 @@ if grep -q "parallel" <<< "${script}"; then
 	    sed -i 's|<NTASKS>|<NTASKS>\n#SBATCH \-\-hint=multithread\n#SBATCH --ntasks-per-core=2|g' ${scheduler_script}
 	    sed -i 's|45|30|g' ${scheduler_script}
 	    if [ "$NUM_RANKS" -gt "6" ];then
-            sed -i 's|cscsci|debug|g' ${scheduler_script}
+            #sed -i 's|cscsci|debug|g' ${scheduler_script}
         fi
 	    sed -i 's|<NTASKS>|"'${NUM_RANKS}'"|g' ${scheduler_script}
 	    sed -i 's|<NTASKSPERNODE>|"24"|g' ${scheduler_script}


### PR DESCRIPTION
## Purpose

The debug queue on Piz Daint has a maximum job limitation. Since we are using the account of @ofuhrer using the debug queue for CI has the potential to fail when @ofuhrer is also using the debug queue on Piz Daint intensively. This PR changes the submission of Jenkins CI jobs to always use cscsci

## Code changes:

- Adaption of .jenkins/jenkins.sh where the SLURM job files are prepared for submission.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes