### PR TITLE
Fix/remove test data

### DIFF
--- a/.jenkins/actions/full_cache_build.sh
+++ b/.jenkins/actions/full_cache_build.sh
@@ -20,4 +20,4 @@ fi
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 1 6 $backend . $data_path
 mkdir -p /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend
-cp -r .gt_cache_00000* /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend/
+mv .gt_cache_00000* /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend/

--- a/.jenkins/actions/run_performance.sh
+++ b/.jenkins/actions/run_performance.sh
@@ -19,3 +19,4 @@ if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
 fi
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path
+rm -rf .gt_cache_0000*

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -92,10 +92,6 @@ fi
 split_path=(${data_path//\// })
 experiment=${split_path[-1]}
 
-if [ ! -d $(pwd)/.gt_cache_000000 ]; then
-    cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend/.gt_cache_0000* .
-    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/zz_fv3core_cacheSetup\/backend\/$backend\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
-fi
 echo "submitting script to do compilation"
 # Adapt batch script to compile the code:
 sed -i s/\<NAME\>/standalone/g compile.daint.slurm
@@ -130,4 +126,7 @@ sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/p
 sbatch -W -C gpu run.daint.slurm
 wait
 rsync *.json $target_dir
+
+echo "clean up workspace"
+rm -rf test_data
 echo "performance run sucessful"


### PR DESCRIPTION
## Purpose

Current jenkins plans do not clear their workspace on failure but in order to keep under the file limit, we remove the data and the gt_caches always

## Code changes:

- updates to jenkins scripts to remove caches / data
