### PR TITLE
Move 'dt2' to end of 'update_vorticity_and_kinetic_energy_stencil'

### DIFF
--- a/tests/translate/translate_c_sw.py
+++ b/tests/translate/translate_c_sw.py
@@ -244,9 +244,9 @@ def update_vorticity_and_kinetic_energy_stencil(
     cos_sg3: FloatField,
     sin_sg4: FloatField,
     cos_sg4: FloatField,
-    dt2: float,
     ke_c: FloatField,
     vort_c: FloatField,
+    dt2: float,
 ):
     with computation(PARALLEL), interval(...):
         ke_c, vort_c = update_vorticity_and_kinetic_energy(


### PR DESCRIPTION
## Purpose

This PR moves the `dt2` parameter of the `update_vorticity_and_kinetic_energy_stencil` to the end of the argument list to prevent type mismatch errors in GT backends.

## Code changes:

- See previous section...
