### PR TITLE
fix zh/gz copy order in dyn_core

### DIFF
--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -253,8 +253,8 @@ def compute(state, comm):
                 )
             else:
                 copy_stencil(
-                    state.gz,
                     state.zh,
+                    state.gz,
                     origin=grid.full_origin(),
                     domain=grid.domain_shape_full(add=(0, 0, 1)),
                 )


### PR DESCRIPTION
## Purpose

In the first timestep, zh is copied from gz, for all subsequent timesteps, gz is copied from zh. Somehow this did not happen properly in the first version and our test code doesn't catch it. 

## Code changes:

- minor change to dyn_core
