### PR TITLE
Enable `fv3core-performance-profile` Jenkins plan

### DIFF
--- a/.jenkins/actions/run_profile.sh
+++ b/.jenkins/actions/run_profile.sh
@@ -18,5 +18,6 @@ if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
     data_path="${TESTDATA_PATH}/c128_6ranks_baroclinic"
 fi
 
-$ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path "-m cProfile -o /project/s1053/performance/profiles/fv3core_${experiment}_${backend}.prof"
+$ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path "-m cProfile -o $ROOT_DIR/fv3core_${experiment}_${backend}.prof"
+mv $ROOT_DIR/fv3core_${experiment}_${backend}.prof /project/s1053/performance/fv3core_monitor/$backend/
 rm -rf .gt_cache_0000*

--- a/.jenkins/actions/run_profile.sh
+++ b/.jenkins/actions/run_profile.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e -x
+SCRIPT=`realpath $0`
+SCRIPTPATH=`dirname $SCRIPT`
+ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
+TESTDATA_PATH="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data/7.2.5"
+test -n "${experiment}" || exitError 1001 ${LINENO} "experiment is not defined"
+test -n "${backend}" || exitError 1002 ${LINENO} "backend is not defined"
+
+
+if [ "$experiment" = "c12_6ranks_standard" ]; then
+    data_path="${TESTDATA_PATH}/c12_6ranks_standard"
+fi
+if [ "$experiment" = "c96_6ranks_baroclinic" ]; then
+    data_path="${TESTDATA_PATH}/c96_6ranks_baroclinic"
+fi
+if [ "$experiment" = "c128_6ranks_baroclinic" ]; then
+    data_path="${TESTDATA_PATH}/c128_6ranks_baroclinic"
+fi
+
+$ROOT_DIR/examples/standalone/benchmarks/run_on_daint.sh 2 6 $backend /project/s1053/performance/fv3core_monitor/$backend/ $data_path "-m cProfile -o /project/s1053/performance/profiles/fv3core_${experiment}_${backend}.prof"
+rm -rf .gt_cache_0000*

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -46,6 +46,11 @@ if [ -z "$5" ]
     data_path="/scratch/snx3000/olifu/jenkins/scratch/fv3core_fortran_data/7.2.5/c12_6ranks_standard/"
 fi
 
+py_args="$6"
+if [ -z "$6" ]
+  then
+    py_args=""
+fi
 
 # set up the virtual environment
 cd $ROOT_DIR
@@ -124,7 +129,7 @@ sed -i s/--output=\<OUTFILE\>/--hint=nomultithread/g run.daint.slurm
 sed -i s/00:45:00/00:30:00/g run.daint.slurm
 sed -i s/cscsci/normal/g run.daint.slurm
 sed -i s/\<G2G\>//g run.daint.slurm
-sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash#g" run.daint.slurm
+sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python $py_args examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash#g" run.daint.slurm
 
 # execute on a gpu node
 sbatch -W -C gpu run.daint.slurm


### PR DESCRIPTION
## Purpose

The purpose of this PR is to enable a new `fv3core-performance-profile` Jenkins plan that runs the performance tests with `cProfile` enabled and output the results into a scratch directory for post-processing / visualization.

## Infrastructure changes:

- Add `$py_args` argument to `run_on_daint.sh` script to pass specific arguments to the python executable.
- Add `.jenkins/actions/run_profile.sh` script to pass the `cProfile` arguments to `python` in `run_on_daint.sh`.
