### PR TITLE
fill_corners python routines are stencils

### DIFF
--- a/fv3core/stencils/divergence_damping.py
+++ b/fv3core/stencils/divergence_damping.py
@@ -199,7 +199,7 @@ def compute(
                 corners.fill_corners_bgrid_x(
                     divg_d,
                     origin=(grid.isd, grid.jsd, kstart),
-                    domain=(grid.nid, grid.njd, nk),
+                    domain=(grid.nid + 1, grid.njd + 1, nk),
                 )
             vc_from_divg(
                 divg_d,
@@ -212,7 +212,7 @@ def compute(
                 corners.fill_corners_bgrid_y(
                     divg_d,
                     origin=(grid.isd, grid.jsd, kstart),
-                    domain=(grid.nid, grid.njd, nk),
+                    domain=(grid.nid + 1, grid.njd + 1, nk),
                 )
             uc_from_divg(
                 divg_d,
@@ -227,7 +227,7 @@ def compute(
                     uc,
                     -1.0,
                     origin=(grid.isd, grid.jsd, kstart),
-                    domain=(grid.nid, grid.njd, nk),
+                    domain=(grid.nid + 1, grid.njd + 1, nk),
                 )
 
             redo_divg_d(

--- a/fv3core/stencils/divergence_damping.py
+++ b/fv3core/stencils/divergence_damping.py
@@ -196,7 +196,11 @@ def compute(
                 )
             )
             if fillc:
-                corners.fill_corners_2d(divg_d, grid, "B", "x", kstart=kstart, nk=nk)
+                corners.fill_corners_bgrid_x(
+                    divg_d,
+                    origin=(grid.isd, grid.jsd, kstart),
+                    domain=(grid.nid, grid.njd, nk),
+                )
             vc_from_divg(
                 divg_d,
                 grid.divg_u,
@@ -205,7 +209,11 @@ def compute(
                 domain=(nint + 1, njnt, nk),
             )
             if fillc:
-                corners.fill_corners_2d(divg_d, grid, "B", "y", kstart=kstart, nk=nk)
+                corners.fill_corners_bgrid_y(
+                    divg_d,
+                    origin=(grid.isd, grid.jsd, kstart),
+                    domain=(grid.nid, grid.njd, nk),
+                )
             uc_from_divg(
                 divg_d,
                 grid.divg_v,
@@ -214,7 +222,13 @@ def compute(
                 domain=(nint, njnt + 1, nk),
             )
             if fillc:
-                corners.fill_corners_dgrid(vc, uc, grid, True, kstart=kstart, nk=nk)
+                corners.fill_corners_dgrid(
+                    vc,
+                    uc,
+                    -1.0,
+                    origin=(grid.isd, grid.jsd, kstart),
+                    domain=(grid.nid, grid.njd, nk),
+                )
 
             redo_divg_d(
                 uc, vc, divg_d, origin=(is_, js, kstart), domain=(nint, njnt, nk)

--- a/fv3core/utils/corners.py
+++ b/fv3core/utils/corners.py
@@ -360,49 +360,131 @@ def copy_corners_y_stencil(q: FloatField):
         q = copy_corners_y(q)
 """
 
-# TODO these can definitely be consolidated/made simpler
-def fill_sw_corner_2d_bgrid(q, i, j, direction, grid, kstart=0, nk=None):
-    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
-    if direction == "x":
-        q[grid.is_ - i, grid.js - j, kslice] = q[grid.is_ - j, grid.js + i, kslice]
-    if direction == "y":
-        q[grid.is_ - j, grid.js - i, kslice] = q[grid.is_ + i, grid.js - j, kslice]
+
+@gtstencil()
+def fill_corners_bgrid_x(q: FloatField):
+    from __externals__ import i_end, i_start, j_end, j_start
+
+    with computation(PARALLEL), interval(...):
+        # sw and se corner
+        with horizontal(
+            region[i_start - 1, j_start - 1], region[i_end + 2, j_start - 1]
+        ):
+            q = q[0, 2, 0]
+        with horizontal(
+            region[i_start - 1, j_start - 2], region[i_end + 3, j_start - 1]
+        ):
+            q = q[-1, 3, 0]
+        with horizontal(
+            region[i_start - 1, j_start - 3], region[i_end + 4, j_start - 1]
+        ):
+            q = q[-2, 4, 0]
+        with horizontal(
+            region[i_start - 2, j_start - 1], region[i_end + 2, j_start - 2]
+        ):
+            q = q[1, 3, 0]
+        with horizontal(
+            region[i_start - 2, j_start - 2], region[i_end + 3, j_start - 2]
+        ):
+            q = q[0, 4, 0]
+        with horizontal(
+            region[i_start - 2, j_start - 3], region[i_end + 4, j_start - 2]
+        ):
+            q = q[-1, 5, 0]
+        with horizontal(
+            region[i_start - 3, j_start - 1], region[i_end + 2, j_start - 3]
+        ):
+            q = q[2, 4, 0]
+        with horizontal(
+            region[i_start - 3, j_start - 2], region[i_end + 3, j_start - 3]
+        ):
+            q = q[1, 5, 0]
+        with horizontal(
+            region[i_start - 3, j_start - 3], region[i_end + 4, j_start - 3]
+        ):
+            q = q[0, 6, 0]
+        # nw and ne corner
+        with horizontal(region[i_start - 1, j_end + 2], region[i_end + 2, j_end + 2]):
+            q = q[0, -2, 0]
+        with horizontal(region[i_start - 1, j_end + 3], region[i_end + 3, j_end + 2]):
+            q = q[-1, -3, 0]
+        with horizontal(region[i_start - 1, j_end + 4], region[i_end + 4, j_end + 2]):
+            q = q[-2, -4, 0]
+        with horizontal(region[i_start - 2, j_end + 2], region[i_end + 2, j_end + 3]):
+            q = q[1, -3, 0]
+        with horizontal(region[i_start - 2, j_end + 3], region[i_end + 3, j_end + 3]):
+            q = q[0, -4, 0]
+        with horizontal(region[i_start - 2, j_end + 4], region[i_end + 4, j_end + 3]):
+            q = q[-1, -5, 0]
+        with horizontal(region[i_start - 3, j_end + 2], region[i_end + 2, j_end + 4]):
+            q = q[2, -4, 0]
+        with horizontal(region[i_start - 3, j_end + 3], region[i_end + 3, j_end + 4]):
+            q = q[1, -5, 0]
+        with horizontal(region[i_start - 3, j_end + 4], region[i_end + 4, j_end + 4]):
+            q = q[0, -6, 0]
 
 
-def fill_nw_corner_2d_bgrid(q, i, j, direction, grid, kstart=0, nk=None):
-    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
-    if direction == "x":
-        q[grid.is_ - i, grid.je + 1 + j, kslice] = q[
-            grid.is_ - j, grid.je + 1 - i, kslice
-        ]
-    if direction == "y":
-        q[grid.is_ - j, grid.je + 1 + i, kslice] = q[
-            grid.is_ + i, grid.je + 1 + j, kslice
-        ]
+@gtstencil()
+def fill_corners_bgrid_y(q: FloatField):
+    from __externals__ import i_end, i_start, j_end, j_start
 
-
-def fill_se_corner_2d_bgrid(q, i, j, direction, grid, kstart=0, nk=None):
-    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
-    if direction == "x":
-        q[grid.ie + 1 + i, grid.js - j, kslice] = q[
-            grid.ie + 1 + j, grid.js + i, kslice
-        ]
-    if direction == "y":
-        q[grid.ie + 1 + j, grid.js - i, kslice] = q[
-            grid.ie + 1 - i, grid.js - j, kslice
-        ]
-
-
-def fill_ne_corner_2d_bgrid(q, i, j, direction, grid, kstart=0, nk=None):
-    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
-    if direction == "x":
-        q[grid.ie + 1 + i, grid.je + 1 + j, kslice] = q[
-            grid.ie + 1 + j, grid.je + 1 - i, kslice
-        ]
-    if direction == "y":
-        q[grid.ie + 1 + j, grid.je + 1 + i, kslice] = q[
-            grid.ie + 1 - i, grid.je + 1 + j, kslice
-        ]
+    with computation(PARALLEL), interval(...):
+        # sw and nw corners
+        with horizontal(
+            region[i_start - 1, j_start - 1], region[i_start - 1, j_end + 2]
+        ):
+            q = q[2, 0, 0]
+        with horizontal(
+            region[i_start - 1, j_start - 2], region[i_start - 2, j_end + 2]
+        ):
+            q = q[3, 1, 0]
+        with horizontal(
+            region[i_start - 1, j_start - 3], region[i_start - 3, j_end + 2]
+        ):
+            q = q[4, 2, 0]
+        with horizontal(
+            region[i_start - 2, j_start - 1], region[i_start - 1, j_end + 3]
+        ):
+            q = q[3, -1, 0]
+        with horizontal(
+            region[i_start - 2, j_start - 2], region[i_start - 2, j_end + 3]
+        ):
+            q = q[4, 0, 0]
+        with horizontal(
+            region[i_start - 2, j_start - 3], region[i_start - 3, j_end + 3]
+        ):
+            q = q[5, 1, 0]
+        with horizontal(
+            region[i_start - 3, j_start - 1], region[i_start - 1, j_end + 4]
+        ):
+            q = q[4, -2, 0]
+        with horizontal(
+            region[i_start - 3, j_start - 2], region[i_start - 2, j_end + 4]
+        ):
+            q = q[5, -1, 0]
+        with horizontal(
+            region[i_start - 3, j_start - 3], region[i_start - 3, j_end + 4]
+        ):
+            q = q[6, 0, 0]
+        # se and ne corners
+        with horizontal(region[i_end + 2, j_start - 1], region[i_end + 2, j_end + 2]):
+            q = q[-2, 0, 0]
+        with horizontal(region[i_end + 2, j_start - 2], region[i_end + 3, j_end + 2]):
+            q = q[-3, 1, 0]
+        with horizontal(region[i_end + 2, j_start - 3], region[i_end + 4, j_end + 2]):
+            q = q[-4, 2, 0]
+        with horizontal(region[i_end + 3, j_start - 1], region[i_end + 2, j_end + 3]):
+            q = q[-3, -1, 0]
+        with horizontal(region[i_end + 3, j_start - 2], region[i_end + 3, j_end + 3]):
+            q = q[-4, 0, 0]
+        with horizontal(region[i_end + 3, j_start - 3], region[i_end + 4, j_end + 3]):
+            q = q[-5, 1, 0]
+        with horizontal(region[i_end + 4, j_start - 1], region[i_end + 2, j_end + 4]):
+            q = q[-4, -2, 0]
+        with horizontal(region[i_end + 4, j_start - 2], region[i_end + 3, j_end + 4]):
+            q = q[-5, -1, 0]
+        with horizontal(region[i_end + 4, j_start - 3], region[i_end + 4, j_end + 4]):
+            q = q[-6, 0, 0]
 
 
 def fill_sw_corner_2d_agrid(q, i, j, direction, grid, kstart=0, nk=None):
@@ -437,91 +519,172 @@ def fill_ne_corner_2d_agrid(q, i, j, direction, grid, mysign=1.0, kstart=0, nk=N
         q[grid.ie + j, grid.je + i, kslice] = q[grid.ie - i + 1, grid.je + j, kslice]
 
 
-def fill_corners_2d(q, grid, gridtype, direction="x", kstart=0, nk=None):
-    for i in range(1, 1 + grid.halo):
-        for j in range(1, 1 + grid.halo):
-            if gridtype == "B":
-                if grid.sw_corner:
-                    fill_sw_corner_2d_bgrid(
-                        q, i, j, direction, grid, kstart=kstart, nk=nk
-                    )
-                if grid.nw_corner:
-                    fill_nw_corner_2d_bgrid(
-                        q, i, j, direction, grid, kstart=kstart, nk=nk
-                    )
-                if grid.se_corner:
-                    fill_se_corner_2d_bgrid(
-                        q, i, j, direction, grid, kstart=kstart, nk=nk
-                    )
-                if grid.ne_corner:
-                    fill_ne_corner_2d_bgrid(
-                        q, i, j, direction, grid, kstart=kstart, nk=nk
-                    )
-            if gridtype == "A":
-                if grid.sw_corner:
-                    fill_sw_corner_2d_agrid(
-                        q, i, j, direction, grid, kstart=kstart, nk=nk
-                    )
-                if grid.nw_corner:
-                    fill_nw_corner_2d_agrid(
-                        q, i, j, direction, grid, kstart=kstart, nk=nk
-                    )
-                if grid.se_corner:
-                    fill_se_corner_2d_agrid(
-                        q, i, j, direction, grid, kstart=kstart, nk=nk
-                    )
-                if grid.ne_corner:
-                    fill_ne_corner_2d_agrid(
-                        q, i, j, direction, grid, kstart=kstart, nk=nk
-                    )
-
-
-def fill_sw_corner_vector_dgrid(x, y, i, j, grid, mysign, kstart=0, nk=None):
-    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
-    x[grid.is_ - i, grid.js - j, kslice] = mysign * y[grid.is_ - j, i + 2, kslice]
-    y[grid.is_ - i, grid.js - j, kslice] = mysign * x[j + 2, grid.js - i, kslice]
-
-
-def fill_nw_corner_vector_dgrid(x, y, i, j, grid, kstart=0, nk=None):
-    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
-    x[grid.is_ - i, grid.je + 1 + j, kslice] = y[grid.is_ - j, grid.je + 1 - i, kslice]
-    y[grid.is_ - i, grid.je + j, kslice] = x[j + 2, grid.je + 1 + i, kslice]
-
-
-def fill_se_corner_vector_dgrid(x, y, i, j, grid, kstart=0, nk=None):
-    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
-    x[grid.ie + i, grid.js - j, kslice] = y[grid.ie + 1 + j, i + 2, kslice]
-    y[grid.ie + 1 + i, grid.js - j, kslice] = x[grid.ie - j + 1, grid.js - i, kslice]
-
-
-def fill_ne_corner_vector_dgrid(x, y, i, j, grid, mysign, kstart=0, nk=None):
-    kslice, nk = utils.kslice_from_inputs(kstart, nk, grid)
-    x[grid.ie + i, grid.je + 1 + j, kslice] = (
-        mysign * y[grid.ie + 1 + j, grid.je - i + 1, kslice]
-    )
-    y[grid.ie + 1 + i, grid.je + j, kslice] = (
-        mysign * x[grid.ie - j + 1, grid.je + 1 + i, kslice]
-    )
-
-
-def fill_corners_dgrid(x, y, grid, vector, kstart=0, nk=None):
-    mysign = 1.0
-    if vector:
-        mysign = -1.0
+def fill_corners_2d_agrid(q, grid, gridtype, direction="x"):
     for i in range(1, 1 + grid.halo):
         for j in range(1, 1 + grid.halo):
             if grid.sw_corner:
-                fill_sw_corner_vector_dgrid(
-                    x, y, i, j, grid, mysign, kstart=kstart, nk=nk
-                )
+                fill_sw_corner_2d_agrid(q, i, j, direction, grid)
             if grid.nw_corner:
-                fill_nw_corner_vector_dgrid(x, y, i, j, grid, kstart=kstart, nk=nk)
+                fill_nw_corner_2d_agrid(q, i, j, direction, grid)
             if grid.se_corner:
-                fill_se_corner_vector_dgrid(x, y, i, j, grid, kstart=kstart, nk=nk)
+                fill_se_corner_2d_agrid(q, i, j, direction, grid)
             if grid.ne_corner:
-                fill_ne_corner_vector_dgrid(
-                    x, y, i, j, grid, mysign, kstart=kstart, nk=nk
-                )
+                fill_ne_corner_2d_agrid(q, i, j, direction, grid)
+
+
+@gtstencil()
+def fill_corners_dgrid(x: FloatField, y: FloatField, mysign: float):
+    from __externals__ import i_end, i_start, j_end, j_start
+
+    with computation(PARALLEL), interval(...):
+        # sw corner
+        with horizontal(region[i_start - 1, j_start - 1]):
+            x = mysign * y[0, 1, 0]
+        with horizontal(region[i_start - 1, j_start - 1]):
+            y = mysign * x[1, 0, 0]
+        with horizontal(region[i_start - 1, j_start - 2]):
+            x = mysign * y[-1, 2, 0]
+        with horizontal(region[i_start - 1, j_start - 2]):
+            y = mysign * x[2, 1, 0]
+        with horizontal(region[i_start - 1, j_start - 3]):
+            x = mysign * y[-2, 3, 0]
+        with horizontal(region[i_start - 1, j_start - 3]):
+            y = mysign * x[3, 2, 0]
+        with horizontal(region[i_start - 2, j_start - 1]):
+            x = mysign * y[1, 2, 0]
+        with horizontal(region[i_start - 2, j_start - 1]):
+            y = mysign * x[2, -1, 0]
+        with horizontal(region[i_start - 2, j_start - 2]):
+            x = mysign * y[0, 3, 0]
+        with horizontal(region[i_start - 2, j_start - 2]):
+            y = mysign * x[3, 0, 0]
+        with horizontal(region[i_start - 2, j_start - 3]):
+            x = mysign * y[-1, 4, 0]
+        with horizontal(region[i_start - 2, j_start - 3]):
+            y = mysign * x[4, 1, 0]
+        with horizontal(region[i_start - 3, j_start - 1]):
+            x = mysign * y[2, 3, 0]
+        with horizontal(region[i_start - 3, j_start - 1]):
+            y = mysign * x[3, -2, 0]
+        with horizontal(region[i_start - 3, j_start - 2]):
+            x = mysign * y[1, 4, 0]
+        with horizontal(region[i_start - 3, j_start - 2]):
+            y = mysign * x[4, -1, 0]
+        with horizontal(region[i_start - 3, j_start - 3]):
+            x = mysign * y[0, 5, 0]
+        with horizontal(region[i_start - 3, j_start - 3]):
+            y = mysign * x[5, 0, 0]
+        # ne corner
+        with horizontal(region[i_end + 1, j_end + 2]):
+            x = mysign * y[1, -2, 0]
+        with horizontal(region[i_end + 2, j_end + 1]):
+            y = mysign * x[-2, 1, 0]
+        with horizontal(region[i_end + 1, j_end + 3]):
+            x = mysign * y[2, -3, 0]
+        with horizontal(region[i_end + 2, j_end + 2]):
+            y = mysign * x[-3, 0, 0]
+        with horizontal(region[i_end + 1, j_end + 4]):
+            x = mysign * y[3, -4, 0]
+        with horizontal(region[i_end + 2, j_end + 3]):
+            y = mysign * x[-4, -1, 0]
+        with horizontal(region[i_end + 2, j_end + 2]):
+            x = mysign * y[0, -3, 0]
+        with horizontal(region[i_end + 3, j_end + 1]):
+            y = mysign * x[-3, 2, 0]
+        with horizontal(region[i_end + 2, j_end + 3]):
+            x = mysign * y[1, -4, 0]
+        with horizontal(region[i_end + 3, j_end + 2]):
+            y = mysign * x[-4, 1, 0]
+        with horizontal(region[i_end + 2, j_end + 4]):
+            x = mysign * y[2, -5, 0]
+        with horizontal(region[i_end + 3, j_end + 3]):
+            y = mysign * x[-5, 0, 0]
+        with horizontal(region[i_end + 3, j_end + 2]):
+            x = mysign * y[-1, -4, 0]
+        with horizontal(region[i_end + 4, j_end + 1]):
+            y = mysign * x[-4, 3, 0]
+        with horizontal(region[i_end + 3, j_end + 3]):
+            x = mysign * y[0, -5, 0]
+        with horizontal(region[i_end + 4, j_end + 2]):
+            y = mysign * x[-5, 2, 0]
+        with horizontal(region[i_end + 3, j_end + 4]):
+            x = mysign * y[1, -6, 0]
+        with horizontal(region[i_end + 4, j_end + 3]):
+            y = mysign * x[-6, 1, 0]
+        # nw corner
+        with horizontal(region[i_start - 1, j_end + 2]):
+            x = y[0, -2, 0]
+        with horizontal(region[i_start - 1, j_end + 1]):
+            y = x[1, 1, 0]
+        with horizontal(region[i_start - 1, j_end + 3]):
+            x = y[-1, -3, 0]
+        with horizontal(region[i_start - 1, j_end + 2]):
+            y = x[2, 0, 0]
+        with horizontal(region[i_start - 1, j_end + 4]):
+            x = y[-2, -4, 0]
+        with horizontal(region[i_start - 1, j_end + 3]):
+            y = x[3, -1, 0]
+        with horizontal(region[i_start - 2, j_end + 2]):
+            x = y[1, -3, 0]
+        with horizontal(region[i_start - 2, j_end + 1]):
+            y = x[2, 2, 0]
+        with horizontal(region[i_start - 2, j_end + 3]):
+            x = y[0, -4, 0]
+        with horizontal(region[i_start - 2, j_end + 2]):
+            y = x[3, 1, 0]
+        with horizontal(region[i_start - 2, j_end + 4]):
+            x = y[-1, -5, 0]
+        with horizontal(region[i_start - 2, j_end + 3]):
+            y = x[4, 0, 0]
+        with horizontal(region[i_start - 3, j_end + 2]):
+            x = y[2, -4, 0]
+        with horizontal(region[i_start - 3, j_end + 1]):
+            y = x[3, 3, 0]
+        with horizontal(region[i_start - 3, j_end + 3]):
+            x = y[1, -5, 0]
+        with horizontal(region[i_start - 3, j_end + 2]):
+            y = x[4, 2, 0]
+        with horizontal(region[i_start - 3, j_end + 4]):
+            x = y[0, -6, 0]
+        with horizontal(region[i_start - 3, j_end + 3]):
+            y = x[5, 1, 0]
+        # se corner
+        with horizontal(region[i_end + 1, j_start - 1]):
+            x = y[1, 1, 0]
+        with horizontal(region[i_end + 2, j_start - 1]):
+            y = x[-2, 0, 0]
+        with horizontal(region[i_end + 1, j_start - 2]):
+            x = y[2, 2, 0]
+        with horizontal(region[i_end + 2, j_start - 2]):
+            y = x[-3, 1, 0]
+        with horizontal(region[i_end + 1, j_start - 3]):
+            x = y[3, 3, 0]
+        with horizontal(region[i_end + 2, j_start - 3]):
+            y = x[-4, 2, 0]
+        with horizontal(region[i_end + 2, j_start - 1]):
+            x = y[0, 2, 0]
+        with horizontal(region[i_end + 3, j_start - 1]):
+            y = x[-3, -1, 0]
+        with horizontal(region[i_end + 2, j_start - 2]):
+            x = y[1, 3, 0]
+        with horizontal(region[i_end + 3, j_start - 2]):
+            y = x[-4, 0, 0]
+        with horizontal(region[i_end + 2, j_start - 3]):
+            x = y[2, 4, 0]
+        with horizontal(region[i_end + 3, j_start - 3]):
+            y = x[-5, 1, 0]
+        with horizontal(region[i_end + 3, j_start - 1]):
+            x = y[-1, 3, 0]
+        with horizontal(region[i_end + 4, j_start - 1]):
+            y = x[-4, -2, 0]
+        with horizontal(region[i_end + 3, j_start - 2]):
+            x = y[0, 4, 0]
+        with horizontal(region[i_end + 4, j_start - 2]):
+            y = x[-5, -1, 0]
+        with horizontal(region[i_end + 3, j_start - 3]):
+            x = y[1, 5, 0]
+        with horizontal(region[i_end + 4, j_start - 3]):
+            y = x[-6, 0, 0]
 
 
 def corner_ke(ke, u, v, ut, vt, i, j, dt, offsets, vsign):


### PR DESCRIPTION
## Purpose

This is already done in open pr #271, which is waiting on regions and potentially some other issues. But we can make an incremental change using what we know worked with copy_corners to convert the bgrid and dgrid fill_corners routines into stencil calls. This gives a ~20% performance boost.
## Code changes:

- corners routines for filling bgrid and dgrid corners are now stencil calls
- divergence damping uses these new routines

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
