### PR TITLE
add cache_key arg to use instead of inspect for caching storages

### DIFF
--- a/fv3core/stencils/updatedzd.py
+++ b/fv3core/stencils/updatedzd.py
@@ -225,22 +225,26 @@ def compute(
     halo = grid.halo
 
     crx_adv = utils.make_storage_from_shape(
-        crx.shape, grid.compute_origin(add=(0, -halo, 0))
+        crx.shape, grid.compute_origin(add=(0, -halo, 0)), cache_key="updatedzd_crx_adv"
     )
     cry_adv = utils.make_storage_from_shape(
-        cry.shape, grid.compute_origin(add=(-halo, 0, 0))
+        cry.shape, grid.compute_origin(add=(-halo, 0, 0)), cache_key="updatedzd_cry_adv"
     )
     xfx_adv = utils.make_storage_from_shape(
-        xfx.shape, grid.compute_origin(add=(0, -halo, 0))
+        xfx.shape, grid.compute_origin(add=(0, -halo, 0)), cache_key="updatedzd_xfx_adv"
     )
     yfx_adv = utils.make_storage_from_shape(
-        yfx.shape, grid.compute_origin(add=(-halo, 0, 0))
+        yfx.shape, grid.compute_origin(add=(-halo, 0, 0)), cache_key="updatedzd_yfx_adv"
     )
     ra_x = utils.make_storage_from_shape(
-        crx.shape, grid.compute_origin(add=(0, -halo, 0))
+        crx.shape,
+        grid.compute_origin(add=(0, -halo, 0)),
+        cache_key="updatedzd_ra_x",
     )
     ra_y = utils.make_storage_from_shape(
-        cry.shape, grid.compute_origin(add=(-halo, 0, 0))
+        cry.shape,
+        grid.compute_origin(add=(-halo, 0, 0)),
+        cache_key="updatedzd_ra_y",
     )
 
     edge_profile_stencil(
@@ -313,11 +317,21 @@ def column_calls(
 
     grid = spec.grid
     full_origin = (grid.isd, grid.jsd, kstart)
-    wk = utils.make_storage_from_shape(zh.shape, full_origin)
-    fx2 = utils.make_storage_from_shape(zh.shape, full_origin)
-    fy2 = utils.make_storage_from_shape(zh.shape, full_origin)
-    fx = utils.make_storage_from_shape(zh.shape, full_origin)
-    fy = utils.make_storage_from_shape(zh.shape, full_origin)
+    wk = utils.make_storage_from_shape(
+        zh.shape, full_origin, cache_key="updatedzd_column_calls_wk"
+    )
+    fx2 = utils.make_storage_from_shape(
+        zh.shape, full_origin, cache_key="updatedzd_column_calls_fx2"
+    )
+    fy2 = utils.make_storage_from_shape(
+        zh.shape, full_origin, cache_key="updatedzd_column_calls_fy2"
+    )
+    fx = utils.make_storage_from_shape(
+        zh.shape, full_origin, cache_key="updatedzd_column_calls_fx"
+    )
+    fy = utils.make_storage_from_shape(
+        zh.shape, full_origin, cache_key="updatedzd_column_calls_fy"
+    )
     z2 = copy(zh, origin=full_origin, domain=(grid.nid, grid.njd, nk))
 
     fvtp2d.compute_no_sg(

--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -246,7 +246,7 @@ def compute_al(q, dxa, iord, is1, ie3, jfirst, jlast, kstart=0, nk=None):
         nk = grid().npz - kstart
     dimensions = q.shape
     local_origin = (origin[0], origin[1], kstart)
-    al = utils.make_storage_from_shape(dimensions, local_origin)
+    al = utils.make_storage_from_shape(dimensions, local_origin, cache_key="xppm_al")
     domain_y = (1, dimensions[1], nk)
     if iord < 8:
         main_al(
@@ -286,10 +286,10 @@ def compute_blbr_ord8plus(q, iord, jfirst, jlast, is1, ie1, kstart, nk):
     r3 = 1.0 / 3.0
     grid = spec.grid
     local_origin = (origin[0], origin[1], kstart)
-    bl = utils.make_storage_from_shape(q.shape, local_origin)
-    br = utils.make_storage_from_shape(q.shape, local_origin)
-    dm = utils.make_storage_from_shape(q.shape, local_origin)
-    al = utils.make_storage_from_shape(q.shape, local_origin)
+    bl = utils.make_storage_from_shape(q.shape, local_origin, cache_key="xppm_bl")
+    br = utils.make_storage_from_shape(q.shape, local_origin, cache_key="xppm_br")
+    dm = utils.make_storage_from_shape(q.shape, local_origin, cache_key="xppm_dm")
+    al = utils.make_storage_from_shape(q.shape, local_origin, cache_key="xppm_al")
     dj = jlast - jfirst + 1
     dm_iord8plus(
         q, al, dm, origin=(grid.is_ - 2, jfirst, kstart), domain=(grid.nic + 4, dj, nk)

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -348,7 +348,7 @@ def compute_al(q, dyvar, jord, ifirst, ilast, js1, je3, kstart=0, nk=None):
         nk = grid().npz - kstart
     dimensions = q.shape
     local_origin = (origin[0], origin[1], kstart)
-    al = utils.make_storage_from_shape(dimensions, local_origin)
+    al = utils.make_storage_from_shape(dimensions, local_origin, cache_key="yppm_al")
     if jord < 8:
         main_al_ord_under8(
             q,
@@ -411,10 +411,10 @@ def compute_blbr_ord8plus(q, jord, dya, ifirst, ilast, js1, je1, kstart, nk):
     r3 = 1.0 / 3.0
     grid = spec.grid
     local_origin = (origin[0], origin[1], kstart)
-    bl = utils.make_storage_from_shape(q.shape, local_origin)
-    br = utils.make_storage_from_shape(q.shape, local_origin)
-    dm = utils.make_storage_from_shape(q.shape, local_origin)
-    al = utils.make_storage_from_shape(q.shape, local_origin)
+    bl = utils.make_storage_from_shape(q.shape, local_origin, cache_key="yppm_bl")
+    br = utils.make_storage_from_shape(q.shape, local_origin, cache_key="yppm_br")
+    dm = utils.make_storage_from_shape(q.shape, local_origin, cache_key="yppm_dm")
+    al = utils.make_storage_from_shape(q.shape, local_origin, cache_key="yppm_al")
     di = ilast - ifirst + 1
     dm_jord8plus(
         q, al, dm, origin=(ifirst, grid.js - 2, kstart), domain=(di, grid.njc + 4, nk)


### PR DESCRIPTION
Add cache_key arg to `make_storage_from_shape` which can be used instead of inspect for caching storages. Reduces run time by avoiding calls to inspect.

## Purpose

Describe the purpose of this PR and the motivation if relevant to understanding. Include links to related issues, bugs or features.

Remove the sections below which do not apply.

## Code changes:

- Provide a list of relevant code changes and the side effects they have on other code.

## Requirements changes:

- Provide a list of any changes made to requirements, e.g. changes to files requirements*.txt, constraints.txt, setup.py, pyproject.toml, pre-commit-config.yaml and a reason if not included in the Purpose section (e.g. incompatibility, updates, etc)

## Infrastructure changes:

- Provide a list of changes that impact the infrastructure around running the code -- that is, changes to Makefiles, docker files, git submodules, or .jenkins (testing infrastructure changes). If Jenkins plans are also being manually changed, indicate that as well.

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [ ] The names of all the new contributors have been added to CONTRIBUTORS.md
