### PR TITLE
Attempt to improve performance history plot

### DIFF
--- a/examples/standalone/benchmarks/plotting.py
+++ b/examples/standalone/benchmarks/plotting.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     plot_variance = True
     plots = {
         "per_timestep": {
-            "title": "Performance history of components",
+            "title": "Performance history of components of mainloop",
             "timers": [
                 {"name": "mainloop", "linestyle": "-o"},
                 {"name": "DynCore", "linestyle": "--o"},
@@ -38,7 +38,7 @@ if __name__ == "__main__":
             "y_axis_label": "Execution time per timestep [s]",
         },
         "absolute_time": {
-            "title": "Performance history of absolute runtime",
+            "title": "Performance history of total runtime",
             "timers": [
                 {"name": "total", "linestyle": "-o"},
                 {"name": "initialization", "linestyle": "--o"},
@@ -76,6 +76,11 @@ if __name__ == "__main__":
             specific = [x for x in alldata if x["setup"]["version"] == backend]
             if specific:
                 for timer in plot_config["timers"]:
+                    label = None
+                    if "mainloop" in timer["name"] or "total" in timer["name"]:
+                        label = backend_config["short_name"]
+                    elif "gtcuda" in backend_config["short_name"]:
+                        label = backend_config["short_name"] + " " + timer["name"]
                     plt.plot(
                         [
                             datetime.strptime(
@@ -94,7 +99,7 @@ if __name__ == "__main__":
                         ],
                         timer["linestyle"],
                         markersize=markersize,
-                        label=backend_config["short_name"] + " " + timer["name"],
+                        label=label,
                         color=backend_config["color"],
                     )
                     if plot_variance:
@@ -156,6 +161,7 @@ if __name__ == "__main__":
             fontsize=fontsize,
         )
         ax.set_facecolor("white")
+        ax.set_yscale("log")
         plt.grid(color="silver", alpha=0.4)
         plt.gcf().set_size_inches(8, 6)
         plt.savefig("history_" + plottype + ".png", dpi=100)


### PR DESCRIPTION
## Purpose

The Fortran timings were not visible on the performance plot. Since the numpy times will probably not go down significantly, this is an attempt to make everything visible. This includes abbreviating the legend to have more plot area.

## Code changes:

Just a change in `plotting.py`

## Plot changes:

![image](https://user-images.githubusercontent.com/5963462/109108048-a1435700-76e7-11eb-80fa-ab00fe926d2f.png)

![image](https://user-images.githubusercontent.com/5963462/109108138-cd5ed800-76e7-11eb-9450-6c3027ddf45e.png)
