### PR TITLE
updates the gt4py directory when the tag does not match

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -32,9 +32,11 @@ dev_wrapper:
 .PHONY: dev fortran_image wrapper_image fv3core_image build build_deps push_deps pull_deps get_gt4py
 
 get_gt4py:
-	if [ ! -f ${GT4PY_DIR}/pyproject.toml ]; then \
-	  git clone https://github.com/VulcanClimateModeling/gt4py.git ${GT4PY_DIR} && \
-	  cd ${GT4PY_DIR} && git checkout ${GT4PY_VERSION};\
+	if [ ! -f ${GT4PY_DIR}/pyproject.toml ]  || \
+	[ "$(shell cd ${GT4PY_DIR} && git describe --tags )" != "${GT4PY_VERSION}"  ]; then \
+                rm -rf ${GT4PY_DIR} && \
+	  	git clone https://github.com/VulcanClimateModeling/gt4py.git ${GT4PY_DIR} && \
+	  	cd ${GT4PY_DIR} && git checkout ${GT4PY_VERSION};\
 	fi
 
 fortran_image:


### PR DESCRIPTION
## Purpose

 The gt4py directory gets cloned to the local directory, and the GT4PY_VERSION defined in Makefile.image_names is checked out. For development, when this tag changes, we want it to also trigger updating the gt4py directory.  The main problem with this is that sometimes there are multiple gt4py tags on the same commit, in which case the version will always not match and every time the code is built it will be slow as it reclones the directory and rebuilds the image using that directory... 

## Infrastructure changes:

- add a check to the get_gt4py endpoint in docker/Makefile

