### PR TITLE
jenkins tag should be fixed whether or not it exists already

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -142,12 +142,11 @@ export FV3_STENCIL_REBUILD_FLAG=False
 export TEST_DATA_HOST="${TEST_DATA_DIR}/${experiment}/"
 export EXPERIMENT=${experiment}
 if [ -z ${JENKINS_TAG} ]; then
-    if [ ${#JOB_NAME} -gt 85 ]; then
-	NAME=`echo ${JOB_NAME} | md5sum | cut -f1 -d" "`
-    else
-	NAME=${JOB_NAME}
-    fi
-    export JENKINS_TAG=${NAME//[,=\/]/-}-${BUILD_NUMBER}
+    export JENKINS_TAG=${JOB_NAME//[,=\/]/-}-${BUILD_NUMBER}
+fi
+if [ ${#JENKINS_TAG} -gt 85 ]; then
+	NAME=`echo ${JENKINS_TAG} | md5sum | cut -f1 -d" "`
+	export JENKINS_TAG=${NAME//[,=\/]/-}-${BUILD_NUMBER}
 fi
 echo "JENKINS TAG ${JENKINS_TAG}"
 

--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -175,16 +175,14 @@ export DOCKER_BUILDKIT=1
 
 run_command "${script} ${backend} ${experiment} " Job${action} ${G2G} ${scheduler_script}
 
-
-# load scheduler tools
-. ${envloc}/env/schedulerTools.sh
-run_timing_script="`dirname $0`/env/submit.${host}.${scheduler}"
-
 if [ $? -ne 0 ] ; then
   exitError 1510 ${LINENO} "problem while executing script ${script}"
 fi
 echo "### ACTION ${action} SUCCESSFUL"
 
+# load scheduler tools
+. ${envloc}/env/schedulerTools.sh
+run_timing_script="`dirname $0`/env/submit.${host}.${scheduler}"
 
 # second run, this time with timing
 if grep -q "fv_dynamics" <<< "${script}"; then


### PR DESCRIPTION
## Purpose

We had a workflow where the JENKINS_TAG got assigned to a valid tag if it didn't exist yet, but a new plan sent through bad values from a multiconfiguration process, and this didn't catch it. Now it should. 
Also fix a bug where by run-command failures were not causing the jenkins script to fail when run through docker (vs a slurm job)
## Infrastructure changes:

- .jenkins/jenkins.sh redefines JENKINS_TAG to something valid whether it exists or not
- .jenkins/jenkins.sh checks for slurm job failures directly after running
- Update daint_venv submodule to point back at master now that the GT4PY_VERSION pr on that repo is merged
