### PR TITLE
remove k_subset_run

### DIFF
--- a/fv3core/stencils/divergence_damping.py
+++ b/fv3core/stencils/divergence_damping.py
@@ -196,7 +196,7 @@ def compute(
                 )
             )
             if fillc:
-                corners.fill_corners_2d(divg_d, grid, "B", "x")
+                corners.fill_corners_2d(divg_d, grid, "B", "x", kstart=kstart, nk=nk)
             vc_from_divg(
                 divg_d,
                 grid.divg_u,
@@ -205,7 +205,7 @@ def compute(
                 domain=(nint + 1, njnt, nk),
             )
             if fillc:
-                corners.fill_corners_2d(divg_d, grid, "B", "y")
+                corners.fill_corners_2d(divg_d, grid, "B", "y", kstart=kstart, nk=nk)
             uc_from_divg(
                 divg_d,
                 grid.divg_v,
@@ -214,7 +214,7 @@ def compute(
                 domain=(nint, njnt + 1, nk),
             )
             if fillc:
-                corners.fill_corners_dgrid(vc, uc, grid, True)
+                corners.fill_corners_dgrid(vc, uc, grid, True, kstart=kstart, nk=nk)
 
             redo_divg_d(
                 uc, vc, divg_d, origin=(is_, js, kstart), domain=(nint, njnt, nk)

--- a/fv3core/utils/corners.py
+++ b/fv3core/utils/corners.py
@@ -2,6 +2,7 @@ from gt4py import gtscript
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
 import fv3core._config as spec
+import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.utils.typing import FloatField
 
@@ -360,119 +361,167 @@ def copy_corners_y_stencil(q: FloatField):
 """
 
 # TODO these can definitely be consolidated/made simpler
-def fill_sw_corner_2d_bgrid(q, i, j, direction, grid):
+def fill_sw_corner_2d_bgrid(q, i, j, direction, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
     if direction == "x":
-        q[grid.is_ - i, grid.js - j, :] = q[grid.is_ - j, grid.js + i, :]
+        q[grid.is_ - i, grid.js - j, kslice] = q[grid.is_ - j, grid.js + i, kslice]
     if direction == "y":
-        q[grid.is_ - j, grid.js - i, :] = q[grid.is_ + i, grid.js - j, :]
+        q[grid.is_ - j, grid.js - i, kslice] = q[grid.is_ + i, grid.js - j, kslice]
 
 
-def fill_nw_corner_2d_bgrid(q, i, j, direction, grid):
+def fill_nw_corner_2d_bgrid(q, i, j, direction, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
     if direction == "x":
-        q[grid.is_ - i, grid.je + 1 + j, :] = q[grid.is_ - j, grid.je + 1 - i, :]
+        q[grid.is_ - i, grid.je + 1 + j, kslice] = q[
+            grid.is_ - j, grid.je + 1 - i, kslice
+        ]
     if direction == "y":
-        q[grid.is_ - j, grid.je + 1 + i, :] = q[grid.is_ + i, grid.je + 1 + j, :]
+        q[grid.is_ - j, grid.je + 1 + i, kslice] = q[
+            grid.is_ + i, grid.je + 1 + j, kslice
+        ]
 
 
-def fill_se_corner_2d_bgrid(q, i, j, direction, grid):
+def fill_se_corner_2d_bgrid(q, i, j, direction, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
     if direction == "x":
-        q[grid.ie + 1 + i, grid.js - j, :] = q[grid.ie + 1 + j, grid.js + i, :]
+        q[grid.ie + 1 + i, grid.js - j, kslice] = q[
+            grid.ie + 1 + j, grid.js + i, kslice
+        ]
     if direction == "y":
-        q[grid.ie + 1 + j, grid.js - i, :] = q[grid.ie + 1 - i, grid.js - j, :]
+        q[grid.ie + 1 + j, grid.js - i, kslice] = q[
+            grid.ie + 1 - i, grid.js - j, kslice
+        ]
 
 
-def fill_ne_corner_2d_bgrid(q, i, j, direction, grid):
+def fill_ne_corner_2d_bgrid(q, i, j, direction, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
     if direction == "x":
-        q[grid.ie + 1 + i, grid.je + 1 + j, :] = q[grid.ie + 1 + j, grid.je + 1 - i, :]
+        q[grid.ie + 1 + i, grid.je + 1 + j, kslice] = q[
+            grid.ie + 1 + j, grid.je + 1 - i, kslice
+        ]
     if direction == "y":
-        q[grid.ie + 1 + j, grid.je + 1 + i, :] = q[grid.ie + 1 - i, grid.je + 1 + j, :]
+        q[grid.ie + 1 + j, grid.je + 1 + i, kslice] = q[
+            grid.ie + 1 - i, grid.je + 1 + j, kslice
+        ]
 
 
-def fill_sw_corner_2d_agrid(q, i, j, direction, grid):
+def fill_sw_corner_2d_agrid(q, i, j, direction, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
     if direction == "x":
-        q[grid.is_ - i, grid.js - j, :] = q[grid.is_ - j, i, :]
+        q[grid.is_ - i, grid.js - j, kslice] = q[grid.is_ - j, i, kslice]
     if direction == "y":
-        q[grid.is_ - j, grid.js - i, :] = q[i, grid.js - j, :]
+        q[grid.is_ - j, grid.js - i, kslice] = q[i, grid.js - j, kslice]
 
 
-def fill_nw_corner_2d_agrid(q, i, j, direction, grid):
+def fill_nw_corner_2d_agrid(q, i, j, direction, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
     if direction == "x":
-        q[grid.is_ - i, grid.je + j, :] = q[grid.is_ - j, grid.je - i + 1, :]
+        q[grid.is_ - i, grid.je + j, kslice] = q[grid.is_ - j, grid.je - i + 1, kslice]
     if direction == "y":
-        q[grid.is_ - j, grid.je + i, :] = q[i, grid.je + j, :]
+        q[grid.is_ - j, grid.je + i, kslice] = q[i, grid.je + j, kslice]
 
 
-def fill_se_corner_2d_agrid(q, i, j, direction, grid):
+def fill_se_corner_2d_agrid(q, i, j, direction, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
     if direction == "x":
-        q[grid.ie + i, grid.js - j, :] = q[grid.ie + j, i, :]
+        q[grid.ie + i, grid.js - j, kslice] = q[grid.ie + j, i, kslice]
     if direction == "y":
-        q[grid.ie + j, grid.js - i, :] = q[grid.ie - i + 1, grid.js - j, :]
+        q[grid.ie + j, grid.js - i, kslice] = q[grid.ie - i + 1, grid.js - j, kslice]
 
 
-def fill_ne_corner_2d_agrid(q, i, j, direction, grid, mysign=1.0):
+def fill_ne_corner_2d_agrid(q, i, j, direction, grid, mysign=1.0, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
     if direction == "x":
-        q[grid.ie + i, grid.je + j, :] = q[grid.ie + j, grid.je - i + 1, :]
+        q[grid.ie + i, grid.je + j, kslice] = q[grid.ie + j, grid.je - i + 1, kslice]
     if direction == "y":
-        q[grid.ie + j, grid.je + i, :] = q[grid.ie - i + 1, grid.je + j, :]
+        q[grid.ie + j, grid.je + i, kslice] = q[grid.ie - i + 1, grid.je + j, kslice]
 
 
-def fill_corners_2d(q, grid, gridtype, direction="x"):
+def fill_corners_2d(q, grid, gridtype, direction="x", kstart=0, nk=None):
     for i in range(1, 1 + grid.halo):
         for j in range(1, 1 + grid.halo):
             if gridtype == "B":
                 if grid.sw_corner:
-                    fill_sw_corner_2d_bgrid(q, i, j, direction, grid)
+                    fill_sw_corner_2d_bgrid(
+                        q, i, j, direction, grid, kstart=kstart, nk=nk
+                    )
                 if grid.nw_corner:
-                    fill_nw_corner_2d_bgrid(q, i, j, direction, grid)
+                    fill_nw_corner_2d_bgrid(
+                        q, i, j, direction, grid, kstart=kstart, nk=nk
+                    )
                 if grid.se_corner:
-                    fill_se_corner_2d_bgrid(q, i, j, direction, grid)
+                    fill_se_corner_2d_bgrid(
+                        q, i, j, direction, grid, kstart=kstart, nk=nk
+                    )
                 if grid.ne_corner:
-                    fill_ne_corner_2d_bgrid(q, i, j, direction, grid)
+                    fill_ne_corner_2d_bgrid(
+                        q, i, j, direction, grid, kstart=kstart, nk=nk
+                    )
             if gridtype == "A":
                 if grid.sw_corner:
-                    fill_sw_corner_2d_agrid(q, i, j, direction, grid)
+                    fill_sw_corner_2d_agrid(
+                        q, i, j, direction, grid, kstart=kstart, nk=nk
+                    )
                 if grid.nw_corner:
-                    fill_nw_corner_2d_agrid(q, i, j, direction, grid)
+                    fill_nw_corner_2d_agrid(
+                        q, i, j, direction, grid, kstart=kstart, nk=nk
+                    )
                 if grid.se_corner:
-                    fill_se_corner_2d_agrid(q, i, j, direction, grid)
+                    fill_se_corner_2d_agrid(
+                        q, i, j, direction, grid, kstart=kstart, nk=nk
+                    )
                 if grid.ne_corner:
-                    fill_ne_corner_2d_agrid(q, i, j, direction, grid)
+                    fill_ne_corner_2d_agrid(
+                        q, i, j, direction, grid, kstart=kstart, nk=nk
+                    )
 
 
-def fill_sw_corner_vector_dgrid(x, y, i, j, grid, mysign):
-    x[grid.is_ - i, grid.js - j, :] = mysign * y[grid.is_ - j, i + 2, :]
-    y[grid.is_ - i, grid.js - j, :] = mysign * x[j + 2, grid.js - i, :]
+def fill_sw_corner_vector_dgrid(x, y, i, j, grid, mysign, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
+    x[grid.is_ - i, grid.js - j, kslice] = mysign * y[grid.is_ - j, i + 2, kslice]
+    y[grid.is_ - i, grid.js - j, kslice] = mysign * x[j + 2, grid.js - i, kslice]
 
 
-def fill_nw_corner_vector_dgrid(x, y, i, j, grid):
-    x[grid.is_ - i, grid.je + 1 + j, :] = y[grid.is_ - j, grid.je + 1 - i, :]
-    y[grid.is_ - i, grid.je + j, :] = x[j + 2, grid.je + 1 + i, :]
+def fill_nw_corner_vector_dgrid(x, y, i, j, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
+    x[grid.is_ - i, grid.je + 1 + j, kslice] = y[grid.is_ - j, grid.je + 1 - i, kslice]
+    y[grid.is_ - i, grid.je + j, kslice] = x[j + 2, grid.je + 1 + i, kslice]
 
 
-def fill_se_corner_vector_dgrid(x, y, i, j, grid):
-    x[grid.ie + i, grid.js - j, :] = y[grid.ie + 1 + j, i + 2, :]
-    y[grid.ie + 1 + i, grid.js - j, :] = x[grid.ie - j + 1, grid.js - i, :]
+def fill_se_corner_vector_dgrid(x, y, i, j, grid, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
+    x[grid.ie + i, grid.js - j, kslice] = y[grid.ie + 1 + j, i + 2, kslice]
+    y[grid.ie + 1 + i, grid.js - j, kslice] = x[grid.ie - j + 1, grid.js - i, kslice]
 
 
-def fill_ne_corner_vector_dgrid(x, y, i, j, grid, mysign):
-    x[grid.ie + i, grid.je + 1 + j, :] = mysign * y[grid.ie + 1 + j, grid.je - i + 1, :]
-    y[grid.ie + 1 + i, grid.je + j, :] = mysign * x[grid.ie - j + 1, grid.je + 1 + i, :]
+def fill_ne_corner_vector_dgrid(x, y, i, j, grid, mysign, kstart=0, nk=None):
+    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
+    x[grid.ie + i, grid.je + 1 + j, kslice] = (
+        mysign * y[grid.ie + 1 + j, grid.je - i + 1, kslice]
+    )
+    y[grid.ie + 1 + i, grid.je + j, kslice] = (
+        mysign * x[grid.ie - j + 1, grid.je + 1 + i, kslice]
+    )
 
 
-def fill_corners_dgrid(x, y, grid, vector):
+def fill_corners_dgrid(x, y, grid, vector, kstart=0, nk=None):
     mysign = 1.0
     if vector:
         mysign = -1.0
     for i in range(1, 1 + grid.halo):
         for j in range(1, 1 + grid.halo):
             if grid.sw_corner:
-                fill_sw_corner_vector_dgrid(x, y, i, j, grid, mysign)
+                fill_sw_corner_vector_dgrid(
+                    x, y, i, j, grid, mysign, kstart=kstart, nk=nk
+                )
             if grid.nw_corner:
-                fill_nw_corner_vector_dgrid(x, y, i, j, grid)
+                fill_nw_corner_vector_dgrid(x, y, i, j, grid, kstart=kstart, nk=nk)
             if grid.se_corner:
-                fill_se_corner_vector_dgrid(x, y, i, j, grid)
+                fill_se_corner_vector_dgrid(x, y, i, j, grid, kstart=kstart, nk=nk)
             if grid.ne_corner:
-                fill_ne_corner_vector_dgrid(x, y, i, j, grid, mysign)
+                fill_ne_corner_vector_dgrid(
+                    x, y, i, j, grid, mysign, kstart=kstart, nk=nk
+                )
 
 
 def corner_ke(ke, u, v, ut, vt, i, j, dt, offsets, vsign):

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -390,12 +390,6 @@ class Grid:
         else:
             return 0, 0
 
-    def slice_data_k(self, ki):
-        utils.k_slice_inplace(self.data_fields, ki)
-        # update instance vars
-        for k, v in self.data_fields.items():
-            setattr(self, k, self.data_fields[k])
-
 
 def axis_offsets(
     grid: Grid,

--- a/tests/translate/translate_corners.py
+++ b/tests/translate/translate_corners.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-import fv3core.utils.gt4py_utils as utils
 from fv3core.testing import TranslateFortranData2Py
 from fv3core.utils import corners
 
@@ -32,21 +31,19 @@ class TranslateFillCorners(TranslateFortranData2Py):
             direction = "y"
         else:
             raise ValueError("Invalid input")
-        # for nord in inputs['nord_col'][0,0,:]:
-        #    if nord != 0:
-        #        fill_corners_2d(inputs['divg_d'], self.grid, 'B', direction)
-        # return {'divg_d':inputs['divg_d']}
         nord_column = inputs["nord_col"][0, 0, :]
         self.make_storage_data_input_vars(inputs)
-        num_k = self.grid.npz
         for nord in np.unique(nord_column):
             if nord != 0:
-                ki = [i for i in range(num_k) if nord_column[i] == nord]
-                d = utils.k_slice(inputs, ki)
-                self.grid.npz = len(ki)
-                corners.fill_corners_2d(d["divg_d"], self.grid, "B", direction)
-                inputs["divg_d"][:, :, ki] = d["divg_d"]
-        self.grid.npz = num_k
+                ki = [i for i in range(self.grid.npz) if nord_column[i] == nord]
+                corners.fill_corners_2d(
+                    inputs["divg_d"],
+                    self.grid,
+                    "B",
+                    direction,
+                    kstart=ki[0],
+                    nk=len(ki),
+                )
         return self.slice_output(inputs)
 
 
@@ -85,14 +82,15 @@ class TranslateFillCornersVector(TranslateFortranData2Py):
         nord_column = inputs["nord_col"][0, 0, :]
         vector = True
         self.make_storage_data_input_vars(inputs)
-        num_k = self.grid.npz
         for nord in np.unique(nord_column):
             if nord != 0:
-                ki = [i for i in range(num_k) if nord_column[i] == nord]
-                d = utils.k_slice(inputs, ki)
-                self.grid.npz = len(ki)
-                corners.fill_corners_dgrid(d["vc"], d["uc"], self.grid, vector)
-                inputs["vc"][:, :, ki] = d["vc"]
-                inputs["uc"][:, :, ki] = d["uc"]
-        self.grid.npz = num_k
+                ki = [i for i in range(self.grid.npz) if nord_column[i] == nord]
+                corners.fill_corners_dgrid(
+                    inputs["vc"],
+                    inputs["uc"],
+                    self.grid,
+                    vector,
+                    kstart=ki[0],
+                    nk=len(ki),
+                )
         return self.slice_output(inputs)

--- a/tests/translate/translate_heatdiss.py
+++ b/tests/translate/translate_heatdiss.py
@@ -1,4 +1,4 @@
-import fv3core.stencils.heatdiss as heatdiss
+import fv3core.stencils.d_sw as d_sw
 from fv3core.testing import TranslateFortranData2Py
 
 
@@ -20,7 +20,9 @@ class TranslateHeatDiss(TranslateFortranData2Py):
             "dw": grid.compute_dict(),
         }
 
-    def compute(self, inputs):
-        self.make_storage_data_input_vars(inputs)
-        heatdiss.compute(**inputs)
-        return self.slice_output(inputs)
+    def compute_from_storage(self, inputs):
+        inputs["rarea"] = self.grid.rarea
+        inputs["origin"] = self.grid.compute_origin()
+        inputs["domain"] = self.grid.domain_shape_compute()
+        d_sw.heat_diss(**inputs)
+        return inputs


### PR DESCRIPTION
## Purpose
k_split_run has been a problem for awhile, blocked by various pain points in various directions. This is a first step of many to stop computing d_sw by calling stencils a subset loop over k. The other PRs should be bottom up, either hard coded unrolling, using column variables,  or using some gt4py feature to remove the need for an outside stencil k_loop. This PR is top down, removing the generalized loop over all of d_sw, isolating the k loops over the sections of code that use 'column_namelist'. This should make it easier to identify what needs to be refactored, and removes the global state of grid.npz being altered. 
CAUTION: there are several active PRs that touch the same files, and we want to be careful to not toss anyone in a mire of merge conflicts. Be kind and considerate when merging this one in.  
CAUTION 2: The goals of this is to help reduce the major time consumers. If this does not speed things up, or slows things down because there are *more* k loops, reconsider strongly. 

## Code changes:

- Removed k_subset_run and associated helper functions from gt4py_utils
- Changed d_sw to not slice and loop over all the data, but instead have multiple loops over these k ranges, just pointing to the start and end of the arrays
- Changed the fill_corners_2d and fill_corners_vector to use kstart, nk rather than requiring a ksplit
- Moved heat_diss to D_SW, another PR may have already done this
- Update test code for heat_diss and corners that use kstart, nk


## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate

