### PR TITLE
Combine pe_halo.py stencils by using horizontal regions

### DIFF
--- a/fv3core/stencils/pe_halo.py
+++ b/fv3core/stencils/pe_halo.py
@@ -7,23 +7,23 @@ from fv3core.utils.typing import FloatField
 
 @gtstencil()
 def edge_pe(pe: FloatField, delp: FloatField, ptop: float):
-    from __externals__ import i_end, i_start, j_end, j_start
+    from __externals__ import local_ie, local_is, local_je, local_js
 
     with computation(FORWARD):
         with interval(0, 1):
             with horizontal(
-                region[i_start - 1, j_start : j_end + 1],
-                region[i_end + 1, j_start : j_end + 1],
-                region[i_start - 1 : i_end + 2, j_start - 1],
-                region[i_start - 1 : i_end + 2, j_end + 1],
+                region[local_is - 1, local_js : local_je + 1],
+                region[local_ie + 1, local_js : local_je + 1],
+                region[local_is - 1 : local_ie + 2, local_js - 1],
+                region[local_is - 1 : local_ie + 2, local_je + 1],
             ):
                 pe[0, 0, 0] = ptop
         with interval(1, None):
             with horizontal(
-                region[i_start - 1, j_start : j_end + 1],
-                region[i_end + 1, j_start : j_end + 1],
-                region[i_start - 1 : i_end + 2, j_start - 1],
-                region[i_start - 1 : i_end + 2, j_end + 1],
+                region[local_is - 1, local_js : local_je + 1],
+                region[local_ie + 1, local_js : local_je + 1],
+                region[local_is - 1 : local_ie + 2, local_js - 1],
+                region[local_is - 1 : local_ie + 2, local_je + 1],
             ):
                 pe[0, 0, 0] = pe[0, 0, -1] + delp[0, 0, -1]
 

--- a/fv3core/stencils/pe_halo.py
+++ b/fv3core/stencils/pe_halo.py
@@ -12,18 +12,18 @@ def edge_pe(pe: FloatField, delp: FloatField, ptop: float):
     with computation(FORWARD):
         with interval(0, 1):
             with horizontal(
-                region[i_start - 1 : i_start, j_start : j_end + 1],
-                region[i_end + 1 : i_end + 2, j_start : j_end + 1],
-                region[i_start - 1 : i_end + 1, j_start - 1 : j_start],
-                region[i_start - 1 : i_end + 1, j_end + 1 : j_end + 2],
+                region[i_start - 1, j_start : j_end + 1],
+                region[i_end + 1, j_start : j_end + 1],
+                region[i_start - 1 : i_end + 2, j_start - 1],
+                region[i_start - 1 : i_end + 2, j_end + 1],
             ):
                 pe[0, 0, 0] = ptop
         with interval(1, None):
             with horizontal(
-                region[i_start - 1 : i_start, j_start : j_end + 1],
-                region[i_end + 1 : i_end + 2, j_start : j_end + 1],
-                region[i_start - 1 : i_end + 1, j_start - 1 : j_start],
-                region[i_start - 1 : i_end + 1, j_end + 1 : j_end + 2],
+                region[i_start - 1, j_start : j_end + 1],
+                region[i_end + 1, j_start : j_end + 1],
+                region[i_start - 1 : i_end + 2, j_start - 1],
+                region[i_start - 1 : i_end + 2, j_end + 1],
             ):
                 pe[0, 0, 0] = pe[0, 0, -1] + delp[0, 0, -1]
 

--- a/fv3core/stencils/pe_halo.py
+++ b/fv3core/stencils/pe_halo.py
@@ -1,27 +1,39 @@
-from gt4py.gtscript import FORWARD, computation, interval
+from gt4py.gtscript import FORWARD, computation, horizontal, interval, region
 
 import fv3core._config as spec
-import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-
-
-sd = utils.sd
+from fv3core.utils.typing import FloatField
 
 
 @gtstencil()
-def edge_pe(pe: sd, delp: sd, ptop: float):
+def edge_pe(pe: FloatField, delp: FloatField, ptop: float):
+    from __externals__ import i_end, i_start, j_end, j_start
+
     with computation(FORWARD):
         with interval(0, 1):
-            pe[0, 0, 0] = ptop
+            with horizontal(
+                region[i_start - 1 : i_start, j_start : j_end + 1],
+                region[i_end + 1 : i_end + 2, j_start : j_end + 1],
+                region[i_start - 1 : i_end + 1, j_start - 1 : j_start],
+                region[i_start - 1 : i_end + 1, j_end + 1 : j_end + 2],
+            ):
+                pe[0, 0, 0] = ptop
         with interval(1, None):
-            pe[0, 0, 0] = pe[0, 0, -1] + delp[0, 0, -1]
+            with horizontal(
+                region[i_start - 1 : i_start, j_start : j_end + 1],
+                region[i_end + 1 : i_end + 2, j_start : j_end + 1],
+                region[i_start - 1 : i_end + 2, j_start - 1 : j_start],
+                region[i_start - 1 : i_end + 2, j_end + 1 : j_end + 2],
+            ):
+                pe[0, 0, 0] = pe[0, 0, -1] + delp[0, 0, -1]
 
 
 def compute(pe, delp, ptop):
     grid = spec.grid
-    edge_domain_x = (1, grid.njc, grid.npz + 1)
-    edge_pe(pe, delp, ptop, origin=(grid.is_ - 1, grid.js, 0), domain=edge_domain_x)
-    edge_pe(pe, delp, ptop, origin=(grid.ie + 1, grid.js, 0), domain=edge_domain_x)
-    edge_domain_y = (grid.nic + 2, 1, grid.npz + 1)
-    edge_pe(pe, delp, ptop, origin=(grid.is_ - 1, grid.js - 1, 0), domain=edge_domain_y)
-    edge_pe(pe, delp, ptop, origin=(grid.is_ - 1, grid.je + 1, 0), domain=edge_domain_y)
+    edge_pe(
+        pe,
+        delp,
+        ptop,
+        origin=grid.full_origin(),
+        domain=grid.domain_shape_full(add=(0, 0, 1)),
+    )

--- a/fv3core/stencils/pe_halo.py
+++ b/fv3core/stencils/pe_halo.py
@@ -22,8 +22,8 @@ def edge_pe(pe: FloatField, delp: FloatField, ptop: float):
             with horizontal(
                 region[i_start - 1 : i_start, j_start : j_end + 1],
                 region[i_end + 1 : i_end + 2, j_start : j_end + 1],
-                region[i_start - 1 : i_end + 2, j_start - 1 : j_start],
-                region[i_start - 1 : i_end + 2, j_end + 1 : j_end + 2],
+                region[i_start - 1 : i_end + 1, j_start - 1 : j_start],
+                region[i_start - 1 : i_end + 1, j_end + 1 : j_end + 2],
             ):
                 pe[0, 0, 0] = pe[0, 0, -1] + delp[0, 0, -1]
 


### PR DESCRIPTION
## Purpose

The four stencil calls within the `compute` routine in `pe_halo.py` are combined into one stencil using horizontal regions.

## Code changes:

All code changes are in `/fv3core/stencils/pe_halo.py`.

- Use the `FloatField` type instead of `utils.sd` type for Field variables
- Rewrite `edge_pe` to use horizontal regions that combines the 4 `edge_pe` calls in `compute` into one call
- Define the `origin` as `grid.full_origin()` and `domain` as `grid.domain_shape_full(add(0,0,1))` when calling `edge_pe` 