### PR TITLE
fixing another case of a bad JOB_NAME

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -142,8 +142,9 @@ export FV3_STENCIL_REBUILD_FLAG=False
 export TEST_DATA_HOST="${TEST_DATA_DIR}/${experiment}/"
 export EXPERIMENT=${experiment}
 if [ -z ${JENKINS_TAG} ]; then
-    export JENKINS_TAG=${JOB_NAME//[,=\/]/-}-${BUILD_NUMBER}
+    export JENKINS_TAG=${JOB_NAME}-${BUILD_NUMBER}
 fi
+export JENKINS_TAG=${JENKINS_TAG//[,=\/]/-}
 if [ ${#JENKINS_TAG} -gt 85 ]; then
 	NAME=`echo ${JENKINS_TAG} | md5sum | cut -f1 -d" "`
 	export JENKINS_TAG=${NAME//[,=\/]/-}-${BUILD_NUMBER}


### PR DESCRIPTION
## Purpose
Another multiconfiguration project JOB_NAME is still sneaking through despite changing all the plans. 
Just get rid of the known bad characters from the jenkins_tag