### PR TITLE
add comments from technical documentation

### DIFF
--- a/fv3core/stencils/d2a2c_vect.py
+++ b/fv3core/stencils/d2a2c_vect.py
@@ -41,26 +41,66 @@ def lagrange_interpolation_x_p1(qy: sd, qout: sd):
         qout = lagrange_x_func_p1(qy)
 
 
-@gtscript.function
-def avg_x(u):
-    return 0.5 * (u + u[0, 1, 0])
-
-
-@gtscript.function
-def avg_y(v):
-    return 0.5 * (v + v[1, 0, 0])
-
-
 @gtstencil()
 def avg_box(u: sd, v: sd, utmp: sd, vtmp: sd):
     with computation(PARALLEL), interval(...):
-        utmp = avg_x(u)
-        vtmp = avg_y(v)
+        utmp = 0.5 * (u + u[0, 1, 0])
+        vtmp = 0.5 * (v + v[1, 0, 0])
 
 
 @gtscript.function
-def contravariant(u, v, cosa, rsin):
-    return (u - v * cosa) * rsin
+def contravariant(v1, v2, cosa, rsin2):
+    """
+    Retrieve the contravariant component of the wind from its covariant
+    component and the covariant component in the "other" (x/y) direction.
+
+    For an orthogonal grid, cosa would be 0 and rsin2 would be 1, meaning
+    the contravariant component is equal to the covariant component.
+    However, the gnomonic cubed sphere grid is not orthogonal.
+
+    Args:
+        v1: covariant component of the wind for which we want to get the
+            contravariant component
+        v2: covariant component of the wind for the other direction,
+            i.e. y if v1 is in x, x if v1 is in y
+        cosa: cosine of the angle between the local x-direction and y-direction.
+        rsin2: 1 / sin(alpha), where alpha is the angle between the local
+            x-direction and y-direction
+
+    Returns:
+        v1_contravariant: contravariant component of v1
+    """
+    # From technical docs on FV3 cubed sphere grid:
+    # The gnomonic cubed sphere grid is not orthogonal, meaning
+    # the u and v vectors have some overlapping component. We can decompose
+    # the total wind U in two ways, as a linear combination of the
+    # coordinate vectors ("contravariant"):
+    #    U = u_contravariant * u_dir + v_contravariant * v_dir
+    # or as the projection of the vector onto the coordinate
+    #    u_covariant = U dot u_dir
+    #    v_covariant = U dot v_dir
+    # The names come from the fact that the covariant vectors vary
+    # (under a change in coordinate system) the same way the coordinate values do,
+    # while the contravariant vectors vary in the "opposite" way.
+    #
+    # equations from FV3 technical documentation
+    # u_cov = u_contra + v_contra * cos(alpha)  (eq 3.4)
+    # v_cov = u_contra * cos(alpha) + v_contra  (eq 3.5)
+    #
+    # u_contra = u_cov - v_contra * cos(alpha)  (1, from 3.4)
+    # v_contra = v_cov - u_contra * cos(alpha)  (2, from 3.5)
+    # u_contra = u_cov - (v_cov - u_contra * cos(alpha)) * cos(alpha)  (from 1 & 2)
+    # u_contra = u_cov - v_cov * cos(alpha) + u_contra * cos2(alpha) (follows)
+    # u_contra * (1 - cos2(alpha)) = u_cov - v_cov * cos(alpha)
+    # u_contra = u_cov/(1 - cos2(alpha)) - v_cov * cos(alpha)/(1 - cos2(alpha))
+    # matches if rsin = 1 /(1 + cos2(alpha)), cosa*rsin = cos(alpha)/(1 + cos2(alpha))
+    # rsin = 1 / sin2(alpha)
+
+    # so this means:
+    # rsin2 is 1/(sin(alpha))^2
+    # cosa is cos(alpha)
+
+    return (v1 - v2 * cosa) * rsin2
 
 
 @gtstencil()
@@ -72,7 +112,7 @@ def contravariant_stencil(u: sd, v: sd, cosa: sd, rsin: sd, out: sd):
 @gtstencil()
 def contravariant_components(utmp: sd, vtmp: sd, cosa_s: sd, rsin2: sd, ua: sd, va: sd):
     with computation(PARALLEL), interval(...):
-        ua = contravariant(utmp, vtmp, cosa_s, rsin2)
+        ua = contravariant(utmp, vtmp, cosa_s, rsin2)  # (utmp - vtmp * cosa_s) * rsin2
         va = contravariant(vtmp, utmp, cosa_s, rsin2)
 
 

--- a/fv3core/stencils/d2a2c_vect.py
+++ b/fv3core/stencils/d2a2c_vect.py
@@ -64,7 +64,7 @@ def contravariant(v1, v2, cosa, rsin2):
         v2: covariant component of the wind for the other direction,
             i.e. y if v1 is in x, x if v1 is in y
         cosa: cosine of the angle between the local x-direction and y-direction.
-        rsin2: 1 / sin(alpha), where alpha is the angle between the local
+        rsin2: 1 / (sin(alpha))^2, where alpha is the angle between the local
             x-direction and y-direction
 
     Returns:
@@ -93,10 +93,10 @@ def contravariant(v1, v2, cosa, rsin2):
     # u_contra = u_cov - v_cov * cos(alpha) + u_contra * cos2(alpha) (follows)
     # u_contra * (1 - cos2(alpha)) = u_cov - v_cov * cos(alpha)
     # u_contra = u_cov/(1 - cos2(alpha)) - v_cov * cos(alpha)/(1 - cos2(alpha))
-    # matches if rsin = 1 /(1 + cos2(alpha)), cosa*rsin = cos(alpha)/(1 + cos2(alpha))
-    # rsin = 1 / sin2(alpha)
+    # matches because rsin = 1 /(1 + cos2(alpha)),
+    #                 cosa*rsin = cos(alpha)/(1 + cos2(alpha))
 
-    # so this means:
+    # recall that:
     # rsin2 is 1/(sin(alpha))^2
     # cosa is cos(alpha)
 
@@ -112,7 +112,7 @@ def contravariant_stencil(u: sd, v: sd, cosa: sd, rsin: sd, out: sd):
 @gtstencil()
 def contravariant_components(utmp: sd, vtmp: sd, cosa_s: sd, rsin2: sd, ua: sd, va: sd):
     with computation(PARALLEL), interval(...):
-        ua = contravariant(utmp, vtmp, cosa_s, rsin2)  # (utmp - vtmp * cosa_s) * rsin2
+        ua = contravariant(utmp, vtmp, cosa_s, rsin2)
         va = contravariant(vtmp, utmp, cosa_s, rsin2)
 
 

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -213,12 +213,6 @@ def compute(state, comm):
             if global_config.get_do_halo_exchange():
                 reqs["delp_quantity"].wait()
                 reqs["pt_quantity"].wait()
-            beta_d = 0
-        else:
-            beta_d = spec.namelist.beta
-        last_step = False
-        if it == n_split - 1 and end_step:
-            last_step = True
 
         if it == n_split - 1 and end_step:
             if spec.namelist.use_old_omega:  # apparently True

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -329,7 +329,7 @@ def compute(state, comm, timer=NullTimer()):
     if global_config.get_do_halo_exchange():
         comm.halo_update(state.phis_quantity, n_points=utils.halo)
     compute_preamble(state, comm)
-    # "remapping" loop (because there's one remapping per loop)
+    # "remapping" loop (because there's one remapping per iteration)
     for n_map in range(k_split):
         state.n_map = n_map + 1
         if n_map == k_split - 1:

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -329,6 +329,7 @@ def compute(state, comm, timer=NullTimer()):
     if global_config.get_do_halo_exchange():
         comm.halo_update(state.phis_quantity, n_points=utils.halo)
     compute_preamble(state, comm)
+    # "remapping" loop (because there's one remapping per loop)
     for n_map in range(k_split):
         state.n_map = n_map + 1
         if n_map == k_split - 1:

--- a/fv3core/stencils/remapping.py
+++ b/fv3core/stencils/remapping.py
@@ -43,6 +43,10 @@ def compute(
     do_adiabatic_init,
     nq,
 ):
+    """
+    Remap the deformed Lagrangian surfaces onto the reference, or "Eulerian",
+    coordinate levels.
+    """
     grid = spec.grid
 
     gz = utils.make_storage_from_shape(pt.shape, grid.compute_origin())

--- a/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/stencils/riem_solver_c.py
@@ -18,10 +18,8 @@ def precompute(
     dm: sd,
     q_con: sd,
     pem: sd,
-    peg: sd,
-    dz: sd,
+    dz: sd,  # is actually delta of gz
     gm: sd,
-    pef: sd,
     pm: sd,
     ptop: float,
 ):
@@ -29,11 +27,9 @@ def precompute(
         with interval(0, 1):
             pem = ptop
             peg = ptop
-            pef = ptop
         with interval(1, None):
             pem = pem[0, 0, -1] + dm[0, 0, -1]
             peg = peg[0, 0, -1] + dm[0, 0, -1] * (1.0 - q_con[0, 0, -1])
-            pef = ptop
     with computation(PARALLEL), interval(0, -1):
         dz = gz[0, 0, 1] - gz
     with computation(PARALLEL), interval(...):
@@ -44,7 +40,7 @@ def precompute(
 
 
 @gtstencil()
-def finalize(pe2: sd, pem: sd, hs: sd, dz: sd, pef: sd, gz: sd):
+def finalize(pe2: sd, pem: sd, hs: sd, dz: sd, pef: sd, gz: sd, ptop: float):
     # TODO: We only want to bottom level of hd, so this could be removed once
     # hd0 is a 2d field.
     with computation(FORWARD):
@@ -53,8 +49,11 @@ def finalize(pe2: sd, pem: sd, hs: sd, dz: sd, pef: sd, gz: sd):
         with interval(1, None):
             hs_0 = hs_0[0, 0, -1]
 
-    with computation(PARALLEL), interval(1, None):
-        pef = pe2 + pem
+    with computation(PARALLEL):
+        with interval(0, 1):
+            pef = ptop
+        with interval(1, None):
+            pef = pe2 + pem
     with computation(BACKWARD):
         with interval(-1, None):
             gz = hs_0
@@ -70,9 +69,6 @@ def compute(ms, dt2, akap, cappa, ptop, hs, w3, ptc, q_con, delpc, gz, pef, ws):
     js1 = grid.js - 1
     je1 = grid.je + 1
     km = spec.grid.npz - 1
-    islice = slice(is1, ie1 + 1)
-    kslice = slice(0, km + 1)
-    kslice_shift = slice(1, km + 2)
     shape = w3.shape
     domain = (spec.grid.nic + 2, grid.njc + 2, km + 2)
     riemorigin = (is1, js1, 0)
@@ -81,25 +77,23 @@ def compute(ms, dt2, akap, cappa, ptop, hs, w3, ptc, q_con, delpc, gz, pef, ws):
     w = copy(w3)
 
     pem = utils.make_storage_from_shape(shape, riemorigin)
-    peg = utils.make_storage_from_shape(shape, riemorigin)
     pe = utils.make_storage_from_shape(shape, riemorigin)
     gm = utils.make_storage_from_shape(shape, riemorigin)
     dz = utils.make_storage_from_shape(shape, riemorigin)
     pm = utils.make_storage_from_shape(shape, riemorigin)
+    # it looks like this code sets pef = ptop, and does not otherwise use pef here
     precompute(
         cp3,
         gz,
         dm,
         q_con,
         pem,
-        peg,
         dz,
         gm,
-        pef,
         pm,
         ptop,
         origin=riemorigin,
         domain=domain,
     )
     sim1_solver.solve(is1, ie1, js1, je1, dt2, gm, cp3, pe, dm, pm, pem, w, dz, ptc, ws)
-    finalize(pe, pem, hs, dz, pef, gz, origin=riemorigin, domain=domain)
+    finalize(pe, pem, hs, dz, pef, gz, ptop, origin=riemorigin, domain=domain)


### PR DESCRIPTION
## Purpose

This PR incorporates some information from the new FV3 technical documentation from Lucas. I've also made a few isolated refactors.

## Code changes:

- Added docstrings and comments in several places based on information from the FV3 docs
- in `d2a2c_vect`, `avg_x` and `avg_y` are inlined since they are only called in one place, and the code is more clear than the function name
- in `riem_solver_c`, made `peg` a temporary, and moved manipulation of `pef` to after the `sim1_solver` call to make it clear that `pef` is not used and is only an output of `riem_solver_c`.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).

Note there are several places where I've added comments which should not persist as comments in our final product. The motivation is to add context to inform refactors down the line which can replace the comments.

- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes