### PR TITLE
enable gtcuda backend

### DIFF
--- a/.jenkins/actions/full_cache_build.sh
+++ b/.jenkins/actions/full_cache_build.sh
@@ -19,6 +19,5 @@ if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
 fi
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 1 6 $backend . $data_path
-#mkdir -p /scratch/snx3000/tobwi/store_gt_caches/$experiment
-mkdir -p /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment
-cp -r .gt_cache_00000* /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/
+mkdir -p /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend
+cp -r .gt_cache_00000* /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend/

--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -7,7 +7,8 @@ export TEST_ARGS="-v -s -rsx --backend=${BACKEND} --which_modules=FVDynamics"
 # sync the test data
 make get_test_data
 
-cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
-find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/zz_fv3core_cacheSetup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
-
+if [ ! -d $(pwd)/.gt_cache_00000 ]; then 
+    cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
+    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/zz_fv3core_cacheSetup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
+fi
 make tests_venv_mpi

--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -7,7 +7,7 @@ export TEST_ARGS="-v -s -rsx --backend=${BACKEND} --which_modules=FVDynamics"
 # sync the test data
 make get_test_data
 
-if [ ! -d $(pwd)/.gt_cache_00000 ]; then
+if [ ! -d $(pwd)/.gt_cache_000000 ]; then
     cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
     find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/zz_fv3core_cacheSetup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
 fi

--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -7,7 +7,7 @@ export TEST_ARGS="-v -s -rsx --backend=${BACKEND} --which_modules=FVDynamics"
 # sync the test data
 make get_test_data
 
-cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/.gt_cache_0000* .
-find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/zz_fv3core_cacheSetup\/backend\/gtx86\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
+cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
+find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/zz_fv3core_cacheSetup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
 
 make tests_venv_mpi

--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -7,7 +7,7 @@ export TEST_ARGS="-v -s -rsx --backend=${BACKEND} --which_modules=FVDynamics"
 # sync the test data
 make get_test_data
 
-if [ ! -d $(pwd)/.gt_cache_00000 ]; then 
+if [ ! -d $(pwd)/.gt_cache_00000 ]; then
     cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
     find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/zz_fv3core_cacheSetup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
 fi

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -189,6 +189,7 @@ echo "### ACTION ${action} SUCCESSFUL"
 if grep -q "fv_dynamics" <<< "${script}"; then
     cp  ${run_timing_script} job_${action}_2.sh
     run_timing_script=job_${action}_2.sh
+    export CRAY_CUDA_MPS=0
 	if grep -q "cuda" <<< "${backend}" ; then
 	    export MPICH_RDMA_ENABLED_CUDA=1
 	else

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -108,6 +108,9 @@ fi
 if grep -q "fv_dynamics" <<< "${script}"; then
 	if grep -q "cuda" <<< "${backend}" ; then
 	    export MPICH_RDMA_ENABLED_CUDA=1
+	    # This enables single node compilation
+	    # but will NOT work for c128
+	    export CRAY_CUDA_MPS=1
 	else
 	    export MPICH_RDMA_ENABLED_CUDA=0
 	fi


### PR DESCRIPTION
## Purpose

This PR changes the structure in which the pre-compiled gt_caches are stored to also distinguish the backends in a more obvious way to copy less data around and therefore enables runs with the cuda backend

## Infrastructure changes:

-  The plan fv3core-regression_PR now has an additional label in the backend column being gtcuda.
-  The plan zz_fv3core_cacheSetup now has an additional label in the backend column being gtcuda.
