### PR TITLE
pk3_halo.py update

### DIFF
--- a/fv3core/stencils/pk3_halo.py
+++ b/fv3core/stencils/pk3_halo.py
@@ -12,23 +12,23 @@ from fv3core.utils.typing import FloatField, FloatFieldIJ
 def edge_pe_update(
     pe: FloatFieldIJ, delp: FloatField, pk3: FloatField, ptop: float, akap: float
 ):
-    from __externals__ import i_end, i_start, j_end, j_start
+    from __externals__ import local_ie, local_is, local_je, local_js
 
     with computation(FORWARD):
         with interval(0, 1):
             with horizontal(
-                region[i_start - 2 : i_start, j_start : j_end + 1],
-                region[i_end + 1 : i_end + 3, j_start : j_end + 1],
-                region[i_start - 2 : i_end + 3, j_start - 2 : j_start],
-                region[i_start - 2 : i_end + 3, j_end + 1 : j_end + 3],
+                region[local_is - 2 : local_is, local_js : local_je + 1],
+                region[local_ie + 1 : local_ie + 3, local_js : local_je + 1],
+                region[local_is - 2 : local_ie + 3, local_js - 2 : local_js],
+                region[local_is - 2 : local_ie + 3, local_je + 1 : local_je + 3],
             ):
                 pe = ptop
         with interval(1, None):
             with horizontal(
-                region[i_start - 2 : i_start, j_start : j_end + 1],
-                region[i_end + 1 : i_end + 3, j_start : j_end + 1],
-                region[i_start - 2 : i_end + 3, j_start - 2 : j_start],
-                region[i_start - 2 : i_end + 3, j_end + 1 : j_end + 3],
+                region[local_is - 2 : local_is, local_js : local_je + 1],
+                region[local_ie + 1 : local_ie + 3, local_js : local_je + 1],
+                region[local_is - 2 : local_ie + 3, local_js - 2 : local_js],
+                region[local_is - 2 : local_ie + 3, local_je + 1 : local_je + 3],
             ):
                 pe = pe + delp[0, 0, -1]
                 pk3 = pe ** akap


### PR DESCRIPTION
## Purpose

This PR reduces the number of stencil call by utilizing horizontal regions within the stencil call to define the halo computation domain.

## Code changes:

`fv3core/stencils/pk3_halo.py`
- In `compute`, the 4 `edge_pe` stencil calls are replaced with a single `edge_pe_update` stencil call that incorporates horizontal regions.  Also, the two three-dimensional fields, `pei` and `pej`, allocated as temporaries are replaced by a two-dimensional field temporary `pe_tmp`.  
- In the `edge_pe_update` stencil, horizontal regions are defined to address the halo computation domain.  The `pk3` computation is rolled into the `FORWARD` computation.  Also, `pk3 = exp(akap * log(pe))` is replaced with `pk3 = pe ** akap` since a potential horizontal region bug was discovered.  Using the `pk3` computation with `log` and `exp` results in an inconsistent data type error when multiple `region` declarations are used within a `with horizontal` declaration.
- Type references to `utils.sd` are replaced using `FloatField` and `FloatFieldIJ` from `fv3core.utils.typing`