### PR TITLE
only copy caches if they already exist

### DIFF
--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -92,9 +92,13 @@ fi
 
 split_path=(${data_path//\// })
 experiment=${split_path[-1]}
-if [ ! -d $(pwd)/.gt_cache_000000 ]; then
-    cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend/.gt_cache_0000* .
-    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$backend\/experiment\/$experiment\/slave\/daint_submit|$(pwd)|g" {} +
+sample_cache=.gt_cache_000000
+if [ ! -d $(pwd)/${sample_cache} ]; then
+    premade_caches=/scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend
+    if [ -d ${premade_caches}/${sample_cache} ]; then
+	cp -r ${premade_caches}/.gt_cache_0000* .
+	find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$backend\/experiment\/$experiment\/slave\/daint_submit|$(pwd)|g" {} +
+    fi
 fi
 
 echo "submitting script to do compilation"


### PR DESCRIPTION
## Purpose

We only need to load in existing caches for the gt backends, it is fine to not copy in numpy caches. This change stops the jenkins plan fv3core-performance-test from failing on the numpy backend
