### PR TITLE
reduce the filecount on daint scratch 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 
 update_submodules:
 	if [ ! -f $(FV3UTIL_DIR)/requirements.txt  ]; then \
-		git submodule update --init --recursive; \
+		git submodule update --init external/fv3gfs-util external/daint_venv; \
 	fi
 
 constraints.txt: requirements.txt requirements_wrapper.txt requirements_lint.txt

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -118,7 +118,7 @@ sed -i s/--output=\<OUTFILE\>/--hint=nomultithread/g compile.daint.slurm
 sed -i s/00:45:00/03:30:00/g compile.daint.slurm
 sed -i s/cscsci/normal/g compile.daint.slurm
 sed -i s/\<G2G\>/export\ CRAY_CUDA_MPS=1/g compile.daint.slurm
-sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py $data_path 1 $backend $githash --disable_halo_exchange#g" compile.daint.slur
+sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py $data_path 1 $backend $githash --disable_halo_exchange#g" compile.daint.slurm
 
 # execute on a gpu node
 sbatch -W -C gpu compile.daint.slurm

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -118,11 +118,19 @@ sed -i s/--output=\<OUTFILE\>/--hint=nomultithread/g compile.daint.slurm
 sed -i s/00:45:00/03:30:00/g compile.daint.slurm
 sed -i s/cscsci/normal/g compile.daint.slurm
 sed -i s/\<G2G\>/export\ CRAY_CUDA_MPS=1/g compile.daint.slurm
-sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py $data_path 1 $backend $githash --disable_halo_exchange#g" compile.daint.slurm
+sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py $data_path 1 $backend $githash --disable_halo_exchange#g" compile.daint.slur
 
 # execute on a gpu node
 sbatch -W -C gpu compile.daint.slurm
 wait
+
+if [ $? -ne 0 ] ; then
+    rm -rf .gt_cache_0000*
+    pip list
+    deactivate
+    rm -rf venv
+    exitError 1003 ${LINENO} "problem while compiling"
+fi
 echo "compilation step finished"
 
 echo "submitting script to do performance run"
@@ -140,6 +148,13 @@ sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/p
 # execute on a gpu node
 sbatch -W -C gpu run.daint.slurm
 wait
+if [ $? -ne 0 ] ; then
+    rm -rf .gt_cache_0000*
+    pip list
+    deactivate
+    rm -rf venv
+    exitError 1004 ${LINENO} "problem while running for performance numbers"
+fi
 if [ -n "$target_dir" ] ; then
     rsync *.json $target_dir
 fi

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -18,6 +18,23 @@ exitError()
     exit $1
 }
 
+function cleanupFailedJob {
+    res=$1
+    jobid=`echo "${res}" | sed  's/^Submitted batch job //g'`
+    test -n "${jobid}" || exitError 7207 ${LINENO} "problem determining job ID of SLURM job"
+    echo "jobid:" ${jobid}
+    status=`scontrol show job ${jobid} | grep JobState`
+    if [[ ! $status == *"COMPLETED"* ]]; then
+	echo ${status}
+	echo `cat slurm*`
+	rm -rf .gt_cache_0000*
+	pip list
+	deactivate
+	rm -rf venv
+	exitError 1003 ${LINENO} "problem in slurm job"
+    fi
+}
+
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$(dirname "$SCRIPTPATH")")")"
@@ -121,16 +138,11 @@ sed -i s/\<G2G\>/export\ CRAY_CUDA_MPS=1/g compile.daint.slurm
 sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python examples/standalone/runfile/dynamics.py $data_path 1 $backend $githash --disable_halo_exchange#g" compile.daint.slurm
 
 # execute on a gpu node
-sbatch -W -C gpu compile.daint.slurm
+res=$(sbatch -W -C gpu compile.daint.slurm 2>&1)
 wait
+cleanupFailedJob "${res}"
 
-if [ $? -ne 0 ] ; then
-    rm -rf .gt_cache_0000*
-    pip list
-    deactivate
-    rm -rf venv
-    exitError 1003 ${LINENO} "problem while compiling"
-fi
+echo "DONE WAITING ${$?}"
 echo "compilation step finished"
 
 echo "submitting script to do performance run"
@@ -146,15 +158,10 @@ sed -i s/\<G2G\>//g run.daint.slurm
 sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python $py_args examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash $run_args#g" run.daint.slurm
 
 # execute on a gpu node
-sbatch -W -C gpu run.daint.slurm
+res=$(sbatch -W -C gpu run.daint.slurm 2>&1)
 wait
-if [ $? -ne 0 ] ; then
-    rm -rf .gt_cache_0000*
-    pip list
-    deactivate
-    rm -rf venv
-    exitError 1004 ${LINENO} "problem while running for performance numbers"
-fi
+cleanupFailedJob "${res}"
+
 if [ -n "$target_dir" ] ; then
     rsync *.json $target_dir
 fi


### PR DESCRIPTION
## Purpose

Remove the files that take up a lot of space and are not that helpful for debugging when run_on_daint fails, and only submodule update the ones we actually use right now


## Infrastructure changes:

- run_on_daint.sh will remove gt caches and the virtualenv when it fails
- Makefile by default only submodule updates the ones we use

