### PR TITLE
adding an action to get test data on daint

### DIFF
--- a/.jenkins/actions/get_test_data.sh
+++ b/.jenkins/actions/get_test_data.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e -x
+for dataset in c12_6ranks_standard c12_54ranks_standard c128_6ranks_baroclinic ; do
+    TEST_DATA_HOST="${TEST_DATA_DIR}/${dataset}/" make get_test_data
+done

--- a/.jenkins/actions/get_test_data.sh
+++ b/.jenkins/actions/get_test_data.sh
@@ -2,4 +2,5 @@
 set -e -x
 for dataset in c12_6ranks_standard c12_54ranks_standard c128_6ranks_baroclinic ; do
     TEST_DATA_HOST="${TEST_DATA_DIR}/${dataset}/" make get_test_data
+    mv ${TEST_DATA_HOST}/${dataset}.yml ${TEST_DATA_HOST}/input.yml
 done


### PR DESCRIPTION
## Purpose

The regression tests no longer have 'touchstone' configurations, so when the data on daint needs to be updated, the multiconfiguration project messes this up and usually fails. Adding a simple action to make sure daint has the test data for the datasets we are using, to be added to the fv3core-daint-setup plan that runs before the fv3core-regressions_PR runs. 


## Infrastructure changes:

- added a jenkins actions get_test_data
