### PR TITLE
Fix data cache not written bug

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -120,7 +120,7 @@ class StencilDataCache(collections.abc.Mapping):
         pymodule_filename = stencil._file_name
         return f"{os.path.splitext(pymodule_filename)[0]}_{self.extension}"
 
-    def __getitem__(self, stencil: gt4py.StencilObject):
+    def __getitem__(self, stencil: gt4py.StencilObject) -> Any:
         key = hash(stencil)
         if key not in self.cache:
             filename = self._get_cache_filename(stencil)
@@ -128,12 +128,15 @@ class StencilDataCache(collections.abc.Mapping):
                 self.cache[key] = pickle.load(open(filename, mode="rb"))
         return self.cache[key] if key in self.cache else {}
 
-    def __setitem__(self, stencil: gt4py.StencilObject, value: Any):
+    def __setitem__(self, stencil: gt4py.StencilObject, value: Any) -> None:
         key = hash(stencil)
         filename = self._get_cache_filename(stencil)
         self.cache[key] = value
         pickle.dump(self.cache[key], open(filename, mode="wb"))
         return self.cache[key]
+
+    def __contains__(self, stencil: gt4py.StencilObject) -> bool:
+        return self[stencil]
 
     def __len__(self) -> int:
         return len(self.cache)


### PR DESCRIPTION
## Purpose

This PR fixes a bug that causes the stencil data cache including `axis_offsets` and `passed_externals` to not be pickled to the file system when the `__getitem__` method evaluates to empty. The resolution is to add an explicit `__contains__` method to the `StencilDataCache` class.

## Code changes:

- Add `__contains__` method to the `StencilDataCache` class
- Add return types to `StencilDataCache` methods

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
