### PR TITLE
Add 'passed_externals' to stencil data cache

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -124,10 +124,9 @@ class StencilDataCache(collections.abc.Mapping):
         key = hash(stencil)
         if key not in self.cache:
             filename = self._get_cache_filename(stencil)
-            if not os.path.exists(filename):
-                raise KeyError(f"Cache file {filename} does not exist")
-            self.cache[key] = pickle.load(open(filename, mode="rb"))
-        return self.cache[key]
+            if os.path.exists(filename):
+                self.cache[key] = pickle.load(open(filename, mode="rb"))
+        return self.cache[key] if key in self.cache else {}
 
     def __setitem__(self, stencil: gt4py.StencilObject, value: Any):
         key = hash(stencil)
@@ -167,7 +166,8 @@ class FV3StencilObject:
         self.backend_kwargs: Dict[str, Any] = kwargs
         """Remainder of the arguments assumed to be compiler backend options."""
 
-        self._axis_offsets_cache: StencilDataCache = StencilDataCache("axis_offsets.p")
+        self._data_cache: StencilDataCache = StencilDataCache("data_cache.p")
+        """Data cache to store axis offsets and passed externals."""
 
     @property
     def built(self) -> bool:
@@ -177,7 +177,35 @@ class FV3StencilObject:
     @property
     def axis_offsets(self) -> Dict[str, Any]:
         """AxisOffsets used in this stencil."""
-        return self._axis_offsets_cache[self.stencil_object]
+        cached_data = self._data_cache[self.stencil_object]
+        return cached_data["axis_offsets"] if "axis_offsets" in cached_data else {}
+
+    @property
+    def passed_externals(self) -> Dict[str, Any]:
+        """Passed externals used in this stencil."""
+        cached_data = self._data_cache[self.stencil_object]
+        return (
+            cached_data["passed_externals"] if "passed_externals" in cached_data else {}
+        )
+
+    def _check_axis_offsets(self, axis_offsets: Dict[str, Any]) -> bool:
+        axis_offsets_changed = False
+        for key, value in self.axis_offsets.items():
+            if axis_offsets[key] != value:
+                axis_offsets_changed = True
+                break
+        return axis_offsets_changed
+
+    def _check_passed_externals(
+        self,
+    ) -> bool:  # , passed_externals: Dict[str, Any]) -> bool:
+        passed_externals_changed = False
+        passed_externals = self.passed_externals
+        for key, value in self._passed_externals.items():
+            if passed_externals[key] != value:
+                passed_externals_changed = True
+                break
+        return passed_externals_changed
 
     def __call__(self, *args, origin: Index3D, domain: Index3D, **kwargs) -> None:
         """Call the stencil, compiling the stencil if necessary.
@@ -196,15 +224,15 @@ class FV3StencilObject:
         axis_offsets = fv3core.utils.axis_offsets(spec.grid, origin, domain)
 
         regenerate_stencil = not self.built or global_config.get_rebuild()
+
+        # Check if we really do need to regenerate
         if not regenerate_stencil:
-            # Check if we really do need to regenerate
-            for key, value in self.axis_offsets.items():
-                if axis_offsets[key] != value:
-                    axis_offsets_changed = True
-                    break
-            else:
-                axis_offsets_changed = False
+            axis_offsets_changed = self._check_axis_offsets(axis_offsets)
             regenerate_stencil = regenerate_stencil or axis_offsets_changed
+
+        if self._passed_externals and not regenerate_stencil:
+            passed_externals_changed = self._check_passed_externals()
+            regenerate_stencil = regenerate_stencil or passed_externals_changed
 
         if regenerate_stencil:
             new_build_info = {}
@@ -227,12 +255,15 @@ class FV3StencilObject:
             self.stencil_object = gtscript.stencil(
                 definition=self.func, **stencil_kwargs
             )
-            if self.stencil_object not in self._axis_offsets_cache:
+            key = self.stencil_object
+            if key not in self._data_cache and "def_ir" in stencil_kwargs["build_info"]:
                 def_ir = stencil_kwargs["build_info"]["def_ir"]
                 axis_offsets = {
                     k: v for k, v in def_ir.externals.items() if k in axis_offsets
                 }
-                self._axis_offsets_cache[self.stencil_object] = axis_offsets
+                self._data_cache[key] = dict(
+                    axis_offsets=axis_offsets, passed_externals=self._passed_externals
+                )
 
         # Call it
         exec_info = {}

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -189,23 +189,17 @@ class FV3StencilObject:
         )
 
     def _check_axis_offsets(self, axis_offsets: Dict[str, Any]) -> bool:
-        axis_offsets_changed = False
         for key, value in self.axis_offsets.items():
             if axis_offsets[key] != value:
-                axis_offsets_changed = True
-                break
-        return axis_offsets_changed
+                return True
+        return False
 
-    def _check_passed_externals(
-        self,
-    ) -> bool:  # , passed_externals: Dict[str, Any]) -> bool:
-        passed_externals_changed = False
+    def _check_passed_externals(self) -> bool:
         passed_externals = self.passed_externals
         for key, value in self._passed_externals.items():
             if passed_externals[key] != value:
-                passed_externals_changed = True
-                break
-        return passed_externals_changed
+                return True
+        return False
 
     def __call__(self, *args, origin: Index3D, domain: Index3D, **kwargs) -> None:
         """Call the stencil, compiling the stencil if necessary.
@@ -255,13 +249,16 @@ class FV3StencilObject:
             self.stencil_object = gtscript.stencil(
                 definition=self.func, **stencil_kwargs
             )
-            key = self.stencil_object
-            if key not in self._data_cache and "def_ir" in stencil_kwargs["build_info"]:
+            stencil = self.stencil_object
+            if (
+                stencil not in self._data_cache
+                and "def_ir" in stencil_kwargs["build_info"]
+            ):
                 def_ir = stencil_kwargs["build_info"]["def_ir"]
                 axis_offsets = {
                     k: v for k, v in def_ir.externals.items() if k in axis_offsets
                 }
-                self._data_cache[key] = dict(
+                self._data_cache[stencil] = dict(
                     axis_offsets=axis_offsets, passed_externals=self._passed_externals
                 )
 


### PR DESCRIPTION
## Purpose

This PR serves two primary purposes:
1. Generalize the `StencilDataCache` to store and pickle multiple cached objects.
2. Add `passed_externals` to the cache in addition to `axis_offsets`.

## Code changes:

- Change the way `axis_offsets` are accessed from the `StencilDataCache`.
- Add `passed_externals` to the `StencilDataCache`.
- Add private methods to compare `axis_offsets` and `passed_externals` dictionaries.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
