### PR TITLE
Combining stencils in tracer_2d_1l.py

### DIFF
--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -177,8 +177,8 @@ def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
         grid.sin_sg4,
         xfx,
         yfx,
-        origin=grid.compute_origin(add=(-grid.halo, -grid.halo, 0)),
-        domain=grid.domain_shape_compute(add=(2 * grid.halo, 2 * grid.halo, 0)),
+        origin=grid.full_origin(),
+        domain=grid.domain_shape_full(),
     )
     # {
     # # TODO for if we end up using the Allreduce and compute cmax globally
@@ -237,8 +237,8 @@ def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
         ra_x,
         yfx,
         ra_y,
-        origin=grid.compute_origin(add=(-grid.halo, -grid.halo, 0)),
-        domain=grid.domain_shape_compute(add=(2 * grid.halo, 2 * grid.halo, 0)),
+        origin=grid.full_origin(),
+        domain=grid.domain_shape_full(),
     )
 
     # TODO: Revisit: the loops over q and nsplt have two inefficient options

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -274,17 +274,6 @@ def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
                 domain=grid.domain_shape_compute(),
             )
             if nsplt != 1:
-                # if it == 0:
-                # TODO 1d
-                # qn2 = grid.quantity_wrap(
-                #     copy(
-                #         q.storage,
-                #         origin=grid.full_origin(),
-                #         domain=grid.domain_shape_full(),
-                #     ),
-                #     units="kg/m^2",
-                # )
-
                 fvtp2d.compute_no_sg(
                     qn2.storage,
                     cxd,

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -255,6 +255,14 @@ def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
             origin=grid.full_origin(),
             domain=grid.domain_shape_full(),
         )
+        qn2 = grid.quantity_wrap(
+            copy(
+                q.storage,
+                origin=grid.full_origin(),
+                domain=grid.domain_shape_full(),
+            ),
+            units="kg/m^2",
+        )
         for it in range(int(nsplt)):
             dp_fluxadjustment(
                 dp1,
@@ -266,16 +274,16 @@ def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
                 domain=grid.domain_shape_compute(),
             )
             if nsplt != 1:
-                if it == 0:
-                    # TODO 1d
-                    qn2 = grid.quantity_wrap(
-                        copy(
-                            q.storage,
-                            origin=grid.full_origin(),
-                            domain=grid.domain_shape_full(),
-                        ),
-                        units="kg/m^2",
-                    )
+                # if it == 0:
+                # TODO 1d
+                # qn2 = grid.quantity_wrap(
+                #     copy(
+                #         q.storage,
+                #         origin=grid.full_origin(),
+                #         domain=grid.domain_shape_full(),
+                #     ),
+                #     units="kg/m^2",
+                # )
 
                 fvtp2d.compute_no_sg(
                     qn2.storage,

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -9,14 +9,19 @@ import fv3core.utils.global_config as global_config
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy, copy_stencil
-from fv3core.stencils.updatedzd import ra_x_stencil, ra_y_stencil
-
-
-sd = utils.sd
+from fv3core.stencils.updatedzd import ra_stencil_update
+from fv3core.utils.typing import FloatField
 
 
 @gtstencil()
-def flux_x(cx: sd, dxa: sd, dy: sd, sin_sg3: sd, sin_sg1: sd, xfx: sd):
+def flux_x(
+    cx: FloatField,
+    dxa: FloatField,
+    dy: FloatField,
+    sin_sg3: FloatField,
+    sin_sg1: FloatField,
+    xfx: FloatField,
+):
     with computation(PARALLEL), interval(...):
         xfx[0, 0, 0] = (
             cx * dxa[-1, 0, 0] * dy * sin_sg3[-1, 0, 0]
@@ -26,7 +31,14 @@ def flux_x(cx: sd, dxa: sd, dy: sd, sin_sg3: sd, sin_sg1: sd, xfx: sd):
 
 
 @gtstencil()
-def flux_y(cy: sd, dya: sd, dx: sd, sin_sg4: sd, sin_sg2: sd, yfx: sd):
+def flux_y(
+    cy: FloatField,
+    dya: FloatField,
+    dx: FloatField,
+    sin_sg4: FloatField,
+    sin_sg2: FloatField,
+    yfx: FloatField,
+):
     with computation(PARALLEL), interval(...):
         yfx[0, 0, 0] = (
             cy * dya[0, -1, 0] * dx * sin_sg4[0, -1, 0]
@@ -37,7 +49,13 @@ def flux_y(cy: sd, dya: sd, dx: sd, sin_sg4: sd, sin_sg2: sd, yfx: sd):
 
 @gtstencil()
 def cmax_multiply_by_frac(
-    cxd: sd, xfx: sd, mfxd: sd, cyd: sd, yfx: sd, mfyd: sd, frac: float
+    cxd: FloatField,
+    xfx: FloatField,
+    mfxd: FloatField,
+    cyd: FloatField,
+    yfx: FloatField,
+    mfyd: FloatField,
+    frac: float,
 ):
     """multiply all other inputs in-place by frac."""
     with computation(PARALLEL), interval(...):
@@ -50,19 +68,27 @@ def cmax_multiply_by_frac(
 
 
 @gtstencil()
-def cmax_stencil1(cx: sd, cy: sd, cmax: sd):
+def cmax_stencil1(cx: FloatField, cy: FloatField, cmax: FloatField):
     with computation(PARALLEL), interval(...):
         cmax = max(abs(cx), abs(cy))
 
 
 @gtstencil()
-def cmax_stencil2(cx: sd, cy: sd, sin_sg5: sd, cmax: sd):
+def cmax_stencil2(
+    cx: FloatField, cy: FloatField, sin_sg5: FloatField, cmax: FloatField
+):
     with computation(PARALLEL), interval(...):
         cmax = max(abs(cx), abs(cy)) + 1.0 - sin_sg5
 
 
 @gtstencil()
-def dp_fluxadjustment(dp1: sd, mfx: sd, mfy: sd, rarea: sd, dp2: sd):
+def dp_fluxadjustment(
+    dp1: FloatField,
+    mfx: FloatField,
+    mfy: FloatField,
+    rarea: FloatField,
+    dp2: FloatField,
+):
     with computation(PARALLEL), interval(...):
         dp2 = dp1 + (mfx - mfx[1, 0, 0] + mfy - mfy[0, 1, 0]) * rarea
 
@@ -73,15 +99,35 @@ def adjustment(q, dp1, fx, fy, rarea, dp2):
 
 
 @gtstencil()
-def q_adjust(q: sd, dp1: sd, fx: sd, fy: sd, rarea: sd, dp2: sd):
+def q_adjust(
+    q: FloatField,
+    dp1: FloatField,
+    fx: FloatField,
+    fy: FloatField,
+    rarea: FloatField,
+    dp2: FloatField,
+):
     with computation(PARALLEL), interval(...):
         q = adjustment(q, dp1, fx, fy, rarea, dp2)
 
 
 @gtstencil()
-def q_other_adjust(q: sd, qset: sd, dp1: sd, fx: sd, fy: sd, rarea: sd, dp2: sd):
+def q_adjustments(
+    q: FloatField,
+    qset: FloatField,
+    dp1: FloatField,
+    fx: FloatField,
+    fy: FloatField,
+    rarea: FloatField,
+    dp2: FloatField,
+    it: int,
+    nsplt: int,
+):
     with computation(PARALLEL), interval(...):
-        qset = adjustment(q, dp1, fx, fy, rarea, dp2)
+        if it < nsplt - 1:
+            q = adjustment(q, dp1, fx, fy, rarea, dp2)
+        else:
+            qset = adjustment(q, dp1, fx, fy, rarea, dp2)
 
 
 def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
@@ -176,19 +222,29 @@ def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
             q = tracers[qname + "_quantity"]
             comm.halo_update(q, n_points=utils.halo)
 
-    ra_x_stencil(
+    # ra_x_stencil(
+    #     grid.area,
+    #     xfx,
+    #     ra_x,
+    #     origin=grid.compute_origin(add=(0, -grid.halo, 0)),
+    #     domain=grid.domain_shape_compute(add=(0, 2 * grid.halo, 0)),
+    # )
+    # ra_y_stencil(
+    #     grid.area,
+    #     yfx,
+    #     ra_y,
+    #     origin=grid.compute_origin(add=(-grid.halo, 0, 0)),
+    #     domain=grid.domain_shape_compute(add=(2 * grid.halo, 0, 0)),
+    # )
+
+    ra_stencil_update(
         grid.area,
         xfx,
         ra_x,
-        origin=grid.compute_origin(add=(0, -grid.halo, 0)),
-        domain=grid.domain_shape_compute(add=(0, 2 * grid.halo, 0)),
-    )
-    ra_y_stencil(
-        grid.area,
         yfx,
         ra_y,
-        origin=grid.compute_origin(add=(-grid.halo, 0, 0)),
-        domain=grid.domain_shape_compute(add=(2 * grid.halo, 0, 0)),
+        origin=grid.compute_origin(add=(-grid.halo, -grid.halo, 0)),
+        domain=grid.domain_shape_compute(add=(2 * grid.halo, 2 * grid.halo, 0)),
     )
 
     # TODO: Revisit: the loops over q and nsplt have two inefficient options
@@ -241,29 +297,20 @@ def compute(comm, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt, nq):
                     mfx=mfxd,
                     mfy=mfyd,
                 )
-                if it < nsplt - 1:
-                    q_adjust(
-                        qn2.storage,
-                        dp1,
-                        fx,
-                        fy,
-                        grid.rarea,
-                        dp2,
-                        origin=grid.compute_origin(),
-                        domain=grid.domain_shape_compute(),
-                    )
-                else:
-                    q_other_adjust(
-                        qn2.storage,
-                        q.storage,
-                        dp1,
-                        fx,
-                        fy,
-                        grid.rarea,
-                        dp2,
-                        origin=grid.compute_origin(),
-                        domain=grid.domain_shape_compute(),
-                    )
+
+                q_adjustments(
+                    qn2.storage,
+                    q.storage,
+                    dp1,
+                    fx,
+                    fy,
+                    grid.rarea,
+                    dp2,
+                    it,
+                    nsplt,
+                    origin=grid.compute_origin(),
+                    domain=grid.domain_shape_compute(),
+                )
             else:
                 fvtp2d.compute_no_sg(
                     q.storage,

--- a/fv3core/stencils/updatedzd.py
+++ b/fv3core/stencils/updatedzd.py
@@ -24,24 +24,6 @@ DZ_MIN = constants.DZ_MIN
 
 
 @gtstencil()
-def ra_x_stencil(area: sd, xfx_adv: sd, ra_x: sd):
-    from __externals__ import local_ie, local_is, local_je, local_js
-
-    with computation(PARALLEL), interval(...):
-        with horizontal(region[local_is : local_ie + 1, local_js - 3 : local_je + 4]):
-            ra_x = ra_x_func(area, xfx_adv)
-
-
-@gtstencil()
-def ra_y_stencil(area: sd, yfx_adv: sd, ra_y: sd):
-    from __externals__ import local_ie, local_is, local_je, local_js
-
-    with computation(PARALLEL), interval(...):
-        with horizontal(region[local_is - 3 : local_ie + 4, local_js : local_je + 1]):
-            ra_y = ra_y_func(area, yfx_adv)
-
-
-@gtstencil()
 def ra_stencil_update(area: sd, xfx_adv: sd, ra_x: sd, yfx_adv: sd, ra_y: sd):
     from __externals__ import local_ie, local_is, local_je, local_js
 
@@ -220,20 +202,16 @@ def compute(ndif, damp_vtd, dp0, zs, zh, crx, cry, xfx, yfx, wsd, dt):
         domain=(grid.nid, grid.njc + 1, grid.npz + 1),
     )
 
-    ra_x_stencil(
+    ra_stencil_update(
         grid.area,
         xfx_adv,
         ra_x,
-        origin=grid.compute_origin(add=(0, -grid.halo, 0)),
-        domain=(grid.nic, grid.njd, grid.npz + 1),
-    )
-    ra_y_stencil(
-        grid.area,
         yfx_adv,
         ra_y,
-        origin=grid.compute_origin(add=(-grid.halo, 0, 0)),
-        domain=(grid.nid, grid.njc, grid.npz + 1),
+        origin=grid.compute_origin(add=(-grid.halo, -grid.halo, 0)),
+        domain=(grid.nid, grid.njd, grid.npz + 1),
     )
+
     # TODO, when consoldiating k plitting, change this too
     data = {}
     for varname in ["zh", "crx_adv", "cry_adv", "xfx_adv", "yfx_adv", "ra_x", "ra_y"]:


### PR DESCRIPTION
## Purpose

The purpose is to combine stencils in `tracer_2d_1l.py` (and `updatedzd.py`).  The following stencils are combined.

- `q_adjust` and `q_other_adjust` are combined into `q_adjustments` in `tracer_2d_1l.py`
- `ra_x_stencil` and `ra_y_stencil` are combined into `ra_stencil_update` in `updatedzd.py`
- `flux_x` and `flux_y` are combined into `flux_compute` in `tracer_2d_1l.py`

## Code changes:

- `q_adjustment` stencil created in `tracer_2d_1l.py`
- `q_other_adjust` stencil deleted from `tracer_2d_1l.py`
- `ra_stencil_update` stencil created in `updatedzd.py`
- `ra_x_stencil` and `ra_y_stencil` stencil definitions are deleted from `updatedzd.py`.
- Calls to `ra_x_stencil` and `ra_y_stencil` in `tracer_2d_1l.py` and `updatedzd.py` are replaced by `ra_stencil_update` 
- `flux_x` and `flux_y` stencils are converted into `gtscript.function` calls in `tracer_2d_1l.py`
- `flux_compute` stencil created in `tracer_2d_1l.py` that call `flux_x` and `flux_y` functions
- `utils.sd` type replaced by `FloatField`
