### PR TITLE
Move to the new name of generated caches

### DIFF
--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -9,6 +9,6 @@ make get_test_data
 
 if [ ! -d $(pwd)/.gt_cache_000000 ]; then
     cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
-    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/zz_fv3core_cacheSetup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
+    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
 fi
 make tests_venv_mpi


### PR DESCRIPTION
## Purpose

By renaming the jenkins plan, we need to change what we search and replace in the py files to get the cache to work properly
