### PR TITLE
jenkins.sh should only set the GT4PY_VERSION if needed

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -127,7 +127,9 @@ module load gcloud
 
 # get the test data version from the Makefile
 export FORTRAN_VERSION=`grep "FORTRAN_SERIALIZED_DATA_VERSION=" Makefile  | cut -d '=' -f 2`
-export GT4PY_VERSION=`grep "GT4PY_VERSION ?=" docker/Makefile.image_names  | cut -d '=' -f 2`
+if [ -z "${GT4PY_VERSION}"]; then
+    export GT4PY_VERSION=`grep "GT4PY_VERSION ?=" docker/Makefile.image_names  | cut -d '=' -f 2`
+fi
 # Set the SCRATCH directory to the working directory if not set (e.g. for running on gce)
 if [ -z ${SCRATCH} ] ; then
     export SCRATCH=`pwd`

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -127,7 +127,7 @@ module load gcloud
 
 # get the test data version from the Makefile
 export FORTRAN_VERSION=`grep "FORTRAN_SERIALIZED_DATA_VERSION=" Makefile  | cut -d '=' -f 2`
-if [ -z "${GT4PY_VERSION}"]; then
+if [ -z "${GT4PY_VERSION}" ]; then
     export GT4PY_VERSION=`grep "GT4PY_VERSION ?=" docker/Makefile.image_names  | cut -d '=' -f 2`
 fi
 # Set the SCRATCH directory to the working directory if not set (e.g. for running on gce)


### PR DESCRIPTION
## Purpose
jenkins.sh was setting GT4PY_VERSION so that the virtualenv could pick it up (and any other action). But we shoud only set it to what is in the Makefile if it is not set in the environment, which it is when testing gt4py.

