### PR TITLE
Ignore caches if GT4Py Version that generated the cache does not match

### DIFF
--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -8,7 +8,10 @@ export TEST_ARGS="-v -s -rsx --backend=${BACKEND} --which_modules=FVDynamics"
 make get_test_data
 
 if [ ! -d $(pwd)/.gt_cache_000000 ]; then
-    cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
-    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
+    version=`cat /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/version.txt`
+    if [ "$version" = "$GT4PY_VERSION" ]; then
+        cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
+        find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
+    fi    
 fi
 make tests_venv_mpi

--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -9,7 +9,7 @@ make get_test_data
 
 if [ ! -d $(pwd)/.gt_cache_000000 ]; then
     version=`cat /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/version.txt`
-    if [ "$version" = "$GT4PY_VERSION" ]; then
+    if [ "$version" == "$GT4PY_VERSION" ]; then
         cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
         find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
     fi    

--- a/.jenkins/actions/run_standalone.sh
+++ b/.jenkins/actions/run_standalone.sh
@@ -98,6 +98,8 @@ fi
 # store cache artifacts (and remove caches afterwards)
 if [ "${SAVE_CACHE}" == "true" ] ; then
     echo "Copying GT4Py cache directories to ${CACHE_DIR}"
+    GT4PY_VERSION=`grep "GT4PY_VERSION=" docker/Makefile.image_names | cut -d '=' -f 2`
+    echo "$GT4PY_VERSION" > ${CACHE_DIR}/version.txt
     mkdir -p ${CACHE_DIR}
     rm -rf ${CACHE_DIR}/.gt_cache*
     cp -rp .gt_cache* ${CACHE_DIR}/


### PR DESCRIPTION
## Purpose

If only the gt4py version changes, our current jenkins infrastructure copies in all the previously generated files and then runs with `rebuild=False`. This has the effect that changes to gt4py are never picked up. This PR changes it such that the gt4py version is written to the cache and the cache is only copied in if the versions match.


## Infrastructure changes:

- All the jenkins plans started from `gt4py-develop` are rebuilding everything
- If the `GT4PY_VERSION` changes, fv3core tests will rebuild everything


