### PR TITLE
remove commas from docker tags in jenkins

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -143,7 +143,7 @@ export FV3_STENCIL_REBUILD_FLAG=False
 export TEST_DATA_HOST="${TEST_DATA_DIR}/${experiment}/"
 export EXPERIMENT=${experiment}
 if [ -z ${JENKINS_TAG} ]; then
-    export JENKINS_TAG=${JOB_NAME//[=\/]/-}-${BUILD_NUMBER}
+    export JENKINS_TAG=${JOB_NAME//[,=\/]/-}-${BUILD_NUMBER}
 fi
 echo "JENKINS TAG ${JENKINS_TAG}"
 if [ -z ${VIRTUALENV} ]; then


### PR DESCRIPTION
## Purpose

Commas also show up in multiconfiguration project JOB_NAMEs, so we should remove those from the tag as well to unblock the fv3core-docker-master-gtbackends jenkins plan. 
