### PR TITLE
Use error thresholds by default

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -105,25 +105,6 @@ if grep -q "parallel" <<< "${script}"; then
     fi
 fi
 
-# set thresholds override file if it exists
-test_type=${experiment##*_}
-OVERRIDES_FOLDER="${envloc}/../tests/translate/overrides/"
-OVERRIDES_FILE="${OVERRIDES_FOLDER}/${test_type}.yaml"
-echo "overrides file:"
-echo ${OVERRIDES_FILE}
-if test -f "${OVERRIDES_FILE}"; then
-    echo "OVERRIDE"
-    export MOUNTS=" -v ${OVERRIDES_FOLDER}:/thresholds"
-    if [ ${python_env} == "virtualenv" ]; then
-	threshold_folder=${OVERRIDES_FOLDER}
-    else
-	threshold_folder="/thresholds"
-    fi
-    export THRESH_ARGS="--threshold_overrides_file=${threshold_folder}/${test_type}.yaml"
-fi
-export PROF_FOLDER="${envloc}/../prof"
-`mkdir -p ${PROF_FOLDER}`
-export MOUNTS="${MOUNTS} -v ${PROF_FOLDER}:/prof"
 module load daint-gpu
 module add "${installdir}/modulefiles/"
 module load gcloud

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,13 @@ CORE_TAR=$(SARUS_FV3CORE_IMAGE).tar
 MPIRUN_CALL ?=mpirun -np $(NUM_RANKS)
 BASE_INSTALL?=$(FV3)-install-serialbox
 DATA_BUCKET= $(REGRESSION_DATA_STORAGE_BUCKET)/$(FORTRAN_SERIALIZED_DATA_VERSION)/$(EXPERIMENT)/
-DEV_MOUNTS = '-v $(CWD)/$(FV3):/$(FV3)/$(FV3) -v $(CWD)/tests:/$(FV3)/tests -v $(FV3UTIL_DIR):/usr/src/fv3gfs-util -v $(TEST_DATA_HOST):$(TEST_DATA_RUN_LOC)'
-PYTEST_SEQUENTIAL=pytest --data_path=$(TEST_DATA_RUN_LOC) $(TEST_ARGS) $(FV3_PATH)/tests
-PYTEST_PARALLEL=$(MPIRUN_CALL) pytest --data_path=$(TEST_DATA_RUN_LOC) $(TEST_ARGS) -m parallel $(FV3_PATH)/tests
 
+DEV_MOUNTS = '-v $(CWD)/$(FV3):/$(FV3)/$(FV3) -v $(CWD)/tests:/$(FV3)/tests -v $(FV3UTIL_DIR):/usr/src/fv3gfs-util -v $(TEST_DATA_HOST):$(TEST_DATA_RUN_LOC) '
+TEST_TYPE=$(word 3, $(subst _, ,$(EXPERIMENT)))
+THRESH_ARGS=--threshold_overrides_file=$(FV3_PATH)/tests/translate/overrides/$(TEST_TYPE).yaml
+TEST_ARGS_USE=$(TEST_ARGS) $(THRESH_ARGS)
+PYTEST_SEQUENTIAL=pytest --data_path=$(TEST_DATA_RUN_LOC) $(TEST_ARGS_USE) $(FV3_PATH)/tests
+PYTEST_PARALLEL=$(MPIRUN_CALL) pytest --data_path=$(TEST_DATA_RUN_LOC) $(TEST_ARGS_USE) -m parallel $(FV3_PATH)/tests
 
 clean:
 	find . -name ""

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ common options for our tests, which you can add to `TEST_ARGS`:
 
 * `-m` - will let you run only certain groups of tests. For example, `-m=parallel` will run only parallel stencils, while `-m=sequential` will run only stencils that operate on one rank at a time.
 
+* `--threshold_overrides_file` - will read a yaml file with error thresholds specified for specific backend and platform (docker or metal) configurations, overriding the max_error thresholds defined in the Translate classes.
+
 **NOTE:** FV3 is current assumed to be by default in a "development mode", where stencils are checked each time they execute for code changes (which can trigger regeneration). This process is somewhat expensive, so there is an option to put FV3 in a performance mode by telling it that stencils should not automatically be rebuilt:
 
 ```shell


### PR DESCRIPTION
## Purpose
The validation error thresholds defined by the Translate classes can be overridden for specific backends and platforms using a yaml file, a collection of relaxed thresholds we should eventually investigate the reasons for and either or officially relax them in the class or fix a bug. This was initially implemented just for the jenkins tests, to enable automated testing to work, with the thought local developers would choose whether or not to use an override file. But, for consistency and convenience, this PR moves the specification of the thresholds file into the Makefile. This makes experimenting with other datasets more strict. Now for the Makefile to work properly, one would need to name the experiment with the same `c##_#ranks_<>` convention existing experiments use, and have an existing overrides filename that matches the `<>` in the experiment name. This is less flexible, but more convenient for our main use case. 

## Infrastructure changes:

- Removed specification of overrides thresholds in .jenkins/jenkins.sh
- Removed the profile variables in the .jenkins/jenkins.sh script leftover from a previous 
- Adds the --threshold_overrides_file argument to the pytest commands in the Makefile, that will pick 'standard' or 'baroclinic' based on what EXPERIMENT is set to 

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
