### PR TITLE
Moving the final assignment of remapped quantities into a stencil

### DIFF
--- a/fv3core/stencils/map_single.py
+++ b/fv3core/stencils/map_single.py
@@ -30,6 +30,12 @@ def set_eulerian_pressures(pe: FloatField, ptop: FloatFieldIJ, pbot: FloatFieldI
 
 
 @gtstencil()
+def set_remapped_quantity(q: FloatField, set_values: FloatFieldIJ):
+    with computation(FORWARD), interval(0, 1):
+        q = set_values[0, 0]
+
+
+@gtstencil()
 def lagrangian_contributions(
     pe1: FloatField,
     ptop: FloatFieldIJ,
@@ -249,7 +255,13 @@ def lagrangian_contributions_stencil(
             origin=origin,
             domain=domain,
         )
-        q1[i1 : i2 + 1, jslice, k_eul] = q2_adds[i1 : i2 + 1, jslice]
+
+        set_remapped_quantity(
+            q1,
+            q2_adds,
+            origin=(origin[0], origin[1], k_eul),
+            domain=(domain[0], domain[1], 1),
+        )
 
 
 def lagrangian_contributions_transliterated(


### PR DESCRIPTION
## Purpose

This PR moves the assignments of remapped values from Python code to a stencil to improve performance by getting rid of `setitem` and stripping Python code from between stencils.

## Code changes:

- Added a stencil `set_remapped_quantity` to map_single.py that assigns the values after remapping.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
