### PR TITLE
Change git hash to come in from the calling script

### DIFF
--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -77,6 +77,12 @@ echo "    Input data dir:   $data_path"
 echo "    Output dir:       $target_dir"
 echo "    Slurm output dir: $ROOT_DIR"
 
+if git rev-parse --git-dir > /dev/null 2>&1; then
+  githash =`git rev-parse HEAD`
+else
+  githash="notarepo"
+fi  
+
 # Adapt batch script:
 cp buildenv/submit.daint.slurm .
 sed -i s/\<NAME\>/standalone/g submit.daint.slurm
@@ -87,7 +93,7 @@ sed -i s/--output=\<OUTFILE\>/--hint=nomultithread/g submit.daint.slurm
 sed -i s/00:45:00/03:30:00/g submit.daint.slurm
 sed -i s/cscsci/normal/g submit.daint.slurm
 sed -i s/\<G2G\>//g submit.daint.slurm
-sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun vcm_1.0/bin/python examples/standalone/runfile/dynamics.py test_data/ $timesteps $backend#g" submit.daint.slurm
+sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun vcm_1.0/bin/python examples/standalone/runfile/dynamics.py test_data/ $timesteps $backend $githash#g" submit.daint.slurm
 
 # execute on a gpu node
 sbatch -W -C gpu submit.daint.slurm

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -81,7 +81,7 @@ if git rev-parse --git-dir > /dev/null 2>&1; then
   githash =`git rev-parse HEAD`
 else
   githash="notarepo"
-fi  
+fi
 
 # Adapt batch script:
 cp buildenv/submit.daint.slurm .

--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -1,5 +1,4 @@
 import json
-import pathlib
 from argparse import ArgumentParser
 from datetime import datetime
 

--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -3,7 +3,6 @@ import pathlib
 from argparse import ArgumentParser
 from datetime import datetime
 
-import git
 import numpy as np
 import serialbox
 import yaml
@@ -17,7 +16,7 @@ import fv3gfs.util as util
 
 
 def parse_args():
-    usage = "usage: python %(prog)s <data_dir> <timesteps> <backend>"
+    usage = "usage: python %(prog)s <data_dir> <timesteps> <backend> <hash>"
     parser = ArgumentParser(usage=usage)
 
     parser.add_argument(
@@ -38,25 +37,25 @@ def parse_args():
         action="store",
         help="path to the namelist",
     )
+    parser.add_argument(
+        "hash",
+        type=str,
+        action="store",
+        help="git hash to store",
+    )
 
     return parser.parse_args()
 
 
-def set_experiment_info(experiment_name, time_step, backend):
+def set_experiment_info(experiment_name, time_step, backend, git_hash):
     experiment = {}
-    try:
-        sha = git.Repo(
-            pathlib.Path(__file__).parent.absolute(), search_parent_directories=True
-        ).head.object.hexsha
-    except:
-        sha = "hash not found"
     now = datetime.now()
     dt_string = now.strftime("%d/%m/%Y %H:%M:%S")
     experiment["setup"] = {}
     experiment["setup"]["timestamp"] = dt_string
     experiment["setup"]["dataset"] = experiment_name
     experiment["setup"]["timesteps"] = time_step
-    experiment["setup"]["hash"] = sha
+    experiment["setup"]["hash"] = git_hash
     experiment["setup"]["version"] = "python/" + backend
     experiment["times"] = {}
     return experiment
@@ -176,7 +175,9 @@ if __name__ == "__main__":
     timer.stop("total")
     # collect times and output simple statistics
     print("Gathering Times")
-    experiment = set_experiment_info(experiment_name, args.time_step, args.backend)
+    experiment = set_experiment_info(
+        experiment_name, args.time_step, args.backend, args.hash
+    )
     gather_timing_statistics(timer, experiment, comm)
     now = datetime.now()
     filename = now.strftime("%Y-%m-%d-%H-%M-%S")

--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -48,7 +48,7 @@ def set_experiment_info(experiment_name, time_step, backend):
         sha = git.Repo(
             pathlib.Path(__file__).parent.absolute(), search_parent_directories=True
         ).head.object.hexsha
-    except git.InvalidGitRepositoryError:
+    except:
         sha = "hash not found"
     now = datetime.now()
     dt_string = now.strftime("%d/%m/%Y %H:%M:%S")


### PR DESCRIPTION
## Purpose

Fix catch more kinds of errors when parsing the git hash.

## Code changes:

- Since daint can also throw os errors in parsing the git hash we now catch everything.