### PR TITLE
use existing data rather than always untarring

### DIFF
--- a/.jenkins/actions/full_cache_build.sh
+++ b/.jenkins/actions/full_cache_build.sh
@@ -3,19 +3,19 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
-TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data/"
+TESTDATA_PATH="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data/7.2.5/"
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
 test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 
 
 if [ "$experiment" = "c12_6ranks_standard" ]; then
-    data_path="${TESTDATA_PATH}7.0.0/c12_6ranks_standard"
+    data_path="${TESTDATA_PATH}/c12_6ranks_standard"
 fi
 if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}7.2.3/c96_6ranks_baroclinic"
+    data_path="${TESTDATA_PATH}/c96_6ranks_baroclinic"
 fi
 if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}7.2.3/c128_6ranks_baroclinic"
+    data_path="${TESTDATA_PATH}/c128_6ranks_baroclinic"
 fi
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 1 6 $backend . $data_path

--- a/.jenkins/actions/run_performance.sh
+++ b/.jenkins/actions/run_performance.sh
@@ -3,19 +3,19 @@ set -e -x
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
-TESTDATA_PATH="/project/s1053/fv3core_serialized_test_data/"
+TESTDATA_PATH="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data/7.2.5"
 test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
 test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
 
 
 if [ "$experiment" = "c12_6ranks_standard" ]; then
-    data_path="${TESTDATA_PATH}7.0.0/c12_6ranks_standard"
+    data_path="${TESTDATA_PATH}/c12_6ranks_standard"
 fi
 if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}7.2.3/c96_6ranks_baroclinic"
+    data_path="${TESTDATA_PATH}/c96_6ranks_baroclinic"
 fi
 if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
-    data_path="${TESTDATA_PATH}7.2.3/c128_6ranks_baroclinic"
+    data_path="${TESTDATA_PATH}/c128_6ranks_baroclinic"
 fi
 
 $ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -43,7 +43,7 @@ fi
 data_path="$5"
 if [ -z "$5" ]
   then
-    data_path="/project/s1053/fv3core_serialized_test_data/7.0.0/c12_6ranks_standard/"
+    data_path="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data/7.2.5/c12_6ranks_standard/"
 fi
 
 
@@ -63,10 +63,6 @@ pip install .
 
 pip list
 
-# set up the experiment data
-cp -r $data_path test_data
-tar -xf test_data/dat_files.tar.gz -C test_data
-cp test_data/*.yml test_data/input.yml
 
 # set the environment
 git clone https://github.com/VulcanClimateModeling/buildenv/
@@ -111,7 +107,7 @@ sed -i s/--output=\<OUTFILE\>/--hint=nomultithread/g compile.daint.slurm
 sed -i s/00:45:00/03:30:00/g compile.daint.slurm
 sed -i s/cscsci/normal/g compile.daint.slurm
 sed -i s/\<G2G\>/export\ CRAY_CUDA_MPS=1/g compile.daint.slurm
-sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py test_data/ 1 $backend $githash --disable_halo_exchange#g" compile.daint.slurm
+sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py $data_path 1 $backend $githash --disable_halo_exchange#g" compile.daint.slurm
 
 # execute on a gpu node
 sbatch -W -C gpu compile.daint.slurm
@@ -128,13 +124,11 @@ sed -i s/--output=\<OUTFILE\>/--hint=nomultithread/g run.daint.slurm
 sed -i s/00:45:00/00:30:00/g run.daint.slurm
 sed -i s/cscsci/normal/g run.daint.slurm
 sed -i s/\<G2G\>//g run.daint.slurm
-sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py test_data/ $timesteps $backend $githash#g" run.daint.slurm
+sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash#g" run.daint.slurm
 
 # execute on a gpu node
 sbatch -W -C gpu run.daint.slurm
 wait
 rsync *.json $target_dir
 
-echo "clean up workspace"
-rm -rf test_data
 echo "performance run sucessful"


### PR DESCRIPTION
## Purpose

We keep running out of space on scratch. This is partly due to the multiple copies of 2-3 GB of data every performance test. The gt caches bring another 3 gb of data and it pretty quickly fills up. 
Here,  instead of copying the data, and untarring it multiple times for every performance run, keep the untarred data with all the other data and use it. This PR currently does not handle all the steps to make sure the data is there nd input.yml is there, so more could be done to make it easier to use a new dataset. 
This may not work for very high resolution data if we increase this. But currently the tarred c128 data is 2 GB and untarred is 3gb, so seems like it could be worthwhile. 

I don't mind closing this if it is preferable to not do this. It may be enough to delete the tar file after unzipping it as propose n another PR> 
## Infrastructure changes:

- Update the jenkins plan code that relied on the run_on_daint data to be in a local directory named test_data

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
