### PR TITLE
Refactor daint performance & profile scripts

### DIFF
--- a/.jenkins/actions/full_cache_build.sh
+++ b/.jenkins/actions/full_cache_build.sh
@@ -3,20 +3,12 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
-TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data/"
+TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data"
+FORTRAN_SERIALIZED_DATA_VERSION=7.2.5
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
 test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 
-
-if [ "$experiment" = "c12_6ranks_standard" ]; then
-    data_path="${TESTDATA_PATH}7.0.0/c12_6ranks_standard"
-fi
-if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}7.2.3/c96_6ranks_baroclinic"
-fi
-if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}7.2.3/c128_6ranks_baroclinic"
-fi
+data_path=${TESTDATA_PATH}/${FORTRAN_SERIALIZED_DATA_VERSION}/${experiment}
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 1 6 $backend . $data_path
 mkdir -p /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend

--- a/.jenkins/actions/full_cache_build.sh
+++ b/.jenkins/actions/full_cache_build.sh
@@ -5,7 +5,7 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
-TESTDATA_PATH="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data"
+TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data"
 FORTRAN_SERIALIZED_DATA_VERSION=7.2.5
 
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
@@ -14,6 +14,7 @@ test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 data_path=${TESTDATA_PATH}/${FORTRAN_SERIALIZED_DATA_VERSION}/${experiment}
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 1 6 $backend . $data_path
+
 mkdir -p /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend
 rm -rf /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend/.gt_cache_00000*
 mv .gt_cache_00000* /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$backend/

--- a/.jenkins/actions/run_performance.sh
+++ b/.jenkins/actions/run_performance.sh
@@ -5,7 +5,7 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
-TESTDATA_PATH="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data"
+TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data"
 FORTRAN_SERIALIZED_DATA_VERSION=7.2.5
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
 test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
@@ -13,4 +13,5 @@ test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 data_path=${TESTDATA_PATH}/${FORTRAN_SERIALIZED_DATA_VERSION}/${experiment}
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path
+
 rm -rf .gt_cache_0000*

--- a/.jenkins/actions/run_performance.sh
+++ b/.jenkins/actions/run_performance.sh
@@ -3,20 +3,12 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
-TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data/"
+TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data"
+FORTRAN_SERIALIZED_DATA_VERSION=7.2.5
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
 test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 
-
-if [ "$experiment" = "c12_6ranks_standard" ]; then
-    data_path="${TESTDATA_PATH}7.0.0/c12_6ranks_standard"
-fi
-if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}7.2.3/c96_6ranks_baroclinic"
-fi
-if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}7.2.3/c128_6ranks_baroclinic"
-fi
+data_path=${TESTDATA_PATH}/${FORTRAN_SERIALIZED_DATA_VERSION}/${experiment}
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path
 rm -rf .gt_cache_0000*

--- a/.jenkins/actions/run_profile.sh
+++ b/.jenkins/actions/run_profile.sh
@@ -3,21 +3,30 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
-TESTDATA_PATH="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data/7.2.5"
+TESTDATA_PATH="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data"
+FORTRAN_SERIALIZED_DATA_VERSION=7.2.5
+
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
 test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 
-
-if [ "$experiment" = "c12_6ranks_standard" ]; then
-    data_path="${TESTDATA_PATH}/c12_6ranks_standard"
-fi
-if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}/c96_6ranks_baroclinic"
-fi
-if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}/c128_6ranks_baroclinic"
-fi
+data_path=${TESTDATA_PATH}/${FORTRAN_SERIALIZED_DATA_VERSION}/${experiment}
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path "-m cProfile -o $ROOT_DIR/fv3core_${experiment}_${backend}.prof"
-mv $ROOT_DIR/fv3core_${experiment}_${backend}.prof /project/s1053/performance/fv3core_monitor/$backend/
+
+cp $ROOT_DIR/fv3core_${experiment}_${backend}.prof /project/s1053/performance/fv3core_monitor/$backend/
+
+source externals/daint_venv/test_ve/bin/activate
+cat > $ROOT_DIR/stats.py <<EOF
+#!/usr/bin/env python3
+
+import pstats
+
+stats = pstats.Stats("$ROOT_DIR/fv3core_${experiment}_${backend}.prof")
+stats.strip_dirs()
+stats.sort_stats('cumulative')
+stats.print_stats()
+EOF
+chmod 755 $ROOT_DIR/stats.py
+$ROOT_DIR/stats.py > stats.txt
+
 rm -rf .gt_cache_0000*

--- a/.jenkins/actions/run_profile.sh
+++ b/.jenkins/actions/run_profile.sh
@@ -15,8 +15,11 @@ $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s
 
 cp $ROOT_DIR/fv3core_${experiment}_${backend}.prof /project/s1053/performance/fv3core_monitor/$backend/
 
-source externals/daint_venv/test_ve/bin/activate
-cat > $ROOT_DIR/stats.py <<EOF
+rm -rf .gt_cache_0000*
+
+# generate simple profile listing
+source $ROOT_DIR/external/daint_venv/test_ve/bin/activate
+cat > $ROOT_DIR/profile.py <<EOF
 #!/usr/bin/env python3
 
 import pstats
@@ -26,7 +29,12 @@ stats.strip_dirs()
 stats.sort_stats('cumulative')
 stats.print_stats()
 EOF
-chmod 755 $ROOT_DIR/stats.py
-$ROOT_DIR/stats.py > stats.txt
+chmod 755 $ROOT_DIR/profile.py
+$ROOT_DIR/profile.py > profile.txt
 
-rm -rf .gt_cache_0000*
+# convert to html
+mkdir -p html
+echo "<html><body><pre>" > html/index.html
+cat profile.txt >> html/index.html
+echo "</pre></body></html>" >> html/index.html
+

--- a/.jenkins/actions/run_profile.sh
+++ b/.jenkins/actions/run_profile.sh
@@ -38,3 +38,5 @@ echo "<html><body><pre>" > html/index.html
 cat profile.txt >> html/index.html
 echo "</pre></body></html>" >> html/index.html
 
+# so long!
+exit 0

--- a/.jenkins/actions/run_profile.sh
+++ b/.jenkins/actions/run_profile.sh
@@ -3,7 +3,7 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
-TESTDATA_PATH="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data"
+TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data"
 FORTRAN_SERIALIZED_DATA_VERSION=7.2.5
 
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -43,7 +43,7 @@ fi
 data_path="$5"
 if [ -z "$5" ]
   then
-    data_path="/project/s1053/fv3core_serialized_test_data/7.2.5/c12_6ranks_baroclinic/"
+    data_path="/project/s1053/fv3core_serialized_test_data/7.2.5/c12_6ranks_standard/"
 fi
 
 

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -43,7 +43,7 @@ fi
 data_path="$5"
 if [ -z "$5" ]
   then
-    data_path="/project/s1053/fv3core_serialized_test_data/7.0.0/c12_6ranks_standard/"
+    data_path="/project/s1053/fv3core_serialized_test_data/7.2.5/c12_6ranks_baroclinic/"
 fi
 
 

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -66,6 +66,7 @@ pip list
 # set up the experiment data
 cp -r $data_path test_data
 tar -xf test_data/dat_files.tar.gz -C test_data
+rm -rf test_data/dat_files.tar.gz
 cp test_data/*.yml test_data/input.yml
 
 # set the environment


### PR DESCRIPTION
## Purpose

This PRs has changed in purpose. Data now seems to live on /scratch. So changes have been adapted accordingly and updated to latest master.

Add simple generation of profiling output in *.txt and *.html format. See https://jenkins.ginko.ch/view/Owners/job/fv3core-performance-profile/backend=gtx86,experiment=c128_6ranks_baroclinic,slave=daint_submit/ for an example.