### PR TITLE
Combining stencils in d_sw.py

### DIFF
--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -238,11 +238,6 @@ def heat_source_from_vorticity_damping(
         )
 
 
-def initialize_heat_source(heat_source, diss_est):
-    heat_source[grid().compute_interface()] = 0
-    diss_est[grid().compute_interface()] = 0
-
-
 def heat_from_damping(
     ub,
     vb,
@@ -587,7 +582,6 @@ def d_sw(
     )
 
     fluxcap.compute(cx, cy, xflux, yflux, crx, cry, fx, fy)
-    initialize_heat_source(heat_s, diss_e)
 
     if not spec.namelist.hydrostatic:
         dw, wk = damp_vertical_wind(w, heat_s, diss_e, dt, column_namelist)

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -724,7 +724,9 @@ def d_sw(
     )
 
     if not grid().nested:
-        corners.fix_corner_ke(ke, u, v, ut, vt, dt, grid())
+        corners.fix_corner_ke(
+            ke, u, v, ut, vt, dt, origin=(0, 0, 0), domain=spec.grid.domain_shape_full()
+        )
 
     horizontal_relative_vorticity_from_winds(
         u,

--- a/fv3core/utils/corners.py
+++ b/fv3core/utils/corners.py
@@ -410,25 +410,3 @@ def corner_ke(
     )
 
     return ke
-
-
-@gtstencil
-def fix_corner_ke(
-    ke: FloatField,
-    u: FloatField,
-    v: FloatField,
-    ut: FloatField,
-    vt: FloatField,
-    dt: float,
-):
-    from __externals__ import i_end, i_start, j_end, j_start
-
-    with computation(PARALLEL), interval(...):
-        with horizontal(region[i_start, j_start]):
-            ke = corner_ke(ke, u, v, ut, vt, dt, 0, 0, -1, 1)
-        with horizontal(region[i_end + 1, j_start]):
-            ke = corner_ke(ke, u, v, ut, vt, dt, -1, 0, 0, -1)
-        with horizontal(region[i_end + 1, j_end + 1]):
-            ke = corner_ke(ke, u, v, ut, vt, dt, -1, -1, 0, 1)
-        with horizontal(region[i_start, j_end + 1]):
-            ke = corner_ke(ke, u, v, ut, vt, dt, 0, -1, -1, -1)

--- a/fv3core/utils/corners.py
+++ b/fv3core/utils/corners.py
@@ -384,26 +384,26 @@ def fill_corners_dgrid(x, y, grid, vector):
                 fill_ne_corner_vector_dgrid(x, y, i, j, grid, mysign)
 
 
-def corner_ke(ke, u, v, ut, vt, i, j, dt, offsets, vsign):
+def corner_ke(ke, u, v, ut, vt, i, j, dt, io1, jo1, io2, vsign):
     dt6 = dt / 6.0
     ke[i, j, :] = dt6 * (
-        (ut[i, j, :] + ut[i, j - 1, :]) * u[i + offsets["io1"], j, :]
-        + (vt[i, j, :] + vt[i - 1, j, :]) * v[i, j + offsets["jo1"], :]
-        + (ut[i, j + offsets["jo1"], :] + vsign * vt[i + offsets["io1"], j, :])
-        * u[i + offsets["io2"], j, :]
+        (ut[i, j, :] + ut[i, j - 1, :]) * ((io1 + 1) * u[i, j, :] - (io1 * u[i - 1, j, :]))
+        + (vt[i, j, :] + vt[i - 1, j, :]) * ((jo1 + 1) * v[i, j, :] - (jo1 * v[i, j - 1, :]))
+        + (((jo1 + 1) * ut[i, j, :] - (jo1 * ut[i, j - 1, :])) + vsign * ((io1 + 1) * vt[i, j, :] - (io1 * vt[i -1, j, :])))
+        * ((io2 + 1) * u[i, j, :] - (io2 * u[i-1, j, :]))
     )
 
 
 def fix_corner_ke(ke, u, v, ut, vt, dt, grid):
     if grid.sw_corner:
-        offsets = {"io1": 0, "jo1": 0, "io2": -1}
-        corner_ke(ke, u, v, ut, vt, grid.is_, grid.js, dt, offsets, 1)
+        #offsets = {"io1": 0, "jo1": 0, "io2": -1}
+        corner_ke(ke, u, v, ut, vt, grid.is_, grid.js, dt, 0, 0, -1, 1)
     if grid.se_corner:
-        offsets = {"io1": -1, "jo1": 0, "io2": 0}
-        corner_ke(ke, u, v, ut, vt, grid.ie + 1, grid.js, dt, offsets, -1)
+        #offsets = {"io1": -1, "jo1": 0, "io2": 0}
+        corner_ke(ke, u, v, ut, vt, grid.ie + 1, grid.js, dt, -1, 0, 0, -1)
     if grid.ne_corner:
-        offsets = {"io1": -1, "jo1": -1, "io2": 0}
-        corner_ke(ke, u, v, ut, vt, grid.ie + 1, grid.je + 1, dt, offsets, 1)
+        #offsets = {"io1": -1, "jo1": -1, "io2": 0}
+        corner_ke(ke, u, v, ut, vt, grid.ie + 1, grid.je + 1, dt, -1, -1, 0, 1)
     if grid.nw_corner:
-        offsets = {"io1": 0, "jo1": -1, "io2": -1}
-        corner_ke(ke, u, v, ut, vt, grid.is_, grid.je + 1, dt, offsets, -1)
+        #offsets = {"io1": 0, "jo1": -1, "io2": -1}
+        corner_ke(ke, u, v, ut, vt, grid.is_, grid.je + 1, dt, 0, -1, -1, -1)


### PR DESCRIPTION
## Purpose

Several stencils within `fv3core/stencils/d_sw.py` are consolidated into a single stencil.

## Code changes:

The following change was made in `fv3core/stencils/corners.py`

- Code from `fix_corner_ke` was removed from `fv3core/stencils/corners.py` and moved to `fv3core/stencils/d_sw.py`

The following changes were made in `fv3core/stencils/d_sw.py`

- `initial_heat_source` stencil was removed
- Single stencil created to merge `ke_from_b_wind`, `fix_corner_ke`, `horizontal_relative_vorticity_from_winds`, and `adjust_w_and_qcon`
- Single stencil created to merge `ub_from_vort`, `vb_from_vort`, `zrat_vorticity`, and `basic_addition`
- Single stencil created to merge `u_from_ke` and `v_from_ke`
- Single stencil created to merge `heat_from_damping`, `basic_add_term_stencil`, and `basic_subtract_term_stencil`
- `FloatField` replaces `utils.sd`
