### PR TITLE
Restrict JENKINS_TAG size to legal docker tag length

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -143,7 +143,7 @@ export FV3_STENCIL_REBUILD_FLAG=False
 export TEST_DATA_HOST="${TEST_DATA_DIR}/${experiment}/"
 export EXPERIMENT=${experiment}
 if [ -z ${JENKINS_TAG} ]; then
-    if [ ${#JOB_NAME} -gt 75 ]; then
+    if [ ${#JOB_NAME} -gt 85 ]; then
 	NAME=`echo ${JOB_NAME} | md5sum | cut -f1 -d" "`
     else
 	NAME=${JOB_NAME}

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -143,7 +143,12 @@ export FV3_STENCIL_REBUILD_FLAG=False
 export TEST_DATA_HOST="${TEST_DATA_DIR}/${experiment}/"
 export EXPERIMENT=${experiment}
 if [ -z ${JENKINS_TAG} ]; then
-    export JENKINS_TAG=${JOB_NAME//[,=\/]/-}-${BUILD_NUMBER}
+    if [ ${#JOB_NAME} > 122 ]; then
+	NAME=`/bin/echo ${JOB_NAME} | md5sum | cut -f1 -d" "`
+    else
+	NAME=${JOB_NAME}
+    fi
+    export JENKINS_TAG=${NAME//[,=\/]/-}-${BUILD_NUMBER}
 fi
 echo "JENKINS TAG ${JENKINS_TAG}"
 if [ -z ${VIRTUALENV} ]; then

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -143,7 +143,7 @@ export FV3_STENCIL_REBUILD_FLAG=False
 export TEST_DATA_HOST="${TEST_DATA_DIR}/${experiment}/"
 export EXPERIMENT=${experiment}
 if [ -z ${JENKINS_TAG} ]; then
-    if [ ${#JOB_NAME} -gt 122 ]; then
+    if [ ${#JOB_NAME} -gt 75 ]; then
 	NAME=`echo ${JOB_NAME} | md5sum | cut -f1 -d" "`
     else
 	NAME=${JOB_NAME}

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -144,7 +144,7 @@ export TEST_DATA_HOST="${TEST_DATA_DIR}/${experiment}/"
 export EXPERIMENT=${experiment}
 if [ -z ${JENKINS_TAG} ]; then
     if [ ${#JOB_NAME} > 122 ]; then
-	NAME=`/bin/echo ${JOB_NAME} | md5sum | cut -f1 -d" "`
+	NAME=`echo ${JOB_NAME} | md5sum | cut -f1 -d" "`
     else
 	NAME=${JOB_NAME}
     fi

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -143,7 +143,7 @@ export FV3_STENCIL_REBUILD_FLAG=False
 export TEST_DATA_HOST="${TEST_DATA_DIR}/${experiment}/"
 export EXPERIMENT=${experiment}
 if [ -z ${JENKINS_TAG} ]; then
-    if [ ${#JOB_NAME} > 122 ]; then
+    if [ ${#JOB_NAME} -gt 122 ]; then
 	NAME=`echo ${JOB_NAME} | md5sum | cut -f1 -d" "`
     else
 	NAME=${JOB_NAME}
@@ -151,6 +151,7 @@ if [ -z ${JENKINS_TAG} ]; then
     export JENKINS_TAG=${NAME//[,=\/]/-}-${BUILD_NUMBER}
 fi
 echo "JENKINS TAG ${JENKINS_TAG}"
+
 if [ -z ${VIRTUALENV} ]; then
     echo "setting VIRTUALENV"
     export VIRTUALENV=${WORKSPACE}/vcm_env_${JENKINS_TAG}


### PR DESCRIPTION
## Purpose

When the jenkins tag is too long, turn it into a 32 character hash string to prevent illegal docker tags (they can't be longer than 128 characters, and multiconfiguration projects can end up with really long job names)

## Infrastructure changes:

JENKINS_TAG in .jenkins/jenkins will include a md5sum of the JOB_NAME if it is too long to be a docker tag. This should re-enable multiconfiguration plans that don't take the VIRTUALENV or JENKINS_TAG as parameters. This for example, enables this: https://jenkins.ginko.ch/job/fv3core-regressions-cron/3/backend=numpy,experiment=c12_6ranks_standard,runaction=run_parallel_regression_tests,slave=gce-cpu/console