### PR TITLE
Removed temporaries from Saturation stencil

### DIFF
--- a/fv3core/stencils/remapping_part2.py
+++ b/fv3core/stencils/remapping_part2.py
@@ -41,12 +41,6 @@ def sum_z1(pkz: sd, delp: sd, te0_2d: sd, te_2d: sd, zsum1: sd):
 
 
 @gtstencil()
-def layer_gradient(peln: sd, dpln: sd):
-    with computation(PARALLEL), interval(...):
-        dpln = peln[0, 0, 1] - peln
-
-
-@gtstencil()
 def sum_te(te: sd, te0_2d: sd):
     with computation(FORWARD):
         with interval(0, None):
@@ -97,7 +91,6 @@ def compute(
     )
     dtmp = 0.0
     phis = utils.make_storage_from_shape(pt.shape, grid.compute_origin())
-    dpln = utils.make_storage_from_shape(pt.shape, grid.compute_origin())
     if spec.namelist.do_sat_adj:
         fast_mp_consv = not do_adiabatic_init and consv > constants.CONSV_MIN
         # TODO pfull is a 1d var
@@ -181,9 +174,7 @@ def compute(
 
         kmp_origin = (grid.is_, grid.js, kmp)
         kmp_domain = (grid.nic, grid.njc, grid.npz - kmp)
-        layer_gradient(peln, dpln, origin=kmp_origin, domain=kmp_domain)
         saturation_adjustment.compute(
-            dpln,
             te,
             qvapor,
             qliquid,

--- a/tests/translate/translate_satadjust3d.py
+++ b/tests/translate/translate_satadjust3d.py
@@ -9,7 +9,6 @@ class TranslateSatAdjust3d(TranslateFortranData2Py):
         cvar = {"axis": 0, "kstart": 3}
         self.in_vars["data_vars"] = {
             "te": {},
-            "dpln": {"istart": grid.is_, "jstart": grid.js},
             "qvapor": {},
             "qliquid": {},
             "qice": {},
@@ -38,14 +37,6 @@ class TranslateSatAdjust3d(TranslateFortranData2Py):
         ]
         self.out_vars = {
             "te": {},
-            "dpln": {
-                "istart": grid.is_,
-                "iend": grid.ie,
-                "jstart": grid.js,
-                "jend": grid.je,
-                "kstart": grid.npz - 1,
-                "kend": grid.npz - 1,
-            },
             "qvapor": {},
             "qliquid": {},
             "qice": {},


### PR DESCRIPTION
## Purpose

The temporary fields that were previously necessary for the `compute` routine for the saturation stencil are now removed since the saturation stencil is a single stencil.  Also, the computation for `dpln` is removed and rolled into the computation of `den` in the `satadjust` routine, and `dpln`  is removed from the remapping_part2 stencil.

## Code changes:

fv3core/stencils/saturation_adjustment.py : Removed temporary fields and references to `dpln`
fv3core/stencils/saturation_adjustment.py : Removed references to `dpln`
fv3core/stencils/remapping_part2.py : Removed references to 'dpln' and removed `layer_gradient` routine
