### PR TITLE
Revert "Lower dimensional grid and input variables (#269)"

### DIFF
--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -7,8 +7,8 @@ export TEST_ARGS="-v -s -rsx --backend=${BACKEND} --which_modules=FVDynamics"
 # sync the test data
 make get_test_data
 
-#if [ ! -d $(pwd)/.gt_cache_000000 ]; then
-#    cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
-#    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
-#fi
+if [ ! -d $(pwd)/.gt_cache_000000 ]; then
+    cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
+    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
+fi
 make tests_venv_mpi

--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -7,8 +7,8 @@ export TEST_ARGS="-v -s -rsx --backend=${BACKEND} --which_modules=FVDynamics"
 # sync the test data
 make get_test_data
 
-if [ ! -d $(pwd)/.gt_cache_000000 ]; then
-    cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
-    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
-fi
+#if [ ! -d $(pwd)/.gt_cache_000000 ]; then
+#    cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$BACKEND/.gt_cache_0000* .
+#    find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
+#fi
 make tests_venv_mpi

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -4,7 +4,7 @@ import hashlib
 import os
 import pickle
 import types
-from typing import Any, BinaryIO, Callable, Dict, Optional, Tuple
+from typing import Any, BinaryIO, Callable, Dict, Optional
 
 import gt4py
 import gt4py.storage as gt_storage
@@ -203,27 +203,6 @@ class FV3StencilObject:
                 return True
         return False
 
-    def _get_field_origins(
-        self, origin: Tuple[int], *args, **kwargs
-    ) -> Dict[str, Tuple[int]]:
-        origin_dict = {}
-        field_names = list(self.stencil_object.field_info.keys())
-        field_axes = []
-        for i in range(len(field_names)):
-            field_name = field_names[i]
-            # TODO: assert self.stencil_object.field_info[field_name] is not None
-            if self.stencil_object.field_info[field_name]:
-                field_axes = self.stencil_object.field_info[field_name].axes
-            field_shape = args[i].shape if i < len(args) else kwargs[field_name].shape
-            if field_axes == ["K"]:
-                field_origin = [min(field_shape[0] - 1, origin[2])]
-            else:
-                field_origin = [
-                    min(field_shape[j] - 1, origin[j]) for j in range(len(field_shape))
-                ]
-            origin_dict[field_name] = tuple(field_origin)
-        return origin_dict
-
     def __call__(self, *args, origin: Index3D, domain: Index3D, **kwargs) -> None:
         """Call the stencil, compiling the stencil if necessary.
 
@@ -290,7 +269,6 @@ class FV3StencilObject:
         kwargs["exec_info"] = kwargs.get("exec_info", exec_info)
         kwargs["validate_args"] = kwargs.get("validate_args", utils.validate_args)
         name = f"{self.func.__module__}.{self.func.__name__}"
-
         _maybe_save_report(
             f"{name}-before",
             self.times_called,
@@ -298,10 +276,7 @@ class FV3StencilObject:
             args,
             kwargs,
         )
-
-        origin_dict = self._get_field_origins(origin, *args, **kwargs)
-        self.stencil_object(*args, **kwargs, origin=origin_dict, domain=domain)
-
+        self.stencil_object(*args, **kwargs, origin=origin, domain=domain)
         _maybe_save_report(
             f"{name}-after",
             self.times_called,

--- a/fv3core/stencils/a2b_ord4.py
+++ b/fv3core/stencils/a2b_ord4.py
@@ -1,11 +1,11 @@
 import gt4py.gtscript as gtscript
+import numpy as np
 from gt4py.gtscript import PARALLEL, computation, interval
 
 import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy_stencil
-from fv3core.utils.typing import FloatField, FloatFieldI, FloatFieldIJ
 
 
 # comact 4-pt cubic interpolation
@@ -19,6 +19,7 @@ b2 = -1.0 / 12.0
 # 4-pt Lagrange interpolation
 a1 = 9.0 / 16.0
 a2 = -1.0 / 16.0
+sd = utils.sd
 
 
 def grid():
@@ -26,13 +27,13 @@ def grid():
 
 
 @gtstencil()
-def ppm_volume_mean_x(qin: FloatField, qx: FloatField):
+def ppm_volume_mean_x(qin: sd, qx: sd):
     with computation(PARALLEL), interval(...):
         qx[0, 0, 0] = b2 * (qin[-2, 0, 0] + qin[1, 0, 0]) + b1 * (qin[-1, 0, 0] + qin)
 
 
 @gtstencil()
-def ppm_volume_mean_y(qin: FloatField, qy: FloatField):
+def ppm_volume_mean_y(qin: sd, qy: sd):
     with computation(PARALLEL), interval(...):
         qy[0, 0, 0] = b2 * (qin[0, -2, 0] + qin[0, 1, 0]) + b1 * (qin[0, -1, 0] + qin)
 
@@ -43,7 +44,7 @@ def lagrange_y_func(qx):
 
 
 @gtstencil()
-def lagrange_interpolation_y(qx: FloatField, qout: FloatField):
+def lagrange_interpolation_y(qx: sd, qout: sd):
     with computation(PARALLEL), interval(...):
         qout = lagrange_y_func(qx)
 
@@ -54,83 +55,79 @@ def lagrange_x_func(qy):
 
 
 @gtstencil()
-def lagrange_interpolation_x(qy: FloatField, qout: FloatField):
+def lagrange_interpolation_x(qy: sd, qout: sd):
     with computation(PARALLEL), interval(...):
         qout = lagrange_x_func(qy)
 
 
 @gtstencil()
-def cubic_interpolation_south(qx: FloatField, qout: FloatField, qxx: FloatField):
+def cubic_interpolation_south(qx: sd, qout: sd, qxx: sd):
     with computation(PARALLEL), interval(...):
         qxx0 = qxx
         qxx = c1 * (qx[0, -1, 0] + qx) + c2 * (qout[0, -1, 0] + qxx0[0, 1, 0])
 
 
 @gtstencil()
-def cubic_interpolation_north(qx: FloatField, qout: FloatField, qxx: FloatField):
+def cubic_interpolation_north(qx: sd, qout: sd, qxx: sd):
     with computation(PARALLEL), interval(...):
         qxx0 = qxx
         qxx = c1 * (qx[0, -1, 0] + qx) + c2 * (qout[0, 1, 0] + qxx0[0, -1, 0])
 
 
 @gtstencil()
-def cubic_interpolation_west(qy: FloatField, qout: FloatField, qyy: FloatField):
+def cubic_interpolation_west(qy: sd, qout: sd, qyy: sd):
     with computation(PARALLEL), interval(...):
         qyy0 = qyy
         qyy = c1 * (qy[-1, 0, 0] + qy) + c2 * (qout[-1, 0, 0] + qyy0[1, 0, 0])
 
 
 @gtstencil()
-def cubic_interpolation_east(qy: FloatField, qout: FloatField, qyy: FloatField):
+def cubic_interpolation_east(qy: sd, qout: sd, qyy: sd):
     with computation(PARALLEL), interval(...):
         qyy0 = qyy
         qyy = c1 * (qy[-1, 0, 0] + qy) + c2 * (qout[1, 0, 0] + qyy0[-1, 0, 0])
 
 
 @gtstencil()
-def qout_avg(qxx: FloatField, qyy: FloatField, qout: FloatField):
+def qout_avg(qxx: sd, qyy: sd, qout: sd):
     with computation(PARALLEL), interval(...):
         qout[0, 0, 0] = 0.5 * (qxx + qyy)
 
 
 @gtstencil()
-def vort_adjust(qxx: FloatField, qyy: FloatField, qout: FloatField):
+def vort_adjust(qxx: sd, qyy: sd, qout: sd):
     with computation(PARALLEL), interval(...):
         qout[0, 0, 0] = 0.5 * (qxx + qyy)
 
 
 # @gtstencil()
-# def x_edge_q2_west(qin: FloatField, dxa: FloatField, q2: FloatField):
+# def x_edge_q2_west(qin: sd, dxa: sd, q2: sd):
 #    with computation(PARALLEL), interval(...):
 #        q2 = (qin[-1, 0, 0] * dxa + qin * dxa[-1, 0, 0]) / (dxa[-1, 0, 0] + dxa)
 
 # @gtstencil()
-# def x_edge_qout_west_q2(edge_w: FloatField, q2: FloatField, qout: FloatField):
+# def x_edge_qout_west_q2(edge_w: sd, q2: sd, qout: sd):
 #    with computation(PARALLEL), interval(...):
 #        qout = edge_w * q2[0, -1, 0] + (1.0 - edge_w) * q2
 @gtstencil()
-def qout_x_edge(
-    qin: FloatField, dxa: FloatFieldIJ, edge_w: FloatFieldIJ, qout: FloatField
-):
+def qout_x_edge(qin: sd, dxa: sd, edge_w: sd, qout: sd):
     with computation(PARALLEL), interval(...):
-        q2 = (qin[-1, 0, 0] * dxa + qin * dxa[-1, 0]) / (dxa[-1, 0] + dxa)
+        q2 = (qin[-1, 0, 0] * dxa + qin * dxa[-1, 0, 0]) / (dxa[-1, 0, 0] + dxa)
         qout[0, 0, 0] = edge_w * q2[0, -1, 0] + (1.0 - edge_w) * q2
 
 
 @gtstencil()
-def qout_y_edge(
-    qin: FloatField, dya: FloatFieldIJ, edge_s: FloatFieldI, qout: FloatField
-):
+def qout_y_edge(qin: sd, dya: sd, edge_s: sd, qout: sd):
     with computation(PARALLEL), interval(...):
-        q1 = (qin[0, -1, 0] * dya + qin * dya[0, -1]) / (dya[0, -1] + dya)
+        q1 = (qin[0, -1, 0] * dya + qin * dya[0, -1, 0]) / (dya[0, -1, 0] + dya)
         qout[0, 0, 0] = edge_s * q1[-1, 0, 0] + (1.0 - edge_s) * q1
 
 
 @gtstencil()
-def qx_edge_west(qin: FloatField, dxa: FloatFieldIJ, qx: FloatField):
+def qx_edge_west(qin: sd, dxa: sd, qx: sd):
     with computation(PARALLEL), interval(...):
-        g_in = dxa[1, 0] / dxa
-        g_ou = dxa[-2, 0] / dxa[-1, 0]
+        g_in = dxa[1, 0, 0] / dxa
+        g_ou = dxa[-2, 0, 0] / dxa[-1, 0, 0]
         qx[0, 0, 0] = 0.5 * (
             ((2.0 + g_in) * qin - qin[1, 0, 0]) / (1.0 + g_in)
             + ((2.0 + g_ou) * qin[-1, 0, 0] - qin[-2, 0, 0]) / (1.0 + g_ou)
@@ -142,9 +139,9 @@ def qx_edge_west(qin: FloatField, dxa: FloatFieldIJ, qx: FloatField):
 
 
 @gtstencil()
-def qx_edge_west2(qin: FloatField, dxa: FloatFieldIJ, qx: FloatField):
+def qx_edge_west2(qin: sd, dxa: sd, qx: sd):
     with computation(PARALLEL), interval(...):
-        g_in = dxa / dxa[-1, 0]
+        g_in = dxa / dxa[-1, 0, 0]
         qx0 = qx
         qx = (
             3.0 * (g_in * qin[-1, 0, 0] + qin) - (g_in * qx0[-1, 0, 0] + qx0[1, 0, 0])
@@ -152,10 +149,10 @@ def qx_edge_west2(qin: FloatField, dxa: FloatFieldIJ, qx: FloatField):
 
 
 @gtstencil()
-def qx_edge_east(qin: FloatField, dxa: FloatFieldIJ, qx: FloatField):
+def qx_edge_east(qin: sd, dxa: sd, qx: sd):
     with computation(PARALLEL), interval(...):
-        g_in = dxa[-2, 0] / dxa[-1, 0]
-        g_ou = dxa[1, 0] / dxa
+        g_in = dxa[-2, 0, 0] / dxa[-1, 0, 0]
+        g_ou = dxa[1, 0, 0] / dxa
         qx[0, 0, 0] = 0.5 * (
             ((2.0 + g_in) * qin[-1, 0, 0] - qin[-2, 0, 0]) / (1.0 + g_in)
             + ((2.0 + g_ou) * qin - qin[1, 0, 0]) / (1.0 + g_ou)
@@ -163,9 +160,9 @@ def qx_edge_east(qin: FloatField, dxa: FloatFieldIJ, qx: FloatField):
 
 
 @gtstencil()
-def qx_edge_east2(qin: FloatField, dxa: FloatFieldIJ, qx: FloatField):
+def qx_edge_east2(qin: sd, dxa: sd, qx: sd):
     with computation(PARALLEL), interval(...):
-        g_in = dxa[-1, 0] / dxa
+        g_in = dxa[-1, 0, 0] / dxa
         qx0 = qx
         qx = (
             3.0 * (qin[-1, 0, 0] + g_in * qin) - (g_in * qx0[1, 0, 0] + qx0[-1, 0, 0])
@@ -173,10 +170,10 @@ def qx_edge_east2(qin: FloatField, dxa: FloatFieldIJ, qx: FloatField):
 
 
 @gtstencil()
-def qy_edge_south(qin: FloatField, dya: FloatFieldIJ, qy: FloatField):
+def qy_edge_south(qin: sd, dya: sd, qy: sd):
     with computation(PARALLEL), interval(...):
-        g_in = dya[0, 1] / dya
-        g_ou = dya[0, -2] / dya[0, -1]
+        g_in = dya[0, 1, 0] / dya
+        g_ou = dya[0, -2, 0] / dya[0, -1, 0]
         qy[0, 0, 0] = 0.5 * (
             ((2.0 + g_in) * qin - qin[0, 1, 0]) / (1.0 + g_in)
             + ((2.0 + g_ou) * qin[0, -1, 0] - qin[0, -2, 0]) / (1.0 + g_ou)
@@ -184,9 +181,9 @@ def qy_edge_south(qin: FloatField, dya: FloatFieldIJ, qy: FloatField):
 
 
 @gtstencil()
-def qy_edge_south2(qin: FloatField, dya: FloatFieldIJ, qy: FloatField):
+def qy_edge_south2(qin: sd, dya: sd, qy: sd):
     with computation(PARALLEL), interval(...):
-        g_in = dya / dya[0, -1]
+        g_in = dya / dya[0, -1, 0]
         qy0 = qy
         qy = (
             3.0 * (g_in * qin[0, -1, 0] + qin) - (g_in * qy0[0, -1, 0] + qy0[0, 1, 0])
@@ -194,10 +191,10 @@ def qy_edge_south2(qin: FloatField, dya: FloatFieldIJ, qy: FloatField):
 
 
 @gtstencil()
-def qy_edge_north(qin: FloatField, dya: FloatFieldIJ, qy: FloatField):
+def qy_edge_north(qin: sd, dya: sd, qy: sd):
     with computation(PARALLEL), interval(...):
-        g_in = dya[0, -2] / dya[0, -1]
-        g_ou = dya[0, 1] / dya
+        g_in = dya[0, -2, 0] / dya[0, -1, 0]
+        g_ou = dya[0, 1, 0] / dya
         qy[0, 0, 0] = 0.5 * (
             ((2.0 + g_in) * qin[0, -1, 0] - qin[0, -2, 0]) / (1.0 + g_in)
             + ((2.0 + g_ou) * qin - qin[0, 1, 0]) / (1.0 + g_ou)
@@ -205,9 +202,9 @@ def qy_edge_north(qin: FloatField, dya: FloatFieldIJ, qy: FloatField):
 
 
 @gtstencil()
-def qy_edge_north2(qin: FloatField, dya: FloatFieldIJ, qy: FloatField):
+def qy_edge_north2(qin: sd, dya: sd, qy: sd):
     with computation(PARALLEL), interval(...):
-        g_in = dya[0, -1] / dya
+        g_in = dya[0, -1, 0] / dya
         qy0 = qy
         qy = (
             3.0 * (qin[0, -1, 0] + g_in * qin) - (g_in * qy0[0, 1, 0] + qy0[0, -1, 0])
@@ -267,8 +264,8 @@ def extrapolate_corner_qout(qin, qout, i, j, kstart, nk, corner):
     if not getattr(grid(), corner + "_corner"):
         return
     kslice = slice(kstart, kstart + nk)
-    bgrid = utils.stack((grid().bgrid1[:, :], grid().bgrid2[:, :]), axis=2)
-    agrid = utils.stack((grid().agrid1[:, :], grid().agrid2[:, :]), axis=2)
+    bgrid = np.stack((grid().bgrid1[:, :, 0], grid().bgrid2[:, :, 0]), axis=2)
+    agrid = np.stack((grid().agrid1[:, :, 0], grid().agrid2[:, :, 0]), axis=2)
     p0 = bgrid[i, j, :]
     # TODO: Please simplify
     i1a, i1b, j1a, j1b = ec1_offsets(corner)

--- a/fv3core/stencils/basic_operations.py
+++ b/fv3core/stencils/basic_operations.py
@@ -1,13 +1,15 @@
 import gt4py.gtscript as gtscript
-from gt4py.gtscript import FORWARD, PARALLEL, computation, interval
+from gt4py.gtscript import PARALLEL, computation, interval
 
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
 
 
 @gtstencil()
-def copy_stencil(q_in: FloatField, q_out: FloatField):
+def copy_stencil(q_in: sd, q_out: sd):
     """Copy q_in to q_out.
 
     Args:
@@ -15,18 +17,6 @@ def copy_stencil(q_in: FloatField, q_out: FloatField):
         q_out: output field
     """
     with computation(PARALLEL), interval(...):
-        q_out = q_in
-
-
-@gtstencil()
-def copy_stencil_2d(q_in: FloatFieldIJ, q_out: FloatFieldIJ):
-    """Copy q_in to q_out.
-
-    Args:
-        q_in: input field
-        q_out: output field
-    """
-    with computation(FORWARD), interval(0, 1):
         q_out = q_in
 
 
@@ -46,11 +36,6 @@ def copy(q_in, origin=(0, 0, 0), domain=None, use_cache=True):
     if domain is None:
         domain = tuple(extent - orig for extent, orig in zip(q_in.shape, origin))
 
-    copy_fxn = copy_stencil
-    if len(q_in.shape) < 3:
-        domain = (domain[0], domain[1], 1)
-        origin = origin[0:2]
-        copy_fxn = copy_stencil_2d
     if use_cache:
         q_out = utils.make_storage_from_shape(
             q_in.shape, q_in.default_origin, init=True
@@ -59,66 +44,63 @@ def copy(q_in, origin=(0, 0, 0), domain=None, use_cache=True):
         q_out = utils.make_storage_from_shape_uncached(
             q_in.shape, q_in.default_origin, init=True
         )
-    copy_fxn(q_in, q_out, origin=origin, domain=domain)
-
+    copy_stencil(q_in, q_out, origin=origin, domain=domain)
     return q_out
 
 
 @gtstencil()
-def adjustmentfactor_stencil(adjustment: FloatFieldIJ, q_out: FloatField):
+def adjustmentfactor_stencil(adjustment: sd, q_out: sd):
     with computation(PARALLEL), interval(...):
         q_out[0, 0, 0] = q_out * adjustment
 
 
 @gtstencil()
-def adjust_divide_stencil(adjustment: FloatField, q_out: FloatField):
+def adjust_divide_stencil(adjustment: sd, q_out: sd):
     with computation(PARALLEL), interval(...):
         q_out[0, 0, 0] = q_out / adjustment
 
 
 @gtstencil()
-def multiply_stencil(in1: FloatField, in2: FloatField, out: FloatField):
+def multiply_stencil(in1: sd, in2: sd, out: sd):
     with computation(PARALLEL), interval(...):
         out[0, 0, 0] = in1 * in2
 
 
 @gtstencil()
-def divide_stencil(in1: FloatField, in2: FloatField, out: FloatField):
+def divide_stencil(in1: sd, in2: sd, out: sd):
     with computation(PARALLEL), interval(...):
         out[0, 0, 0] = in1 / in2
 
 
 @gtstencil()
-def addition_stencil(in1: FloatField, in2: FloatFieldIJ, out: FloatField):
+def addition_stencil(in1: sd, in2: sd, out: sd):
     with computation(PARALLEL), interval(...):
         out[0, 0, 0] = in1 + in2
 
 
 @gtstencil()
-def add_term_stencil(in1: FloatField, out: FloatField):
+def add_term_stencil(in1: sd, out: sd):
     with computation(PARALLEL), interval(...):
         out[0, 0, 0] = out + in1
 
 
 @gtstencil()
-def add_term_two_vars(
-    in1: FloatField, out1: FloatField, in2: FloatField, out2: FloatField
-):
+def add_term_two_vars(in1: sd, out1: sd, in2: sd, out2: sd):
     with computation(PARALLEL), interval(...):
         out1[0, 0, 0] = out1 + in1
         out2[0, 0, 0] = out2 + in2
 
 
 @gtstencil()
-def subtract_term_stencil(in1: FloatField, out: FloatField):
+def subtract_term_stencil(in1: sd, out: sd):
     with computation(PARALLEL), interval(...):
         out[0, 0, 0] = out - in1
 
 
 @gtstencil()
 def multiply_constant(
-    in1: FloatField,
-    out: FloatField,
+    in1: sd,
+    out: sd,
     in2: float,
 ):
     with computation(PARALLEL), interval(...):
@@ -126,13 +108,13 @@ def multiply_constant(
 
 
 @gtstencil()
-def multiply_constant_inout(inout: FloatField, in_float: float):
+def multiply_constant_inout(inout: sd, in_float: float):
     with computation(PARALLEL), interval(...):
         inout[0, 0, 0] = in_float * inout
 
 
 @gtstencil()
-def floor_cap(var: FloatField, floor_value: float):
+def floor_cap(var: sd, floor_value: float):
     with computation(PARALLEL), interval(0, None):
         var[0, 0, 0] = var if var > floor_value else floor_value
 

--- a/fv3core/stencils/c2l_ord.py
+++ b/fv3core/stencils/c2l_ord.py
@@ -4,7 +4,7 @@ import fv3core._config as spec
 import fv3core.utils.global_config as global_config
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+from fv3core.utils.typing import FloatField
 from fv3gfs.util import CubedSphereCommunicator
 from fv3gfs.util.quantity import Quantity
 
@@ -20,12 +20,12 @@ C2 = -0.125
 def c2l_ord2(
     u: FloatField,
     v: FloatField,
-    dx: FloatFieldIJ,
-    dy: FloatFieldIJ,
-    a11: FloatFieldIJ,
-    a12: FloatFieldIJ,
-    a21: FloatFieldIJ,
-    a22: FloatFieldIJ,
+    dx: FloatField,
+    dy: FloatField,
+    a11: FloatField,
+    a12: FloatField,
+    a21: FloatField,
+    a22: FloatField,
     ua: FloatField,
     va: FloatField,
 ):
@@ -33,8 +33,8 @@ def c2l_ord2(
         wu = u * dx
         wv = v * dy
         # Co-variant vorticity-conserving interpolation
-        u1 = 2.0 * (wu + wu[0, 1, 0]) / (dx + dx[0, 1])
-        v1 = 2.0 * (wv + wv[1, 0, 0]) / (dy + dy[1, 0])
+        u1 = 2.0 * (wu + wu[0, 1, 0]) / (dx + dx[0, 1, 0])
+        v1 = 2.0 * (wv + wv[1, 0, 0]) / (dy + dy[1, 0, 0])
         # Cubed (cell center co-variant winds) to lat-lon
         ua = a11 * u1 + a12 * v1
         va = a21 * u1 + a22 * v1
@@ -44,12 +44,12 @@ def c2l_ord2(
 def ord4_transform(
     u: FloatField,
     v: FloatField,
-    a11: FloatFieldIJ,
-    a12: FloatFieldIJ,
-    a21: FloatFieldIJ,
-    a22: FloatFieldIJ,
-    dx: FloatFieldIJ,
-    dy: FloatFieldIJ,
+    a11: FloatField,
+    a12: FloatField,
+    a21: FloatField,
+    a22: FloatField,
+    dx: FloatField,
+    dy: FloatField,
     ua: FloatField,
     va: FloatField,
 ):
@@ -61,13 +61,13 @@ def ord4_transform(
 
         # south/north edge
         with horizontal(region[:, j_start], region[:, j_end]):
-            vtmp = 2.0 * ((v * dy) + (v[1, 0, 0] * dy[1, 0])) / (dy + dy[1, 0])
-            utmp = 2.0 * (u * dx + u[0, 1, 0] * dx[0, 1]) / (dx + dx[0, 1])
+            vtmp = 2.0 * ((v * dy) + (v[1, 0, 0] * dy[1, 0, 0])) / (dy + dy[1, 0, 0])
+            utmp = 2.0 * (u * dx + u[0, 1, 0] * dx[0, 1, 0]) / (dx + dx[0, 1, 0])
 
         # west/east edge
         with horizontal(region[i_start, :], region[i_end, :]):
-            utmp = 2.0 * ((u * dx) + (u[0, 1, 0] * dx[0, 1])) / (dx + dx[0, 1])
-            vtmp = 2.0 * ((v * dy) + (v[1, 0, 0] * dy[1, 0])) / (dy + dy[1, 0])
+            utmp = 2.0 * ((u * dx) + (u[0, 1, 0] * dx[0, 1, 0])) / (dx + dx[0, 1, 0])
+            vtmp = 2.0 * ((v * dy) + (v[1, 0, 0] * dy[1, 0, 0])) / (dy + dy[1, 0, 0])
 
         # Transform local a-grid winds into latitude-longitude coordinates
         ua = a11 * utmp + a12 * vtmp

--- a/fv3core/stencils/d2a2c_vect.py
+++ b/fv3core/stencils/d2a2c_vect.py
@@ -5,9 +5,9 @@ import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.a2b_ord4 import a1, a2, lagrange_x_func, lagrange_y_func
-from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
+sd = utils.sd
 c1 = -2.0 / 14.0
 c2 = 11.0 / 14.0
 c3 = 5.0 / 14.0
@@ -25,7 +25,7 @@ def lagrange_y_func_p1(qx):
 
 
 @gtstencil()
-def lagrange_interpolation_y_p1(qx: FloatField, qout: FloatField):
+def lagrange_interpolation_y_p1(qx: sd, qout: sd):
     with computation(PARALLEL), interval(...):
         qout = lagrange_y_func_p1(qx)
 
@@ -36,13 +36,13 @@ def lagrange_x_func_p1(qy):
 
 
 @gtstencil()
-def lagrange_interpolation_x_p1(qy: FloatField, qout: FloatField):
+def lagrange_interpolation_x_p1(qy: sd, qout: sd):
     with computation(PARALLEL), interval(...):
         qout = lagrange_x_func_p1(qy)
 
 
 @gtstencil()
-def avg_box(u: FloatField, v: FloatField, utmp: FloatField, vtmp: FloatField):
+def avg_box(u: sd, v: sd, utmp: sd, vtmp: sd):
     with computation(PARALLEL), interval(...):
         utmp = 0.5 * (u + u[0, 1, 0])
         vtmp = 0.5 * (v + v[1, 0, 0])
@@ -104,54 +104,27 @@ def contravariant(v1, v2, cosa, rsin2):
 
 
 @gtstencil()
-def contravariant_stencil(
-    u: FloatField,
-    v: FloatField,
-    cosa: FloatFieldIJ,
-    rsin: FloatFieldIJ,
-    out: FloatField,
-):
+def contravariant_stencil(u: sd, v: sd, cosa: sd, rsin: sd, out: sd):
     with computation(PARALLEL), interval(...):
         out = contravariant(u, v, cosa, rsin)
 
 
 @gtstencil()
-def contravariant_components(
-    utmp: FloatField,
-    vtmp: FloatField,
-    cosa_s: FloatFieldIJ,
-    rsin2: FloatFieldIJ,
-    ua: FloatField,
-    va: FloatField,
-):
+def contravariant_components(utmp: sd, vtmp: sd, cosa_s: sd, rsin2: sd, ua: sd, va: sd):
     with computation(PARALLEL), interval(...):
         ua = contravariant(utmp, vtmp, cosa_s, rsin2)
         va = contravariant(vtmp, utmp, cosa_s, rsin2)
 
 
 @gtstencil()
-def ut_main(
-    utmp: FloatField,
-    uc: FloatField,
-    v: FloatField,
-    cosa_u: FloatFieldIJ,
-    rsin_u: FloatFieldIJ,
-    ut: FloatField,
-):
+def ut_main(utmp: sd, uc: sd, v: sd, cosa_u: sd, rsin_u: sd, ut: sd):
     with computation(PARALLEL), interval(...):
         uc = lagrange_x_func(utmp)
         ut = contravariant(uc, v, cosa_u, rsin_u)
 
 
 @gtstencil()
-def vt_main(
-    vtmp: FloatField,
-    vc: FloatField,
-    u: FloatField,
-    cosa_v: FloatFieldIJ,
-    rsin_v: FloatFieldIJ,
-    vt: FloatField,
-):
+def vt_main(vtmp: sd, vc: sd, u: sd, cosa_v: sd, rsin_v: sd, vt: sd):
     with computation(PARALLEL), interval(...):
         vc = lagrange_y_func(vtmp)
         vt = contravariant(vc, u, cosa_v, rsin_v)
@@ -178,33 +151,25 @@ def vol_conserv_cubic_interp_func_y_rev(v):
 
 
 @gtstencil()
-def vol_conserv_cubic_interp_x(utmp: FloatField, uc: FloatField):
+def vol_conserv_cubic_interp_x(utmp: sd, uc: sd):
     with computation(PARALLEL), interval(...):
         uc = vol_conserv_cubic_interp_func_x(utmp)
 
 
 @gtstencil()
-def vol_conserv_cubic_interp_x_rev(utmp: FloatField, uc: FloatField):
+def vol_conserv_cubic_interp_x_rev(utmp: sd, uc: sd):
     with computation(PARALLEL), interval(...):
         uc = vol_conserv_cubic_interp_func_x_rev(utmp)
 
 
 @gtstencil()
-def vol_conserv_cubic_interp_y(vtmp: FloatField, vc: FloatField):
+def vol_conserv_cubic_interp_y(vtmp: sd, vc: sd):
     with computation(PARALLEL), interval(...):
         vc = vol_conserv_cubic_interp_func_y(vtmp)
 
 
 @gtstencil()
-def vt_edge(
-    vtmp: FloatField,
-    vc: FloatField,
-    u: FloatField,
-    cosa_v: FloatFieldIJ,
-    rsin_v: FloatFieldIJ,
-    vt: FloatField,
-    rev: int,
-):
+def vt_edge(vtmp: sd, vc: sd, u: sd, cosa_v: sd, rsin_v: sd, vt: sd, rev: int):
     with computation(PARALLEL), interval(...):
         vc = (
             vol_conserv_cubic_interp_func_y(vtmp)
@@ -215,41 +180,35 @@ def vt_edge(
 
 
 @gtstencil()
-def uc_x_edge1(
-    ut: FloatField, sin_sg3: FloatFieldIJ, sin_sg1: FloatFieldIJ, uc: FloatField
-):
+def uc_x_edge1(ut: sd, sin_sg3: sd, sin_sg1: sd, uc: sd):
     with computation(PARALLEL), interval(...):
-        uc = ut * sin_sg3[-1, 0] if ut > 0 else ut * sin_sg1
+        uc = ut * sin_sg3[-1, 0, 0] if ut > 0 else ut * sin_sg1
 
 
 @gtstencil()
-def vc_y_edge1(
-    vt: FloatField, sin_sg4: FloatFieldIJ, sin_sg2: FloatFieldIJ, vc: FloatField
-):
+def vc_y_edge1(vt: sd, sin_sg4: sd, sin_sg2: sd, vc: sd):
     with computation(PARALLEL), interval(...):
-        vc = vt * sin_sg4[0, -1] if vt > 0 else vt * sin_sg2
+        vc = vt * sin_sg4[0, -1, 0] if vt > 0 else vt * sin_sg2
 
 
 # TODO: Make this a stencil?
 def edge_interpolate4_x(ua, dxa):
-    t1 = dxa[0, :] + dxa[1, :]
-    t2 = dxa[2, :] + dxa[3, :]
-    n1 = (t1 + dxa[1, :]) * ua[1, :] - dxa[1, :] * ua[0, :]
-    n2 = (t1 + dxa[2, :]) * ua[2, :] - dxa[2, :] * ua[3, :]
+    t1 = dxa[0, :, :] + dxa[1, :, :]
+    t2 = dxa[2, :, :] + dxa[3, :, :]
+    n1 = (t1 + dxa[1, :, :]) * ua[1, :, :] - dxa[1, :, :] * ua[0, :, :]
+    n2 = (t1 + dxa[2, :, :]) * ua[2, :, :] - dxa[2, :, :] * ua[3, :, :]
     return 0.5 * (n1 / t1 + n2 / t2)
 
 
 def edge_interpolate4_y(va, dxa):
-    t1 = dxa[:, 0] + dxa[:, 1]
-    t2 = dxa[:, 2] + dxa[:, 3]
-    n1 = (t1 + dxa[:, 1]) * va[:, 1] - dxa[:, 1] * va[:, 0]
-    n2 = (t1 + dxa[:, 2]) * va[:, 2] - dxa[:, 2] * va[:, 3]
+    t1 = dxa[:, 0, :] + dxa[:, 1, :]
+    t2 = dxa[:, 2, :] + dxa[:, 3, :]
+    n1 = (t1 + dxa[:, 1, :]) * va[:, 1, :] - dxa[:, 1, :] * va[:, 0, :]
+    n2 = (t1 + dxa[:, 2, :]) * va[:, 2, :] - dxa[:, 2, :] * va[:, 3, :]
     return 0.5 * (n1 / t1 + n2 / t2)
 
 
 def compute(dord4, uc, vc, u, v, ua, va, utc, vtc):
-    if spec.namelist.grid_type >= 3:
-        raise Exception("unimplemented grid_type >= 3")
     grid = spec.grid
     big_number = 1e30  # 1e8 if 32 bit
     nx = grid.ie + 1  # grid.npx + 2
@@ -257,7 +216,7 @@ def compute(dord4, uc, vc, u, v, ua, va, utc, vtc):
     i1 = grid.is_ - 1
     j1 = grid.js - 1
     id_ = 1 if dord4 else 0
-    npt = 4 if not grid.nested else 0
+    npt = 4 if spec.namelist.grid_type < 3 and not grid.nested else 0
     if npt > grid.nic - 1 or npt > grid.njc - 1:
         npt = 0
     utmp = utils.make_storage_from_shape(ua.shape, grid.full_origin())
@@ -343,23 +302,27 @@ def compute(dord4, uc, vc, u, v, ua, va, utc, vtc):
     if grid.sw_corner:
         for i in range(-2, 1):
             utmp[i + 2, grid.js - 1, :] = -vtmp[grid.is_ - 1, grid.js - i, :]
-        ua[i1 - 1, j1, :] = -va[i1, j1 + 2, :]
-        ua[i1, j1, :] = -va[i1, j1 + 1, :]
+        if spec.namelist.grid_type < 3:
+            ua[i1 - 1, j1, :] = -va[i1, j1 + 2, :]
+            ua[i1, j1, :] = -va[i1, j1 + 1, :]
     if grid.se_corner:
         for i in range(0, 3):
             utmp[nx + i, grid.js - 1, :] = vtmp[nx, i + grid.js, :]
-        ua[nx, j1, :] = va[nx, j1 + 1, :]
-        ua[nx + 1, j1, :] = va[nx, j1 + 2, :]
+        if spec.namelist.grid_type < 3:
+            ua[nx, j1, :] = va[nx, j1 + 1, :]
+            ua[nx + 1, j1, :] = va[nx, j1 + 2, :]
     if grid.ne_corner:
         for i in range(0, 3):
             utmp[nx + i, ny, :] = -vtmp[nx, grid.je - i, :]
-        ua[nx, ny, :] = -va[nx, ny - 1, :]
-        ua[nx + 1, ny, :] = -va[nx, ny - 2, :]
+        if spec.namelist.grid_type < 3:
+            ua[nx, ny, :] = -va[nx, ny - 1, :]
+            ua[nx + 1, ny, :] = -va[nx, ny - 2, :]
     if grid.nw_corner:
         for i in range(-2, 1):
             utmp[i + 2, ny, :] = vtmp[grid.is_ - 1, grid.je + i, :]
-        ua[i1 - 1, ny, :] = va[i1, ny - 2, :]
-        ua[i1, ny, :] = va[i1, ny - 1, :]
+        if spec.namelist.grid_type < 3:
+            ua[i1 - 1, ny, :] = va[i1, ny - 2, :]
+            ua[i1, ny, :] = va[i1, ny - 1, :]
 
     ifirst = grid.is_ + 2 if grid.west_edge else grid.is_ - 1
     ilast = grid.ie - 1 if grid.east_edge else grid.ie + 2
@@ -375,83 +338,84 @@ def compute(dord4, uc, vc, u, v, ua, va, utc, vtc):
         domain=(idiff, grid.njc + 2, grid.npz),
     )
 
-    domain_edge_x = (1, grid.njc + 2, grid.npz)
-    jslice = slice(grid.js - 1, grid.je + 2)
-    if grid.west_edge and not grid.nested:
-        vol_conserv_cubic_interp_x(utmp, uc, origin=(i1, j1, 0), domain=domain_edge_x)
-        islice = slice(grid.is_ - 2, grid.is_ + 2)
-        for k in range(grid.npz):
-            utc[grid.is_, jslice, k] = edge_interpolate4_x(
-                ua[islice, jslice, k], grid.dxa[islice, jslice]
+    if spec.namelist.grid_type < 3:
+        domain_edge_x = (1, grid.njc + 2, grid.npz)
+        jslice = slice(grid.js - 1, grid.je + 2)
+        if grid.west_edge and not grid.nested:
+            vol_conserv_cubic_interp_x(
+                utmp, uc, origin=(i1, j1, 0), domain=domain_edge_x
             )
-        uc_x_edge1(
-            utc,
-            grid.sin_sg3,
-            grid.sin_sg1,
-            uc,
-            origin=(i1 + 1, j1, 0),
-            domain=domain_edge_x,
-        )
-        vol_conserv_cubic_interp_x_rev(
-            utmp, uc, origin=(i1 + 2, j1, 0), domain=domain_edge_x
-        )
-        contravariant_stencil(
-            uc,
-            v,
-            grid.cosa_u,
-            grid.rsin_u,
-            utc,
-            origin=(i1, j1, 0),
-            domain=domain_edge_x,
-        )
-        contravariant_stencil(
-            uc,
-            v,
-            grid.cosa_u,
-            grid.rsin_u,
-            utc,
-            origin=(i1 + 2, j1, 0),
-            domain=domain_edge_x,
-        )
+            islice = slice(grid.is_ - 2, grid.is_ + 2)
+            utc[grid.is_, jslice, :] = edge_interpolate4_x(
+                ua[islice, jslice, :], grid.dxa[islice, jslice, :]
+            )
+            uc_x_edge1(
+                utc,
+                grid.sin_sg3,
+                grid.sin_sg1,
+                uc,
+                origin=(i1 + 1, j1, 0),
+                domain=domain_edge_x,
+            )
+            vol_conserv_cubic_interp_x_rev(
+                utmp, uc, origin=(i1 + 2, j1, 0), domain=domain_edge_x
+            )
+            contravariant_stencil(
+                uc,
+                v,
+                grid.cosa_u,
+                grid.rsin_u,
+                utc,
+                origin=(i1, j1, 0),
+                domain=domain_edge_x,
+            )
+            contravariant_stencil(
+                uc,
+                v,
+                grid.cosa_u,
+                grid.rsin_u,
+                utc,
+                origin=(i1 + 2, j1, 0),
+                domain=domain_edge_x,
+            )
 
-    if grid.east_edge and not grid.nested:
-        vol_conserv_cubic_interp_x(
-            utmp, uc, origin=(nx - 1, j1, 0), domain=domain_edge_x
-        )
-        islice = slice(nx - 2, nx + 2)
-        for k in range(grid.npz):
-            utc[nx, jslice, k] = edge_interpolate4_x(
-                ua[islice, jslice, k], grid.dxa[islice, jslice]
+        if grid.east_edge and not grid.nested:
+            vol_conserv_cubic_interp_x(
+                utmp, uc, origin=(nx - 1, j1, 0), domain=domain_edge_x
             )
-        uc_x_edge1(
-            utc,
-            grid.sin_sg3,
-            grid.sin_sg1,
-            uc,
-            origin=(nx, j1, 0),
-            domain=domain_edge_x,
-        )
-        vol_conserv_cubic_interp_x_rev(
-            utmp, uc, origin=(nx + 1, j1, 0), domain=domain_edge_x
-        )
-        contravariant_stencil(
-            uc,
-            v,
-            grid.cosa_u,
-            grid.rsin_u,
-            utc,
-            origin=(grid.ie, j1, 0),
-            domain=domain_edge_x,
-        )
-        contravariant_stencil(
-            uc,
-            v,
-            grid.cosa_u,
-            grid.rsin_u,
-            utc,
-            origin=(nx + 1, j1, 0),
-            domain=domain_edge_x,
-        )
+            islice = slice(nx - 2, nx + 2)
+            utc[nx, jslice, :] = edge_interpolate4_x(
+                ua[islice, jslice, :], grid.dxa[islice, jslice, :]
+            )
+            uc_x_edge1(
+                utc,
+                grid.sin_sg3,
+                grid.sin_sg1,
+                uc,
+                origin=(nx, j1, 0),
+                domain=domain_edge_x,
+            )
+            vol_conserv_cubic_interp_x_rev(
+                utmp, uc, origin=(nx + 1, j1, 0), domain=domain_edge_x
+            )
+            contravariant_stencil(
+                uc,
+                v,
+                grid.cosa_u,
+                grid.rsin_u,
+                utc,
+                origin=(grid.ie, j1, 0),
+                domain=domain_edge_x,
+            )
+            contravariant_stencil(
+                uc,
+                v,
+                grid.cosa_u,
+                grid.rsin_u,
+                utc,
+                origin=(nx + 1, j1, 0),
+                domain=domain_edge_x,
+            )
     # Ydir:
     if grid.sw_corner:
         for j in range(-2, 1):
@@ -474,91 +438,92 @@ def compute(dord4, uc, vc, u, v, ua, va, utc, vtc):
         va[nx, ny, :] = -ua[nx - 1, ny, :]
         va[nx, ny + 1, :] = -ua[nx - 2, ny, :]
 
-    domain_edge_y = (grid.nic + 2, 1, grid.npz)
-    islice = slice(grid.is_ - 1, grid.ie + 2)
-    if grid.south_edge:
-        vt_edge(
-            vtmp,
-            vc,
-            u,
-            grid.cosa_v,
-            grid.rsin_v,
-            vtc,
-            0,
-            origin=(i1, j1, 0),
-            domain=domain_edge_y,
-        )
-        jslice = slice(grid.js - 2, grid.js + 2)
-        for k in range(grid.npz):
-            vtc[islice, grid.js, k] = edge_interpolate4_y(
-                va[islice, jslice, k], grid.dya[islice, jslice]
+    if spec.namelist.grid_type < 3:
+        domain_edge_y = (grid.nic + 2, 1, grid.npz)
+        islice = slice(grid.is_ - 1, grid.ie + 2)
+        if grid.south_edge:
+            vt_edge(
+                vtmp,
+                vc,
+                u,
+                grid.cosa_v,
+                grid.rsin_v,
+                vtc,
+                0,
+                origin=(i1, j1, 0),
+                domain=domain_edge_y,
             )
-        vc_y_edge1(
-            vtc,
-            grid.sin_sg4,
-            grid.sin_sg2,
-            vc,
-            origin=(i1, grid.js, 0),
-            domain=domain_edge_y,
-        )
-        vt_edge(
-            vtmp,
-            vc,
-            u,
-            grid.cosa_v,
-            grid.rsin_v,
-            vtc,
-            1,
-            origin=(i1, grid.js + 1, 0),
-            domain=domain_edge_y,
-        )
-    if grid.north_edge:
-        vt_edge(
-            vtmp,
-            vc,
-            u,
-            grid.cosa_v,
-            grid.rsin_v,
-            vtc,
-            0,
-            origin=(i1, ny - 1, 0),
-            domain=domain_edge_y,
-        )
-        jslice = slice(ny - 2, ny + 2)
-        for k in range(grid.npz):
-            vtc[islice, ny, k] = edge_interpolate4_y(
-                va[islice, jslice, k], grid.dya[islice, jslice]
+            jslice = slice(grid.js - 2, grid.js + 2)
+            vtc[islice, grid.js, :] = edge_interpolate4_y(
+                va[islice, jslice, :], grid.dya[islice, jslice, :]
             )
-        vc_y_edge1(
-            vtc,
-            grid.sin_sg4,
-            grid.sin_sg2,
-            vc,
-            origin=(grid.is_ - 1, ny, 0),
-            domain=domain_edge_y,
-        )
-        vt_edge(
-            vtmp,
-            vc,
-            u,
-            grid.cosa_v,
-            grid.rsin_v,
-            vtc,
-            1,
-            origin=(i1, ny + 1, 0),
-            domain=domain_edge_y,
-        )
-    jfirst = grid.js + 2 if grid.south_edge else grid.js - 1
-    jlast = grid.je - 1 if grid.north_edge else grid.je + 2
-    jdiff = jlast - jfirst + 1
+            vc_y_edge1(
+                vtc,
+                grid.sin_sg4,
+                grid.sin_sg2,
+                vc,
+                origin=(i1, grid.js, 0),
+                domain=domain_edge_y,
+            )
+            vt_edge(
+                vtmp,
+                vc,
+                u,
+                grid.cosa_v,
+                grid.rsin_v,
+                vtc,
+                1,
+                origin=(i1, grid.js + 1, 0),
+                domain=domain_edge_y,
+            )
+        if grid.north_edge:
+            vt_edge(
+                vtmp,
+                vc,
+                u,
+                grid.cosa_v,
+                grid.rsin_v,
+                vtc,
+                0,
+                origin=(i1, ny - 1, 0),
+                domain=domain_edge_y,
+            )
+            jslice = slice(ny - 2, ny + 2)
+            vtc[islice, ny, :] = edge_interpolate4_y(
+                va[islice, jslice, :], grid.dya[islice, jslice, :]
+            )
+            vc_y_edge1(
+                vtc,
+                grid.sin_sg4,
+                grid.sin_sg2,
+                vc,
+                origin=(grid.is_ - 1, ny, 0),
+                domain=domain_edge_y,
+            )
+            vt_edge(
+                vtmp,
+                vc,
+                u,
+                grid.cosa_v,
+                grid.rsin_v,
+                vtc,
+                1,
+                origin=(i1, ny + 1, 0),
+                domain=domain_edge_y,
+            )
+        jfirst = grid.js + 2 if grid.south_edge else grid.js - 1
+        jlast = grid.je - 1 if grid.north_edge else grid.je + 2
+        jdiff = jlast - jfirst + 1
 
-    vt_main(
-        vtmp,
-        vc,
-        u,
-        grid.cosa_v,
-        grid.rsin_v,
-        vtc,
-        origin=(i1, jfirst, 0),
-        domain=(grid.nic + 2, jdiff, grid.npz),
-    )
+        vt_main(
+            vtmp,
+            vc,
+            u,
+            grid.cosa_v,
+            grid.rsin_v,
+            vtc,
+            origin=(i1, jfirst, 0),
+            domain=(grid.nic + 2, jdiff, grid.npz),
+        )
+    else:
+        raise Exception("unimplemented grid_type >= 3")

--- a/fv3core/stencils/del2cubed.py
+++ b/fv3core/stencils/del2cubed.py
@@ -4,47 +4,48 @@ import fv3core._config as spec
 import fv3core.utils.corners as corners
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
+origin = utils.origin
 
 
 #
 # Flux value stencils
 # ---------------------
 @gtstencil()
-def compute_zonal_flux(flux: FloatField, a_in: FloatField, del_term: FloatFieldIJ):
+def compute_zonal_flux(flux: sd, A_in: sd, del_term: sd):
     with computation(PARALLEL), interval(...):
-        flux = del_term * (a_in[-1, 0, 0] - a_in)
+        flux = del_term * (A_in[-1, 0, 0] - A_in)
 
 
 @gtstencil()
-def compute_meridional_flux(flux: FloatField, a_in: FloatField, del_term: FloatFieldIJ):
+def compute_meridional_flux(flux: sd, A_in: sd, del_term: sd):
     with computation(PARALLEL), interval(...):
-        flux = del_term * (a_in[0, -1, 0] - a_in)
+        flux = del_term * (A_in[0, -1, 0] - A_in)
 
 
 #
 # Q update stencil
 # ------------------
 @gtstencil()
-def update_q(
-    q: FloatField, rarea: FloatFieldIJ, fx: FloatField, fy: FloatField, cd: float
-):
+def update_q(q: sd, rarea: sd, fx: sd, fy: sd, cd: float):
     with computation(PARALLEL), interval(...):
         q = q + cd * rarea * (fx - fx[1, 0, 0] + fy - fy[0, 1, 0])
 
 
 @gtstencil()
-def copy_row(a: FloatField):
+def copy_row(A: sd):
     with computation(PARALLEL), interval(...):
-        a0 = a
-        a = a0[1, 0, 0]
+        A0 = A
+        A = A0[1, 0, 0]
 
 
 @gtstencil()
-def copy_column(a: FloatField):
+def copy_column(A: sd):
     with computation(PARALLEL), interval(...):
-        a0 = a
-        a = a0[0, 1, 0]
+        A0 = A
+        A = A0[0, 1, 0]
 
 
 #
@@ -92,7 +93,7 @@ def corner_fill(grid, q):
     return q
 
 
-def compute(qdel: FloatField, nmax: int, cd: float, km: int):
+def compute(qdel, nmax, cd, km):
     grid = spec.grid
     origin = (grid.isd, grid.jsd, 0)
 

--- a/fv3core/stencils/delnflux.py
+++ b/fv3core/stencils/delnflux.py
@@ -5,18 +5,20 @@ import fv3core.utils.corners as corners
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
 
 
 @gtstencil()
-def fx2_order(q: FloatField, del6_v: FloatFieldIJ, fx2: FloatField, order: int):
+def fx2_order(q: sd, del6_v: sd, fx2: sd, order: int):
     with computation(PARALLEL), interval(...):
         fx2[0, 0, 0] = del6_v * (q[-1, 0, 0] - q)
         fx2[0, 0, 0] = -1.0 * fx2 if order > 1 else fx2
 
 
 @gtstencil()
-def fy2_order(q: FloatField, del6_u: FloatFieldIJ, fy2: FloatField, order: int):
+def fy2_order(q: sd, del6_u: sd, fy2: sd, order: int):
     with computation(PARALLEL), interval(...):
         fy2[0, 0, 0] = del6_u * (q[0, -1, 0] - q)
         fy2[0, 0, 0] = fy2 * -1 if order > 1 else fy2
@@ -24,14 +26,7 @@ def fy2_order(q: FloatField, del6_u: FloatFieldIJ, fy2: FloatField, order: int):
 
 # WARNING: untested
 @gtstencil()
-def fx2_firstorder_use_sg(
-    q: FloatField,
-    sin_sg1: FloatField,
-    sin_sg3: FloatField,
-    dy: FloatField,
-    rdxc: FloatField,
-    fx2: FloatField,
-):
+def fx2_firstorder_use_sg(q: sd, sin_sg1: sd, sin_sg3: sd, dy: sd, rdxc: sd, fx2: sd):
     with computation(PARALLEL), interval(...):
         fx2[0, 0, 0] = (
             0.5 * (sin_sg3[-1, 0, 0] + sin_sg1) * dy * (q[-1, 0, 0] - q) * rdxc
@@ -40,14 +35,7 @@ def fx2_firstorder_use_sg(
 
 # WARNING: untested
 @gtstencil()
-def fy2_firstorder_use_sg(
-    q: FloatField,
-    sin_sg2: FloatField,
-    sin_sg4: FloatField,
-    dx: FloatField,
-    rdyc: FloatField,
-    fy2: FloatField,
-):
+def fy2_firstorder_use_sg(q: sd, sin_sg2: sd, sin_sg4: sd, dx: sd, rdyc: sd, fy2: sd):
     with computation(PARALLEL), interval(...):
         fy2[0, 0, 0] = (
             0.5 * (sin_sg4[0, -1, 0] + sin_sg2) * dx * (q[0, -1, 0] - q) * rdyc
@@ -55,52 +43,45 @@ def fy2_firstorder_use_sg(
 
 
 @gtstencil()
-def d2_highorder(fx2: FloatField, fy2: FloatField, rarea: FloatFieldIJ, d2: FloatField):
+def d2_highorder(fx2: sd, fy2: sd, rarea: sd, d2: sd):
     with computation(PARALLEL), interval(...):
         d2[0, 0, 0] = (fx2 - fx2[1, 0, 0] + fy2 - fy2[0, 1, 0]) * rarea
 
 
 @gtstencil()
-def d2_damp(q: FloatField, d2: FloatField, damp: float):
+def d2_damp(q: sd, d2: sd, damp: float):
     with computation(PARALLEL), interval(...):
         d2[0, 0, 0] = damp * q
 
 
 @gtstencil()
-def add_diffusive(fx: FloatField, fx2: FloatField, fy: FloatField, fy2: FloatField):
+def add_diffusive(fx: sd, fx2: sd, fy: sd, fy2: sd):
     with computation(PARALLEL), interval(...):
         fx[0, 0, 0] = fx + fx2
         fy[0, 0, 0] = fy + fy2
 
 
 @gtstencil()
-def add_diffusive_component(fx: FloatField, fx2: FloatField):
+def add_diffusive_component(fx: sd, fx2: sd):
     with computation(PARALLEL), interval(...):
         fx[0, 0, 0] = fx + fx2
 
 
 @gtstencil()
-def diffusive_damp(
-    fx: FloatField,
-    fx2: FloatField,
-    fy: FloatField,
-    fy2: FloatField,
-    mass: FloatField,
-    damp: float,
-):
+def diffusive_damp(fx: sd, fx2: sd, fy: sd, fy2: sd, mass: sd, damp: float):
     with computation(PARALLEL), interval(...):
         fx[0, 0, 0] = fx + 0.5 * damp * (mass[-1, 0, 0] + mass) * fx2
         fy[0, 0, 0] = fy + 0.5 * damp * (mass[0, -1, 0] + mass) * fy2
 
 
 @gtstencil()
-def diffusive_damp_x(fx: FloatField, fx2: FloatField, mass: FloatField, damp: float):
+def diffusive_damp_x(fx: sd, fx2: sd, mass: sd, damp: float):
     with computation(PARALLEL), interval(...):
         fx = fx + 0.5 * damp * (mass[-1, 0, 0] + mass) * fx2
 
 
 @gtstencil()
-def diffusive_damp_y(fy: FloatField, fy2: FloatField, mass: FloatField, damp: float):
+def diffusive_damp_y(fy: sd, fy2: sd, mass: sd, damp: float):
     with computation(PARALLEL), interval(...):
         fy[0, 0, 0] = fy + 0.5 * damp * (mass[0, -1, 0] + mass) * fy2
 

--- a/fv3core/stencils/divergence_damping.py
+++ b/fv3core/stencils/divergence_damping.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import gt4py.gtscript as gtscript
 from gt4py.gtscript import PARALLEL, computation, interval
 
@@ -7,79 +5,54 @@ import fv3core._config as spec
 import fv3core.stencils.a2b_ord4 as a2b_ord4
 import fv3core.stencils.basic_operations as basic
 import fv3core.utils.corners as corners
+import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy_stencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
 
 
 @gtstencil()
-def ptc_main(
-    u: FloatField,
-    va: FloatField,
-    cosa_v: FloatFieldIJ,
-    sina_v: FloatFieldIJ,
-    dyc: FloatFieldIJ,
-    ptc: FloatField,
-):
+def ptc_main(u: sd, va: sd, cosa_v: sd, sina_v: sd, dyc: sd, ptc: sd):
     with computation(PARALLEL), interval(...):
-        ptc = (u - 0.5 * (va[0, -1, 0] + va) * cosa_v) * dyc * sina_v
+        ptc[0, 0, 0] = (u - 0.5 * (va[0, -1, 0] + va) * cosa_v) * dyc * sina_v
 
 
 @gtstencil()
-def ptc_y_edge(
-    u: FloatField,
-    vc: FloatField,
-    dyc: FloatFieldIJ,
-    sin_sg4: FloatFieldIJ,
-    sin_sg2: FloatFieldIJ,
-    ptc: FloatField,
-):
+def ptc_y_edge(u: sd, vc: sd, dyc: sd, sin_sg4: sd, sin_sg2: sd, ptc: sd):
     with computation(PARALLEL), interval(...):
-        ptc = u * dyc * sin_sg4[0, -1] if vc > 0 else u * dyc * sin_sg2
+        ptc[0, 0, 0] = u * dyc * sin_sg4[0, -1, 0] if vc > 0 else u * dyc * sin_sg2
 
 
 @gtstencil()
-def vorticity_main(
-    v: FloatField,
-    ua: FloatField,
-    cosa_u: FloatFieldIJ,
-    sina_u: FloatFieldIJ,
-    dxc: FloatFieldIJ,
-    vort: FloatField,
-):
+def vorticity_main(v: sd, ua: sd, cosa_u: sd, sina_u: sd, dxc: sd, vort: sd):
     with computation(PARALLEL), interval(...):
-        vort = (v - 0.5 * (ua[-1, 0, 0] + ua) * cosa_u) * dxc * sina_u
+        vort[0, 0, 0] = (v - 0.5 * (ua[-1, 0, 0] + ua) * cosa_u) * dxc * sina_u
 
 
 @gtstencil()
-def vorticity_x_edge(
-    v: FloatField,
-    uc: FloatField,
-    dxc: FloatFieldIJ,
-    sin_sg3: FloatFieldIJ,
-    sin_sg1: FloatFieldIJ,
-    vort: FloatField,
-):
+def vorticity_x_edge(v: sd, uc: sd, dxc: sd, sin_sg3: sd, sin_sg1: sd, vort: sd):
     with computation(PARALLEL), interval(...):
-        vort = v * dxc * sin_sg3[-1, 0] if uc > 0 else v * dxc * sin_sg1
+        vort[0, 0, 0] = v * dxc * sin_sg3[-1, 0, 0] if uc > 0 else v * dxc * sin_sg1
 
 
 @gtstencil()
-def delpc_main(vort: FloatField, ptc: FloatField, delpc: FloatField):
+def delpc_main(vort: sd, ptc: sd, delpc: sd):
     with computation(PARALLEL), interval(...):
-        delpc = vort[0, -1, 0] - vort + ptc[-1, 0, 0] - ptc
+        delpc[0, 0, 0] = vort[0, -1, 0] - vort + ptc[-1, 0, 0] - ptc
 
 
 @gtstencil()
-def corner_south_remove_extra_term(vort: FloatField, delpc: FloatField):
+def corner_south_remove_extra_term(vort: sd, delpc: sd):
     with computation(PARALLEL), interval(...):
-        delpc -= vort[0, -1, 0]
+        delpc[0, 0, 0] = delpc - vort[0, -1, 0]
 
 
 @gtstencil()
-def corner_north_remove_extra_term(vort: FloatField, delpc: FloatField):
+def corner_north_remove_extra_term(vort: sd, delpc: sd):
     with computation(PARALLEL), interval(...):
-        delpc += vort
+        delpc[0, 0, 0] = delpc + vort
 
 
 @gtscript.function
@@ -93,30 +66,30 @@ def damp_tmp(q, da_min_c, d2_bg, dddmp):
 
 @gtstencil()
 def damping_nord0_stencil(
-    rarea_c: FloatFieldIJ,
-    delpc: FloatField,
-    vort: FloatField,
-    ke: FloatField,
+    rarea_c: sd,
+    delpc: sd,
+    vort: sd,
+    ke: sd,
     da_min_c: float,
     d2_bg: float,
     dddmp: float,
     dt: float,
 ):
     with computation(PARALLEL), interval(...):
-        delpc = rarea_c * delpc
+        delpc[0, 0, 0] = rarea_c * delpc
         delpcdt = delpc * dt
         absdelpcdt = delpcdt if delpcdt >= 0 else -delpcdt
         damp = damp_tmp(absdelpcdt, da_min_c, d2_bg, dddmp)
-        vort = damp * delpc
-        ke += vort
+        vort[0, 0, 0] = damp * delpc
+        ke[0, 0, 0] = ke + vort
 
 
 @gtstencil()
 def damping_nord_highorder_stencil(
-    vort: FloatField,
-    ke: FloatField,
-    delpc: FloatField,
-    divg_d: FloatField,
+    vort: sd,
+    ke: sd,
+    delpc: sd,
+    divg_d: sd,
     da_min_c: float,
     d2_bg: float,
     dddmp: float,
@@ -129,25 +102,25 @@ def damping_nord_highorder_stencil(
 
 
 @gtstencil()
-def vc_from_divg(divg_d: FloatField, divg_u: FloatFieldIJ, vc: FloatField):
+def vc_from_divg(divg_d: sd, divg_u: sd, vc: sd):
     with computation(PARALLEL), interval(...):
         vc[0, 0, 0] = (divg_d[1, 0, 0] - divg_d) * divg_u
 
 
 @gtstencil()
-def uc_from_divg(divg_d: FloatField, divg_v: FloatFieldIJ, uc: FloatField):
+def uc_from_divg(divg_d: sd, divg_v: sd, uc: sd):
     with computation(PARALLEL), interval(...):
         uc[0, 0, 0] = (divg_d[0, 1, 0] - divg_d) * divg_v
 
 
 @gtstencil()
-def redo_divg_d(uc: FloatField, vc: FloatField, divg_d: FloatField):
+def redo_divg_d(uc: sd, vc: sd, divg_d: sd):
     with computation(PARALLEL), interval(...):
         divg_d[0, 0, 0] = uc[0, -1, 0] - uc + vc[-1, 0, 0] - vc
 
 
 @gtstencil()
-def smagorinksy_diffusion_approx(delpc: FloatField, vort: FloatField, absdt: float):
+def smagorinksy_diffusion_approx(delpc: sd, vort: sd, absdt: float):
     with computation(PARALLEL), interval(...):
         vort = absdt * (delpc ** 2.0 + vort ** 2.0) ** 0.5
 
@@ -171,24 +144,24 @@ def vorticity_calc(wk, vort, delpc, dt, nord, kstart, nk):
 
 
 def compute(
-    u: FloatField,
-    v: FloatField,
-    va: FloatField,
-    ptc: FloatField,
-    vort: FloatField,
-    ua: FloatField,
-    divg_d: FloatField,
-    vc: FloatField,
-    uc: FloatField,
-    delpc: FloatField,
-    ke: FloatField,
-    wk: FloatField,
-    d2_bg: float,
-    dt: float,
-    nord: float,
-    kstart: int = 0,
-    nk: Optional[int] = None,
-) -> None:
+    u,
+    v,
+    va,
+    ptc,
+    vort,
+    ua,
+    divg_d,
+    vc,
+    uc,
+    delpc,
+    ke,
+    wk,
+    d2_bg,
+    dt,
+    nord,
+    kstart=0,
+    nk=None,
+):
     grid = spec.grid
     if nk is None:
         nk = grid.npz - kstart
@@ -316,23 +289,8 @@ def compute(
 
 
 def damping_zero_order(
-    u: FloatField,
-    v: FloatField,
-    va: FloatField,
-    ptc: FloatField,
-    vort: FloatField,
-    ua: FloatField,
-    vc: FloatField,
-    uc: FloatField,
-    delpc: FloatField,
-    ke: FloatField,
-    d2_bg: float,
-    dt: float,
-    is2: int,
-    ie1: int,
-    kstart: int,
-    nk: int,
-) -> None:
+    u, v, va, ptc, vort, ua, vc, uc, delpc, ke, d2_bg, dt, is2, ie1, kstart, nk
+):
     grid = spec.grid
     if not grid.nested:
         # TODO: ptc and vort are equivalent, but x vs y, consolidate if possible.

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -29,7 +29,7 @@ import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util as fv3util
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy_stencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
+from fv3core.utils.typing import FloatField
 
 
 HUGE_R = 1.0e40
@@ -38,21 +38,21 @@ HUGE_R = 1.0e40
 # NOTE in Fortran these are columns
 @gtstencil()
 def dp_ref_compute(
-    ak: FloatFieldK,
-    bk: FloatFieldK,
-    phis: FloatFieldIJ,
+    ak: FloatField,
+    bk: FloatField,
+    phis: FloatField,
     dp_ref: FloatField,
     zs: FloatField,
     rgrav: float,
 ):
     with computation(PARALLEL), interval(0, -1):
-        dp_ref = ak[1] - ak + (bk[1] - bk) * 1.0e5
+        dp_ref = ak[0, 0, 1] - ak + (bk[0, 0, 1] - bk) * 1.0e5
     with computation(PARALLEL), interval(...):
         zs = phis * rgrav
 
 
 @gtstencil()
-def set_gz(zs: FloatFieldIJ, delz: FloatField, gz: FloatField):
+def set_gz(zs: FloatField, delz: FloatField, gz: FloatField):
     with computation(BACKWARD):
         with interval(-1, None):
             gz[0, 0, 0] = zs
@@ -83,8 +83,8 @@ def heatadjust_temperature_lowlevel(
 
 @gtstencil()
 def p_grad_c_stencil(
-    rdxc: FloatFieldIJ,
-    rdyc: FloatFieldIJ,
+    rdxc: FloatField,
+    rdyc: FloatField,
     uc: FloatField,
     vc: FloatField,
     delpc: FloatField,
@@ -151,15 +151,9 @@ def dyncore_temporaries(shape):
     tmps = {}
     utils.storage_dict(
         tmps,
-        ["ut", "vt", "gz", "zh", "pem", "pkc", "pk3", "heat_source", "divgd"],
+        ["ut", "vt", "gz", "zh", "pem", "ws3", "pkc", "pk3", "heat_source", "divgd"],
         shape,
         grid.full_origin(),
-    )
-    utils.storage_dict(
-        tmps,
-        ["ws3"],
-        shape[0:2],
-        grid.full_origin()[0:2],
     )
     utils.storage_dict(
         tmps, ["crx", "xfx"], shape, grid.compute_origin(add=(0, -grid.halo, 0))
@@ -231,13 +225,13 @@ def compute(state, comm):
     state.mfyd[grid.slice_dict(grid.y3d_compute_dict())] = 0.0
     state.cxd[grid.slice_dict(grid.x3d_compute_domain_y_dict())] = 0.0
     state.cyd[grid.slice_dict(grid.y3d_compute_domain_x_dict())] = 0.0
-
     if not hydrostatic:
         # k1k = akap / (1.0 - akap)
 
-        # To write in parallel region, these need to be 3D first
-        state.dp_ref = utils.make_storage_from_shape(shape, grid.full_origin())
-        state.zs = utils.make_storage_from_shape(shape, grid.full_origin())
+        # TODO: Is really just a column... when different shapes are supported
+        # perhaps change this.
+        state.dp_ref = utils.make_storage_from_shape(state.ak.shape, grid.full_origin())
+        state.zs = utils.make_storage_from_shape(state.ak.shape, grid.full_origin())
         dp_ref_compute(
             state.ak,
             state.bk,
@@ -248,9 +242,6 @@ def compute(state, comm):
             origin=grid.full_origin(),
             domain=grid.domain_shape_full(add=(0, 0, 1)),
         )
-        # After writing, make 'dp_ref' a K-field and 'zs' an IJ-field
-        state.dp_ref = utils.make_storage_data(state.dp_ref[0, 0, :], (shape[2],), (0,))
-        state.zs = utils.make_storage_data(state.zs[:, :, 0], shape[0:2], (0, 0))
     n_con = get_n_con()
 
     # "acoustic" loop
@@ -350,6 +341,10 @@ def compute(state, comm):
             state.gz, state.ws3 = updatedzc.compute(
                 state.dp_ref, state.zs, state.ut, state.vt, state.gz, state.ws3, dt2
             )
+            # TODO: This is really a 2d field.
+            state.ws3 = utils.make_storage_data(
+                state.ws3[:, :, -1], shape, origin=(0, 0, 0)
+            )
             riem_solver_c.compute(
                 ms,
                 dt2,
@@ -442,6 +437,10 @@ def compute(state, comm):
                 dt,
             )
 
+            # TODO: This is really a 2d field.
+            state.wsd = utils.make_storage_data(
+                state.wsd[:, :, -1], shape, origin=grid.compute_origin()
+            )
             riem_solver3.compute(
                 remap_step,
                 dt,

--- a/fv3core/stencils/fillz.py
+++ b/fv3core/stencils/fillz.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, Tuple
-
 import numpy as np
 from gt4py.gtscript import FORWARD, PARALLEL, computation, interval
 
@@ -101,14 +99,7 @@ def fix_tracer(
             q = fac * dm / dp if fac * dm / dp > 0.0 else 0.0
 
 
-def compute(
-    dp2: FloatField,
-    tracers: Dict[str, Any],
-    im: int,
-    km: int,
-    nq: int,
-    jslice: Tuple[int],
-):
+def compute(dp2, tracers, im, km, nq, jslice):
     # Same as above, but with multiple tracer fields
     i1 = spec.grid.is_
     js = jslice.start

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -14,31 +14,28 @@ import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import ArgSpec, gtstencil, state_inputs
 from fv3core.stencils import c2l_ord
 from fv3core.stencils.basic_operations import copy_stencil
-from fv3core.utils.typing import FloatField, FloatFieldK
 from fv3gfs.util import CubedSphereCommunicator, NullTimer
 
 
+sd = utils.sd
+
+
 @gtstencil()
-def init_ph_columns(
-    ak: FloatFieldK,
-    bk: FloatFieldK,
-    pfull: FloatField,
-    p_ref: float,
-):
+def init_ph_columns(ak: sd, bk: sd, pfull: sd, ph1: sd, ph2: sd, p_ref: float):
     with computation(PARALLEL), interval(...):
         ph1 = ak + bk * p_ref
-        ph2 = ak[1] + bk[1] * p_ref
+        ph2 = ak[0, 0, 1] + bk[0, 0, 1] * p_ref
         pfull = (ph2 - ph1) / log(ph2 / ph1)
 
 
 @gtstencil()
-def pt_adjust(pkz: FloatField, dp1: FloatField, q_con: FloatField, pt: FloatField):
+def pt_adjust(pkz: sd, dp1: sd, q_con: sd, pt: sd):
     with computation(PARALLEL), interval(...):
         pt = pt * (1.0 + dp1) * (1.0 - q_con) / pkz
 
 
 @gtstencil()
-def set_omega(delp: FloatField, delz: FloatField, w: FloatField, omga: FloatField):
+def set_omega(delp: sd, delz: sd, w: sd, omga: sd):
     with computation(PARALLEL), interval(...):
         omga = delp / delz * w
 
@@ -56,29 +53,16 @@ def tracers_dict(state):
 
 def fvdyn_temporaries(shape):
     grid = spec.grid
-    origin = grid.full_origin()
     tmps = {}
     halo_vars = ["cappa"]
-    storage_vars = ["te_2d", "dp1", "pfull", "cvm", "wsd_3d"]
-    column_vars = ["gz"]
-    plane_vars = ["te_2d", "te0_2d", "wsd"]
+    storage_vars = ["te_2d", "dp1", "ph1", "ph2", "dp1", "wsd"]
+    column_vars = ["pfull", "gz", "cvm"]
+    plane_vars = ["te_2d", "te0_2d"]
     utils.storage_dict(
         tmps,
-        halo_vars + storage_vars,
+        halo_vars + storage_vars + column_vars + plane_vars,
         shape,
-        origin,
-    )
-    utils.storage_dict(
-        tmps,
-        plane_vars,
-        shape[0:2],
-        origin[0:2],
-    )
-    utils.storage_dict(
-        tmps,
-        column_vars,
-        (shape[2],),
-        (origin[2],),
+        grid.full_origin(),
     )
     for q in halo_vars:
         grid.quantity_dict_update(tmps, q)
@@ -91,13 +75,12 @@ def compute_preamble(state, comm):
         state.ak,
         state.bk,
         state.pfull,
+        state.ph1,
+        state.ph2,
         spec.namelist.p_ref,
-        origin=(0, 0, 0),
-        domain=(1, 1, grid.domain_shape_compute()[2]),
+        origin=grid.compute_origin(),
+        domain=grid.domain_shape_compute(add=(1, 1, 0)),
     )
-
-    state.pfull = utils.make_storage_data(state.pfull[0, 0, :], state.ak.shape, (0,))
-
     if spec.namelist.hydrostatic:
         raise Exception("Hydrostatic is not implemented")
     print("FV Setup", grid.rank)
@@ -349,15 +332,14 @@ def compute(state, comm, timer=NullTimer()):
     # "remapping" loop (because there's one remapping per iteration)
     for n_map in range(k_split):
         state.n_map = n_map + 1
-        last_step = n_map == k_split - 1
+        if n_map == k_split - 1:
+            last_step = True
         do_dyn(state, comm, timer)
         if grid.npz > 4:
             kord_tracer = [spec.namelist.kord_tr] * state.nq
             kord_tracer[6] = 9
             # do_omega = spec.namelist.hydrostatic and last_step
             print("Remapping", grid.rank)
-            # TODO: Determine a better way to do this, polymorphic fields perhaps?
-            state.wsd_3d[:] = utils.reshape(state.wsd, state.wsd_3d.shape)
             with timer.clock("Remapping"):
                 lagrangian_to_eulerian.compute(
                     state.tracers,
@@ -378,7 +360,7 @@ def compute(state, comm, timer=NullTimer()):
                     state.phis,
                     state.te0_2d,
                     state.ps,
-                    state.wsd_3d,
+                    state.wsd,
                     state.omga,
                     state.ak,
                     state.bk,
@@ -397,5 +379,4 @@ def compute(state, comm, timer=NullTimer()):
                 )
             if last_step:
                 post_remap(state, comm)
-            state.wsd[:] = state.wsd_3d[:, :, 0]
     wrapup(state, comm)

--- a/fv3core/stencils/fvtp2d.py
+++ b/fv3core/stencils/fvtp2d.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import gt4py.gtscript as gtscript
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
@@ -10,13 +8,13 @@ import fv3core.stencils.yppm as yppm
 import fv3core.utils.corners as corners
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+from fv3core.utils.typing import FloatField
 
 
 @gtstencil()
 def q_i_stencil(
     q: FloatField,
-    area: FloatFieldIJ,
+    area: FloatField,
     yfx: FloatField,
     fy2: FloatField,
     ra_y: FloatField,
@@ -30,7 +28,7 @@ def q_i_stencil(
 @gtstencil()
 def q_j_stencil(
     q: FloatField,
-    area: FloatFieldIJ,
+    area: FloatField,
     xfx: FloatField,
     fx2: FloatField,
     ra_x: FloatField,
@@ -73,23 +71,23 @@ def compute(data, nord_column):
 
 
 def compute_no_sg(
-    q: FloatField,
-    crx: FloatField,
-    cry: FloatField,
-    hord: int,
-    xfx: FloatField,
-    yfx: FloatField,
-    ra_x: FloatField,
-    ra_y: FloatField,
-    fx: FloatField,
-    fy: FloatField,
-    kstart: int = 0,
-    nk: Optional[int] = None,
-    nord: Optional[float] = None,
-    damp_c: Optional[float] = None,
-    mass: FloatField = None,
-    mfx: FloatField = None,
-    mfy: FloatField = None,
+    q,
+    crx,
+    cry,
+    hord,
+    xfx,
+    yfx,
+    ra_x,
+    ra_y,
+    fx,
+    fy,
+    kstart=0,
+    nk=None,
+    nord=None,
+    damp_c=None,
+    mass=None,
+    mfx=None,
+    mfy=None,
 ):
     grid = spec.grid
     if nk is None:

--- a/fv3core/stencils/heatdiss.py
+++ b/fv3core/stencils/heatdiss.py
@@ -3,18 +3,21 @@ from gt4py.gtscript import PARALLEL, computation, interval
 import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
+origin = utils.origin
 
 
 @gtstencil()
 def heat_diss(
-    fx2: FloatField,
-    fy2: FloatField,
-    w: FloatField,
-    rarea: FloatFieldIJ,
-    heat_source: FloatField,
-    diss_est: FloatField,
-    dw: FloatField,
+    fx2: sd,
+    fy2: sd,
+    w: sd,
+    rarea: sd,
+    heat_source: sd,
+    diss_est: sd,
+    dw: sd,
     dd8: float,
 ):
     with computation(PARALLEL), interval(...):
@@ -23,15 +26,7 @@ def heat_diss(
         diss_est[0, 0, 0] = heat_source
 
 
-def compute(
-    fx2: FloatField,
-    fy2: FloatField,
-    w: FloatField,
-    dd8: float,
-    dw: FloatField,
-    heat_source: FloatField,
-    diss_est: FloatField,
-) -> None:
+def compute(fx2, fy2, w, dd8, dw, heat_source, diss_est):
     heat_diss(
         fx2,
         fy2,
@@ -41,6 +36,6 @@ def compute(
         diss_est,
         dw,
         dd8,
-        origin=utils.origin,
+        origin=origin,
         domain=spec.grid.domain_shape_compute(),
     )

--- a/fv3core/stencils/map_single.py
+++ b/fv3core/stencils/map_single.py
@@ -230,9 +230,6 @@ def lagrangian_contributions_stencil(
     ptop = utils.make_storage_from_shape(shape2d)
     pbot = utils.make_storage_from_shape(shape2d)
 
-    jsize = shape2d[1]
-    jslice2d = slice(min(jslice.start, jsize - 1), min(jslice.stop, jsize))
-
     for k_eul in range(km):
 
         # TODO (olivere): This is hacky

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -21,6 +21,7 @@ def compute(
     j_2d: Optional[int] = None,
     version: str = "stencil",
 ):
+    fill = spec.namelist.fill
     qs = utils.make_storage_from_shape(pe1.shape, origin=(0, 0, 0))
     (
         dp1,
@@ -73,5 +74,5 @@ def compute(
             domain,
             version,
         )
-    if spec.namelist.fill:
+    if fill:
         fillz.compute(dp2, tracers, i_extent, spec.grid.npz, nq, jslice)

--- a/fv3core/stencils/moist_cv.py
+++ b/fv3core/stencils/moist_cv.py
@@ -1,12 +1,9 @@
-from typing import Optional
-
 import gt4py.gtscript as gtscript
 from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, log
 
 import fv3core._config as spec
 import fv3core.utils.global_constants as constants
 from fv3core.decorators import gtstencil
-from fv3core.utils import Grid
 from fv3core.utils.typing import FloatField
 
 
@@ -358,7 +355,7 @@ def moist_pkz(
         pkz = compute_pkz_func(delp, delz, pt, cappa)
 
 
-def region_mode(j_2d: Optional[int], grid: Grid):
+def region_mode(j_2d, grid):
     if j_2d is None:
         origin = grid.compute_origin()
         domain = grid.domain_shape_compute()
@@ -442,7 +439,8 @@ def compute_pt(
     r_vir: float,
     j_2d: int = None,
 ):
-    origin, domain, jslice = region_mode(j_2d, spec.grid)
+    grid = spec.grid
+    origin, domain, jslice = region_mode(j_2d, grid)
     moist_pt(
         qvapor_js,
         qliquid_js,

--- a/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/stencils/nh_p_grad.py
@@ -4,34 +4,30 @@ import fv3core._config as spec
 import fv3core.stencils.a2b_ord4 as a2b_ord4
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
+
+
+def grid():
+    return spec.grid
 
 
 @gtstencil()
-def set_k0(pp: FloatField, pk3: FloatField, top_value: float):
+def set_k0(pp: sd, pk3: sd, top_value: float):
     with computation(PARALLEL), interval(...):
         pp[0, 0, 0] = 0.0
         pk3[0, 0, 0] = top_value
 
 
 @gtstencil()
-def CalcWk(pk: FloatField, wk: FloatField):
+def CalcWk(pk: sd, wk: sd):
     with computation(PARALLEL), interval(...):
         wk = pk[0, 0, 1] - pk[0, 0, 0]
 
 
 @gtstencil()
-def CalcU(
-    u: FloatField,
-    du: FloatField,
-    wk: FloatField,
-    wk1: FloatField,
-    gz: FloatField,
-    pk3: FloatField,
-    pp: FloatField,
-    rdx: FloatFieldIJ,
-    dt: float,
-):
+def CalcU(u: sd, du: sd, wk: sd, wk1: sd, gz: sd, pk3: sd, pp: sd, rdx: sd, dt: float):
     with computation(PARALLEL), interval(...):
         # hydrostatic contribution
         du = (
@@ -52,21 +48,11 @@ def CalcU(
                 (gz[0, 0, 1] - gz[1, 0, 0]) * (pp[1, 0, 1] - pp[0, 0, 0])
                 + (gz[0, 0, 0] - gz[1, 0, 1]) * (pp[0, 0, 1] - pp[1, 0, 0])
             )
-        ) * rdx
+        ) * rdx[0, 0, 0]
 
 
 @gtstencil()
-def CalcV(
-    v: FloatField,
-    dv: FloatField,
-    wk: FloatField,
-    wk1: FloatField,
-    gz: FloatField,
-    pk3: FloatField,
-    pp: FloatField,
-    rdy: FloatFieldIJ,
-    dt: float,
-):
+def CalcV(v: sd, dv: sd, wk: sd, wk1: sd, gz: sd, pk3: sd, pp: sd, rdy: sd, dt: float):
     with computation(PARALLEL), interval(...):
         # hydrostatic contribution
         dv[0, 0, 0] = (
@@ -87,7 +73,7 @@ def CalcV(
                 (gz[0, 0, 1] - gz[0, 1, 0]) * (pp[0, 1, 1] - pp[0, 0, 0])
                 + (gz[0, 0, 0] - gz[0, 1, 1]) * (pp[0, 0, 1] - pp[0, 1, 0])
             )
-        ) * rdy
+        ) * rdy[0, 0, 0]
 
 
 def compute(u, v, pp, gz, pk3, delp, dt, ptop, akap):

--- a/fv3core/stencils/ray_fast.py
+++ b/fv3core/stencils/ray_fast.py
@@ -12,7 +12,7 @@ from gt4py.gtscript import (
 import fv3core._config as spec
 from fv3core.decorators import gtstencil
 from fv3core.stencils.rayleigh_super import SDAY, compute_rf_vals
-from fv3core.utils.typing import FloatField, FloatFieldK
+from fv3core.utils.typing import FloatField
 
 
 @gtscript.function
@@ -32,8 +32,8 @@ def ray_fast_wind(
     u: FloatField,
     v: FloatField,
     w: FloatField,
-    dp: FloatFieldK,
-    pfull: FloatFieldK,
+    dp: FloatField,
+    pfull: FloatField,
     dt: float,
     ptop: float,
     ks: int,
@@ -113,17 +113,9 @@ def ray_fast_wind(
                 w *= rf
 
 
-def compute(
-    u: FloatField,
-    v: FloatField,
-    w: FloatField,
-    dp: FloatFieldK,
-    pfull: FloatFieldK,
-    dt: float,
-    ptop: float,
-    ks: int,
-):
+def compute(u, v, w, dp, pfull, dt, ptop, ks):
     grid = spec.grid
+    namelist = spec.namelist
 
     ray_fast_wind(
         u,
@@ -134,7 +126,7 @@ def compute(
         dt,
         ptop,
         ks,
-        hydrostatic=spec.namelist.hydrostatic,
+        hydrostatic=namelist.hydrostatic,
         origin=grid.compute_origin(),
         domain=(grid.nic + 1, grid.njc + 1, grid.npz),
     )

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -323,6 +323,11 @@ def set_inner(
     extm: FloatField,
     ext5: FloatField,
     ext6: FloatField,
+    pmp_2: FloatField,
+    lac_2: FloatField,
+    tmp_min3: FloatField,
+    tmp_max3: FloatField,
+    tmp3: FloatField,
     qmin: float,
     kord: int,
     iv: int,
@@ -529,13 +534,18 @@ def compute(
     orig: Tuple[int] = (i1, js, 0)
     full_orig: Tuple[int] = (spec.grid.is_, js, 0)
     dom: Tuple[int] = (i_extent, j_extent, km)
-
     gam: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
     q: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
     q_bot: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
+
     extm: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
     ext5: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
     ext6: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
+    pmp_2: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
+    lac_2: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
+    tmp_min3: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
+    tmp_max3: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
+    tmp3: FloatField = utils.make_storage_from_shape(delp.shape, origin=full_orig)
 
     set_vals(
         gam,
@@ -590,6 +600,11 @@ def compute(
             extm,
             ext5,
             ext6,
+            pmp_2,
+            lac_2,
+            tmp_min3,
+            tmp_max3,
+            tmp3,
             qmin,
             abs(kord),
             iv,

--- a/fv3core/stencils/remapping.py
+++ b/fv3core/stencils/remapping.py
@@ -1,56 +1,58 @@
-from typing import Dict, List
-
 import fv3core._config as spec
 import fv3core.stencils.remapping_part1 as remap_part1
 import fv3core.stencils.remapping_part2 as remap_part2
 import fv3core.utils.gt4py_utils as utils
-from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
+
+
+sd = utils.sd
 
 
 def compute(
-    tracers: Dict[str, "FloatField"],
-    pt: FloatField,
-    delp: FloatField,
-    delz: FloatField,
-    peln: FloatField,
-    u: FloatField,
-    v: FloatField,
-    w: FloatField,
-    ua: FloatField,
-    va: FloatField,
-    cappa: FloatField,
-    q_con: FloatField,
-    pkz: FloatField,
-    pk: FloatField,
-    pe: FloatField,
-    hs: FloatFieldIJ,
-    te0_2d: FloatFieldIJ,
-    ps: FloatFieldIJ,
-    wsd: FloatField,
-    omga: FloatField,
-    ak: FloatFieldK,
-    bk: FloatFieldK,
-    pfull: FloatFieldK,
-    dp1: FloatField,
-    ptop: float,
-    akap: float,
-    zvir: float,
-    last_step: bool,
-    consv_te: float,
-    mdt: float,
-    bdt: float,
-    kord_tracer: List[int],
-    do_adiabatic_init: bool,
-    nq: int,
+    tracers,
+    pt,
+    delp,
+    delz,
+    peln,
+    u,
+    v,
+    w,
+    ua,
+    va,
+    cappa,
+    q_con,
+    pkz,
+    pk,
+    pe,
+    hs,
+    te0_2d,
+    ps,
+    wsd,
+    omga,
+    ak,
+    bk,
+    pfull,
+    dp1,
+    ptop,
+    akap,
+    zvir,
+    last_step,
+    consv_te,
+    mdt,
+    bdt,
+    kord_tracer,
+    do_adiabatic_init,
+    nq,
 ):
     """
     Remap the deformed Lagrangian surfaces onto the reference, or "Eulerian",
     coordinate levels.
     """
     grid = spec.grid
-    gz: FloatField = utils.make_storage_from_shape(pt.shape, grid.compute_origin())
-    cvm: FloatField = utils.make_storage_from_shape(pt.shape, grid.compute_origin())
 
+    gz = utils.make_storage_from_shape(pt.shape, grid.compute_origin())
+    cvm = utils.make_storage_from_shape(pt.shape, grid.compute_origin())
+    te_2d = utils.make_storage_from_shape(pt.shape, grid.compute_origin())
+    zsum1 = utils.make_storage_from_shape(pt.shape, grid.compute_origin())
     remap_part1.compute(
         tracers,
         pt,
@@ -103,9 +105,11 @@ def compute(
         pk,
         pe,
         hs,
+        te_2d,
         te0_2d,
         dp1,
         cvm,
+        zsum1,
         pfull,
         ptop,
         akap,

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -10,7 +10,7 @@ import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy, copy_stencil
 from fv3core.stencils.moist_cv import moist_pt_func
-from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
+from fv3core.utils.typing import FloatField
 
 
 CONSV_MIN = 0.001
@@ -57,10 +57,10 @@ def moist_cv_pt_pressure(
     delz: FloatField,
     pe: FloatField,
     pe2: FloatField,
-    ak: FloatFieldK,
-    bk: FloatFieldK,
+    ak: FloatField,
+    bk: FloatField,
     dp2: FloatField,
-    ps: FloatFieldIJ,
+    ps: FloatField,
     pn2: FloatField,
     peln: FloatField,
     r_vir: float,
@@ -91,9 +91,11 @@ def moist_cv_pt_pressure(
         if not hydrostatic:
             delz = -delz / delp
     # pressure_updates
-    with computation(FORWARD):
+    with computation(BACKWARD):
         with interval(-1, None):
             ps = pe
+        with interval(0, -1):
+            ps = ps[0, 0, 1]
     with computation(PARALLEL):
         with interval(0, 1):
             pn2 = peln
@@ -126,8 +128,8 @@ def pn2_and_pk(pe2: FloatField, pn2: FloatField, pk: FloatField, akap: float):
 def pressures_mapu(
     pe: FloatField,
     pe1: FloatField,
-    ak: FloatFieldK,
-    bk: FloatFieldK,
+    ak: FloatField,
+    bk: FloatField,
     pe0: FloatField,
     pe3: FloatField,
 ):
@@ -150,7 +152,7 @@ def pressures_mapu(
 
 @gtstencil()
 def pressures_mapv(
-    pe: FloatField, ak: FloatFieldK, bk: FloatFieldK, pe0: FloatField, pe3: FloatField
+    pe: FloatField, ak: FloatField, bk: FloatField, pe0: FloatField, pe3: FloatField
 ):
     with computation(BACKWARD):
         with interval(-1, None):
@@ -188,13 +190,13 @@ def compute(
     pkz: FloatField,
     pk: FloatField,
     pe: FloatField,
-    hs: FloatFieldIJ,
+    hs: FloatField,
     te: FloatField,
-    ps: FloatFieldIJ,
+    ps: FloatField,
     wsd: FloatField,
     omga: FloatField,
-    ak: FloatFieldK,
-    bk: FloatFieldK,
+    ak: FloatField,
+    bk: FloatField,
     gz: FloatField,
     cvm: FloatField,
     ptop: float,
@@ -202,15 +204,14 @@ def compute(
     r_vir: float,
     nq: int,
 ):
+    grid = spec.grid
+    hydrostatic = spec.namelist.hydrostatic
+    t_min = 184.0
+
     if spec.namelist.kord_tm >= 0:
         raise Exception("map ppm, untested mode where kord_tm >= 0")
-
-    hydrostatic = spec.namelist.hydrostatic
     if hydrostatic:
         raise Exception("Hydrostatic is not implemented")
-
-    grid = spec.grid
-    t_min = 184.0
 
     # do_omega = hydrostatic and last_step # TODO pull into inputs
     domain_jextra = (grid.nic, grid.njc + 1, grid.npz + 1)
@@ -287,9 +288,8 @@ def compute(
     )
     # TODO else if nq > 0:
     # TODO map1_q2, fillz
-    kord_wz = spec.namelist.kord_wz
-    map_single.compute(w, pe1, pe2, wsd, -2, grid.is_, grid.ie, kord_wz)
-    map_single.compute(delz, pe1, pe2, gz, 1, grid.is_, grid.ie, kord_wz)
+    map_single.compute(w, pe1, pe2, wsd, -2, grid.is_, grid.ie, spec.namelist.kord_wz)
+    map_single.compute(delz, pe1, pe2, gz, 1, grid.is_, grid.ie, spec.namelist.kord_wz)
 
     undo_delz_adjust_and_copy_peln(
         delp,

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -17,23 +17,25 @@ import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
 
 
 @gtstencil()
 def precompute(
-    cp3: FloatField,
-    dm: FloatField,
-    zh: FloatField,
-    q_con: FloatField,
-    pem: FloatField,
-    peln: FloatField,
-    pk3: FloatField,
-    peg: FloatField,
-    pelng: FloatField,
-    gm: FloatField,
-    dz: FloatField,
-    pm: FloatField,
+    cp3: sd,
+    dm: sd,
+    zh: sd,
+    q_con: sd,
+    pem: sd,
+    peln: sd,
+    pk3: sd,
+    peg: sd,
+    pelng: sd,
+    gm: sd,
+    dz: sd,
+    pm: sd,
     ptop: float,
     peln1: float,
     ptk: float,
@@ -63,14 +65,7 @@ def precompute(
 
 
 @gtstencil()
-def last_call_copy(
-    peln_run: FloatField,
-    peln: FloatField,
-    pk3: FloatField,
-    pk: FloatField,
-    pem: FloatField,
-    pe: FloatField,
-):
+def last_call_copy(peln_run: sd, peln: sd, pk3: sd, pk: sd, pem: sd, pe: sd):
     with computation(PARALLEL), interval(...):
         peln = peln_run
         pk = pk3
@@ -79,17 +74,17 @@ def last_call_copy(
 
 @gtstencil()
 def finalize(
-    zs: FloatFieldIJ,
-    dz: FloatField,
-    zh: FloatField,
-    peln_run: FloatField,
-    peln: FloatField,
-    pk3: FloatField,
-    pk: FloatField,
-    pem: FloatField,
-    pe: FloatField,
-    ppe: FloatField,
-    pe_init: FloatField,
+    zs: sd,
+    dz: sd,
+    zh: sd,
+    peln_run: sd,
+    peln: sd,
+    pk3: sd,
+    pk: sd,
+    pem: sd,
+    pe: sd,
+    ppe: sd,
+    pe_init: sd,
     last_call: bool,
 ):
     with computation(PARALLEL), interval(...):
@@ -113,24 +108,24 @@ def finalize(
 
 
 def compute(
-    last_call: bool,
-    dt: float,
-    akap: float,
-    cappa: FloatField,
-    ptop: float,
-    zs: FloatFieldIJ,
-    w: FloatField,
-    delz: FloatField,
-    q_con: FloatField,
-    delp: FloatField,
-    pt: FloatField,
-    zh: FloatField,
-    pe: FloatField,
-    ppe: FloatField,
-    pk3: FloatField,
-    pk: FloatField,
-    peln: FloatField,
-    wsd: FloatFieldIJ,
+    last_call,
+    dt,
+    akap,
+    cappa,
+    ptop,
+    zs,
+    w,
+    delz,
+    q_con,
+    delp,
+    pt,
+    zh,
+    pe,
+    ppe,
+    pk3,
+    pk,
+    peln,
+    wsd,
 ):
     grid = spec.grid
     rgrav = 1.0 / constants.GRAV
@@ -152,7 +147,6 @@ def compute(
     peg = utils.make_storage_from_shape(shape, riemorigin)
     pelng = utils.make_storage_from_shape(shape, riemorigin)
     gm = utils.make_storage_from_shape(shape, riemorigin)
-
     precompute(
         cp3,
         dm,
@@ -174,7 +168,6 @@ def compute(
         origin=riemorigin,
         domain=domain,
     )
-
     sim1_solver.solve(
         grid.is_,
         grid.ie,

--- a/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/stencils/riem_solver_c.py
@@ -6,19 +6,21 @@ import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
 
 
 @gtstencil()
 def precompute(
-    cp3: FloatField,
-    gz: FloatField,
-    dm: FloatField,
-    q_con: FloatField,
-    pem: FloatField,
-    dz: FloatField,  # is actually delta of gz
-    gm: FloatField,
-    pm: FloatField,
+    cp3: sd,
+    gz: sd,
+    dm: sd,
+    q_con: sd,
+    pem: sd,
+    dz: sd,  # is actually delta of gz
+    gm: sd,
+    pm: sd,
     ptop: float,
 ):
     with computation(FORWARD):
@@ -38,15 +40,7 @@ def precompute(
 
 
 @gtstencil()
-def finalize(
-    pe2: FloatField,
-    pem: FloatField,
-    hs: FloatFieldIJ,
-    dz: FloatField,
-    pef: FloatField,
-    gz: FloatField,
-    ptop: float,
-):
+def finalize(pe2: sd, pem: sd, hs: sd, dz: sd, pef: sd, gz: sd, ptop: float):
     # TODO: We only want to bottom level of hd, so this could be removed once
     # hd0 is a 2d field.
     with computation(FORWARD):
@@ -68,21 +62,7 @@ def finalize(
 
 
 # TODO: this is totally inefficient, can we use stencils?
-def compute(
-    ms: int,
-    dt2: float,
-    akap: float,
-    cappa: FloatField,
-    ptop: float,
-    hs: FloatFieldIJ,
-    w3: FloatField,
-    ptc: FloatField,
-    q_con: FloatField,
-    delpc: FloatField,
-    gz: FloatField,
-    pef: FloatField,
-    ws: FloatFieldIJ,
-):
+def compute(ms, dt2, akap, cappa, ptop, hs, w3, ptc, q_con, delpc, gz, pef, ws):
     grid = spec.grid
     is1 = grid.is_ - 1
     ie1 = grid.ie + 1

--- a/fv3core/stencils/saturation_adjustment.py
+++ b/fv3core/stencils/saturation_adjustment.py
@@ -8,7 +8,7 @@ import fv3core.utils.global_constants as constants
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import dim
 from fv3core.stencils.moist_cv import compute_pkz_func
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+from fv3core.utils.typing import FloatField
 
 
 # TODO: This code could be reduced greatly with abstraction, but first gt4py
@@ -568,8 +568,8 @@ def satadjust(
     te0: FloatField,
     q_con: FloatField,
     qa: FloatField,
-    area: FloatFieldIJ,
-    hs: FloatFieldIJ,
+    area: FloatField,
+    hs: FloatField,
     pkz: FloatField,
     sdt: float,
     zvir: float,
@@ -887,30 +887,29 @@ def satadjust(
 
 
 def compute(
-    te: FloatField,
-    qvapor: FloatField,
-    qliquid: FloatField,
-    qice: FloatField,
-    qrain: FloatField,
-    qsnow: FloatField,
-    qgraupel: FloatField,
-    qcld: FloatField,
-    hs: FloatFieldIJ,
-    peln: FloatField,
-    delp: FloatField,
-    delz: FloatField,
-    q_con: FloatField,
-    pt: FloatField,
-    pkz: FloatField,
-    cappa: FloatField,
-    r_vir: float,
-    mdt: float,
-    fast_mp_consv: bool,
-    last_step: bool,
-    akap: float,
-    kmp: int,
-) -> None:
-
+    te,
+    qvapor,
+    qliquid,
+    qice,
+    qrain,
+    qsnow,
+    qgraupel,
+    qcld,
+    hs,
+    peln,
+    delp,
+    delz,
+    q_con,
+    pt,
+    pkz,
+    cappa,
+    r_vir,
+    mdt,
+    fast_mp_consv,
+    last_step,
+    akap,
+    kmp,
+):
     grid = spec.grid
     origin = (grid.is_, grid.js, kmp)
     domain = (grid.nic, grid.njc, (grid.npz - kmp))

--- a/fv3core/stencils/sim1_solver.py
+++ b/fv3core/stencils/sim1_solver.py
@@ -2,22 +2,25 @@ from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, exp, interv
 
 import fv3core._config as spec
 import fv3core.utils.global_constants as constants
+import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+
+
+sd = utils.sd
 
 
 @gtstencil()
 def sim1_solver(
-    w: FloatField,
-    dm: FloatField,
-    gm: FloatField,
-    dz: FloatField,
-    ptr: FloatField,
-    pm: FloatField,
-    pe: FloatField,
-    pem: FloatField,
-    wsr: FloatFieldIJ,
-    cp3: FloatField,
+    w: sd,
+    dm: sd,
+    gm: sd,
+    dz: sd,
+    ptr: sd,
+    pm: sd,
+    pe: sd,
+    pem: sd,
+    wsr: sd,
+    cp3: sd,
     dt: float,
     t1g: float,
     rdt: float,
@@ -109,23 +112,7 @@ def sim1_solver(
 
 
 # TODO: implement MOIST_CAPPA=false
-def solve(
-    is_: int,
-    ie: int,
-    js: int,
-    je: int,
-    dt: float,
-    gm: FloatField,
-    cp3: FloatField,
-    pe: FloatField,
-    dm: FloatField,
-    pm: FloatField,
-    pem: FloatField,
-    w: FloatField,
-    dz: FloatField,
-    ptr: FloatField,
-    wsr: FloatFieldIJ,
-):
+def solve(is_, ie, js, je, dt, gm, cp3, pe, dm, pm, pem, w, dz, ptr, wsr):
     grid = spec.grid
     nic = ie - is_ + 1
     njc = je - js + 1

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -10,7 +10,7 @@ import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy, copy_stencil
 from fv3core.stencils.updatedzd import ra_stencil_update
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+from fv3core.utils.typing import FloatField
 
 
 @gtscript.function
@@ -19,7 +19,9 @@ def flux_x(cx, dxa, dy, sin_sg3, sin_sg1, xfx):
 
     with horizontal(region[local_is : local_ie + 2, local_js - 3 : local_je + 4]):
         xfx = (
-            cx * dxa[-1, 0] * dy * sin_sg3[-1, 0] if cx > 0 else cx * dxa * dy * sin_sg1
+            cx * dxa[-1, 0, 0] * dy * sin_sg3[-1, 0, 0]
+            if cx > 0
+            else cx * dxa * dy * sin_sg1
         )
     return xfx
 
@@ -30,7 +32,9 @@ def flux_y(cy, dya, dx, sin_sg4, sin_sg2, yfx):
 
     with horizontal(region[local_is - 3 : local_ie + 4, local_js : local_je + 2]):
         yfx = (
-            cy * dya[0, -1] * dx * sin_sg4[0, -1] if cy > 0 else cy * dya * dx * sin_sg2
+            cy * dya[0, -1, 0] * dx * sin_sg4[0, -1, 0]
+            if cy > 0
+            else cy * dya * dx * sin_sg2
         )
     return yfx
 
@@ -39,14 +43,14 @@ def flux_y(cy, dya, dx, sin_sg4, sin_sg2, yfx):
 def flux_compute(
     cx: FloatField,
     cy: FloatField,
-    dxa: FloatFieldIJ,
-    dya: FloatFieldIJ,
-    dx: FloatFieldIJ,
-    dy: FloatFieldIJ,
-    sin_sg1: FloatFieldIJ,
-    sin_sg2: FloatFieldIJ,
-    sin_sg3: FloatFieldIJ,
-    sin_sg4: FloatFieldIJ,
+    dxa: FloatField,
+    dya: FloatField,
+    dx: FloatField,
+    dy: FloatField,
+    sin_sg1: FloatField,
+    sin_sg2: FloatField,
+    sin_sg3: FloatField,
+    sin_sg4: FloatField,
     xfx: FloatField,
     yfx: FloatField,
 ):
@@ -94,7 +98,7 @@ def dp_fluxadjustment(
     dp1: FloatField,
     mfx: FloatField,
     mfy: FloatField,
-    rarea: FloatFieldIJ,
+    rarea: FloatField,
     dp2: FloatField,
 ):
     with computation(PARALLEL), interval(...):
@@ -112,7 +116,7 @@ def q_adjust(
     dp1: FloatField,
     fx: FloatField,
     fy: FloatField,
-    rarea: FloatFieldIJ,
+    rarea: FloatField,
     dp2: FloatField,
 ):
     with computation(PARALLEL), interval(...):
@@ -126,7 +130,7 @@ def q_adjustments(
     dp1: FloatField,
     fx: FloatField,
     fy: FloatField,
-    rarea: FloatFieldIJ,
+    rarea: FloatField,
     dp2: FloatField,
     it: int,
     nsplt: int,

--- a/fv3core/stencils/updatedzc.py
+++ b/fv3core/stencils/updatedzc.py
@@ -1,14 +1,15 @@
 import gt4py.gtscript as gtscript
-from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
+from gt4py.gtscript import BACKWARD, PARALLEL, computation, interval
 
 import fv3core._config as spec
 import fv3core.utils.global_constants as constants
+import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy
 from fv3core.utils import corners
-from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
 
+sd = utils.sd
 DZ_MIN = constants.DZ_MIN
 
 
@@ -79,7 +80,7 @@ DZ_MIN = constants.DZ_MIN
 @gtscript.function
 def p_weighted_average_top(vel, dp0):
     # TODO: ratio is a constant, where should this be placed?
-    ratio = dp0 / (dp0 + dp0[1])
+    ratio = dp0 / (dp0 + dp0[0, 0, 1])
     # return (1. + ratio) * vel - ratio * vel[0, 0, 1]
     return vel + (vel - vel[0, 0, 1]) * ratio
 
@@ -101,7 +102,7 @@ def p_weighted_average_top(vel, dp0):
 
 @gtscript.function
 def p_weighted_average_bottom(vel, dp0):
-    ratio = dp0[-1] / (dp0[-2] + dp0[-1])
+    ratio = dp0[0, 0, -1] / (dp0[0, 0, -2] + dp0[0, 0, -1])
     # return (1. + ratio ) * vel[0, 0, -1] - ratio * vel[0, 0, -2]
     return vel[0, 0, -1] + (vel[0, 0, -1] - vel[0, 0, -2]) * ratio
 
@@ -123,10 +124,10 @@ def p_weighted_average_bottom(vel, dp0):
 
 @gtscript.function
 def p_weighted_average_domain(vel, dp0):
-    # ratio = dp0 / ( dp0[-1] + dp0 )
+    # ratio = dp0 / ( dp0[0, 0, -1] + dp0 )
     # return ratio * vel[0, 0, -1] + (1. - ratio) * vel
-    int_ratio = 1.0 / (dp0[-1] + dp0)
-    return (dp0 * vel[0, 0, -1] + dp0[-1] * vel) * int_ratio
+    int_ratio = 1.0 / (dp0[0, 0, -1] + dp0)
+    return (dp0 * vel[0, 0, -1] + dp0[0, 0, -1] * vel) * int_ratio
 
 
 #      do j=js-ng, je+ng
@@ -196,15 +197,15 @@ def xy_flux(gz_x, gz_y, xfx, yfx):
 
 @gtstencil()
 def update_dz_c(
-    dp_ref: FloatFieldK,
-    zs: FloatFieldIJ,
-    area: FloatFieldIJ,
-    ut: FloatField,
-    vt: FloatField,
-    gz: FloatField,
-    gz_x: FloatField,
-    gz_y: FloatField,
-    ws3: FloatFieldIJ,
+    dp_ref: sd,
+    zs: sd,
+    area: sd,
+    ut: sd,
+    vt: sd,
+    gz: sd,
+    gz_x: sd,
+    gz_y: sd,
+    ws3: sd,
     *,
     dt: float,
 ):
@@ -224,7 +225,7 @@ def update_dz_c(
         gz = (gz_y * area + fx - fx[1, 0, 0] + fy - fy[0, 1, 0]) / (
             area + xfx - xfx[1, 0, 0] + yfx - yfx[0, 1, 0]
         )
-    with computation(FORWARD), interval(-1, None):
+    with computation(PARALLEL), interval(-1, None):
         rdt = 1.0 / dt
         ws3 = (zs - gz) * rdt
     with computation(BACKWARD), interval(0, -1):
@@ -232,15 +233,7 @@ def update_dz_c(
         gz = gz if gz > gz_kp1 else gz_kp1
 
 
-def compute(
-    dp_ref: FloatFieldK,
-    zs: FloatFieldIJ,
-    ut: FloatField,
-    vt: FloatField,
-    gz_in: FloatField,
-    ws3: FloatFieldIJ,
-    dt2: float,
-):
+def compute(dp_ref, zs, ut, vt, gz_in, ws3, dt2):
     grid = spec.grid
     origin = (1, 1, 0)
     gz = copy(gz_in, origin=origin)

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -4,7 +4,6 @@ import fv3core._config as spec
 import fv3core.stencils.xppm as xppm
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 from .xppm import (
     compute_al,
@@ -24,18 +23,14 @@ from .xppm import (
 )
 
 
+sd = utils.sd
+
+
 @gtstencil()
-def get_flux_u_stencil_old(
-    q: FloatField,
-    c: FloatField,
-    al: FloatField,
-    rdx: FloatFieldIJ,
-    flux: FloatField,
-    mord: int,
-):
+def get_flux_u_stencil_old(q: sd, c: sd, al: sd, rdx: sd, flux: sd, mord: int):
     with computation(PARALLEL), interval(...):
         bl, br, b0, tmp = flux_intermediates(q, al, mord)
-        cfl = c * rdx[-1, 0] if c > 0 else c * rdx
+        cfl = c * rdx[-1, 0, 0] if c > 0 else c * rdx
         fx0 = fx1_fn(cfl, br, b0, bl)
         # TODO: add [0, 0, 0] when gt4py bug is fixed
         flux = final_flux(c, q, fx0, tmp)  # noqa
@@ -43,43 +38,29 @@ def get_flux_u_stencil_old(
 
 @gtstencil()
 def get_flux_u_stencil(
-    q: FloatField,
-    c: FloatField,
-    al: FloatField,
-    rdx: FloatFieldIJ,
-    bl: FloatField,
-    br: FloatField,
-    flux: FloatField,
-    mord: int,
+    q: sd, c: sd, al: sd, rdx: sd, bl: sd, br: sd, flux: sd, mord: int
 ):
     with computation(PARALLEL), interval(...):
         b0 = get_b0(bl=bl, br=br)
         smt5 = is_smt5_mord5(bl, br) if mord == 5 else is_smt5_most_mords(bl, br, b0)
         tmp = smt5[-1, 0, 0] + smt5 * (smt5[-1, 0, 0] == 0)
-        cfl = c * rdx[-1, 0] if c > 0 else c * rdx
+        cfl = c * rdx[-1, 0, 0] if c > 0 else c * rdx
         fx0 = fx1_fn(cfl, br, b0, bl)
         # TODO: add [0, 0, 0] when gt4py bug is fixed
         flux = final_flux(c, q, fx0, tmp)  # noqa
 
 
 @gtstencil()
-def get_flux_u_ord8plus(
-    q: FloatField,
-    c: FloatField,
-    rdx: FloatFieldIJ,
-    bl: FloatField,
-    br: FloatField,
-    flux: FloatField,
-):
+def get_flux_u_ord8plus(q: sd, c: sd, rdx: sd, bl: sd, br: sd, flux: sd):
     with computation(PARALLEL), interval(...):
         b0 = get_b0(bl, br)
-        cfl = c * rdx[-1, 0] if c > 0 else c * rdx
+        cfl = c * rdx[-1, 0, 0] if c > 0 else c * rdx
         fx1 = fx1_fn(cfl, br, b0, bl)
         flux = q[-1, 0, 0] + fx1 if c > 0.0 else q + fx1
 
 
 @gtstencil()
-def br_bl_main(q: FloatField, al: FloatField, bl: FloatField, br: FloatField):
+def br_bl_main(q: sd, al: sd, bl: sd, br: sd):
     with computation(PARALLEL), interval(...):
         # TODO: add [0, 0, 0] when gt4py bug is fixed
         bl = get_bl(al=al, q=q)  # noqa
@@ -87,7 +68,7 @@ def br_bl_main(q: FloatField, al: FloatField, bl: FloatField, br: FloatField):
 
 
 @gtstencil()
-def br_bl_corner(br: FloatField, bl: FloatField):
+def br_bl_corner(br: sd, bl: sd):
     with computation(PARALLEL), interval(...):
         bl = 0
         br = 0
@@ -273,9 +254,7 @@ def compute(c, u, v, flux):
 
 
 @gtstencil()
-def west_edge_iord8plus_0(
-    q: FloatField, dxa: FloatFieldIJ, dm: FloatField, bl: FloatField, br: FloatField
-):
+def west_edge_iord8plus_0(q: sd, dxa: sd, dm: sd, bl: sd, br: sd):
     with computation(PARALLEL), interval(...):
         bl = s14 * dm[-1, 0, 0] + s11 * (q[-1, 0, 0] - q)
         xt = xt_dxa_edge_0_base(q, dxa)
@@ -283,9 +262,7 @@ def west_edge_iord8plus_0(
 
 
 @gtstencil()
-def west_edge_iord8plus_1(
-    q: FloatField, dxa: FloatFieldIJ, dm: FloatField, bl: FloatField, br: FloatField
-):
+def west_edge_iord8plus_1(q: sd, dxa: sd, dm: sd, bl: sd, br: sd):
     with computation(PARALLEL), interval(...):
         xt = xt_dxa_edge_1_base(q, dxa)
         bl = xt - q
@@ -294,9 +271,7 @@ def west_edge_iord8plus_1(
 
 
 @gtstencil()
-def east_edge_iord8plus_1(
-    q: FloatField, dxa: FloatFieldIJ, dm: FloatField, bl: FloatField, br: FloatField
-):
+def east_edge_iord8plus_1(q: sd, dxa: sd, dm: sd, bl: sd, br: sd):
     with computation(PARALLEL), interval(...):
         xt = s15 * q + s11 * q[-1, 0, 0] + s14 * dm[-1, 0, 0]
         bl = xt - q
@@ -305,9 +280,7 @@ def east_edge_iord8plus_1(
 
 
 @gtstencil()
-def east_edge_iord8plus_2(
-    q: FloatField, dxa: FloatFieldIJ, dm: FloatField, bl: FloatField, br: FloatField
-):
+def east_edge_iord8plus_2(q: sd, dxa: sd, dm: sd, bl: sd, br: sd):
     with computation(PARALLEL), interval(...):
         xt = xt_dxa_edge_1_base(q, dxa)
         bl = xt - q

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -4,7 +4,6 @@ import fv3core._config as spec
 import fv3core.stencils.yppm as yppm
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 from .yppm import (
     compute_al,
@@ -18,45 +17,34 @@ from .yppm import (
 )
 
 
+sd = utils.sd
+
+
 @gtstencil()
 def get_flux_v_stencil(
-    q: FloatField,
-    c: FloatField,
-    al: FloatField,
-    rdy: FloatFieldIJ,
-    bl: FloatField,
-    br: FloatField,
-    flux: FloatField,
-    mord: int,
+    q: sd, c: sd, al: sd, rdy: sd, bl: sd, br: sd, flux: sd, mord: int
 ):
     with computation(PARALLEL), interval(...):
         b0 = get_b0(bl=bl, br=br)
         smt5 = is_smt5_mord5(bl, br) if mord == 5 else is_smt5_most_mords(bl, br, b0)
         tmp = smt5[0, -1, 0] + smt5 * (smt5[0, -1, 0] == 0)
-        cfl = c * rdy[0, -1] if c > 0 else c * rdy
+        cfl = c * rdy[0, -1, 0] if c > 0 else c * rdy
         fx0 = fx1_fn(cfl, br, b0, bl)
         # TODO: add [0, 0, 0] when gt4py bug is fixed
         flux = final_flux(c, q, fx0, tmp)  # noqa
 
 
 @gtstencil()
-def get_flux_v_ord8plus(
-    q: FloatField,
-    c: FloatField,
-    rdy: FloatFieldIJ,
-    bl: FloatField,
-    br: FloatField,
-    flux: FloatField,
-):
+def get_flux_v_ord8plus(q: sd, c: sd, rdy: sd, bl: sd, br: sd, flux: sd):
     with computation(PARALLEL), interval(...):
         b0 = get_b0(bl, br)
-        cfl = c * rdy[0, -1] if c > 0 else c * rdy
+        cfl = c * rdy[0, -1, 0] if c > 0 else c * rdy
         fx1 = fx1_fn(cfl, br, b0, bl)
         flux = q[0, -1, 0] + fx1 if c > 0.0 else q + fx1
 
 
 @gtstencil()
-def br_bl_main(q: FloatField, al: FloatField, bl: FloatField, br: FloatField):
+def br_bl_main(q: sd, al: sd, bl: sd, br: sd):
     with computation(PARALLEL), interval(...):
         # TODO: add [0, 0, 0] when gt4py bug is fixed
         bl = get_bl(al=al, q=q)  # noqa
@@ -64,7 +52,7 @@ def br_bl_main(q: FloatField, al: FloatField, bl: FloatField, br: FloatField):
 
 
 @gtstencil()
-def br_bl_corner(br: FloatField, bl: FloatField):
+def br_bl_corner(br: sd, bl: sd):
     with computation(PARALLEL), interval(...):
         bl = 0
         br = 0

--- a/fv3core/testing/parallel_translate.py
+++ b/fv3core/testing/parallel_translate.py
@@ -11,6 +11,18 @@ from fv3core.utils import gt4py_utils as utils
 from .translate import TranslateFortranData2Py, read_serialized_data
 
 
+def ensure_3d_dims(dims_in):
+    dims_out = [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM]
+    for dim in dims_in:
+        for i, dim_set in enumerate([fv3util.X_DIMS, fv3util.Y_DIMS, fv3util.Z_DIMS]):
+            if dim in dim_set:
+                dims_out[i] = dim
+                break
+        else:
+            raise ValueError(f"dimension {dim} is not an x/y/z dimension")
+    return dims_out
+
+
 class ParallelTranslate:
 
     max_error = TranslateFortranData2Py.max_error
@@ -51,7 +63,8 @@ class ParallelTranslate:
                 properties["name"] = name
             input_data = state[name]
             if len(properties["dims"]) > 0:
-                dims = properties["dims"]
+                # self._base will always make a 3D array
+                dims = ensure_3d_dims(properties["dims"])
                 state[properties["name"]] = fv3util.Quantity(
                     input_data,
                     dims,

--- a/fv3core/testing/translate.py
+++ b/fv3core/testing/translate.py
@@ -27,7 +27,6 @@ class TranslateFortranData2Py:
         self.origin = origin
         self.in_vars = {"data_vars": {}, "parameters": []}
         self.out_vars = {}
-        self.write_vars = []
         self.grid = grid
         self.maxshape = grid.domain_shape_full(add=(1, 1, 1))
         self.ordered_input_vars = None
@@ -75,15 +74,11 @@ class TranslateFortranData2Py:
         dummy_axes: Optional[Tuple[int, int, int]] = None,
         axis: int = 2,
         names_4d: Optional[List[str]] = None,
-        read_only: bool = False,
-        full_shape: bool = False,
-    ) -> Dict[str, "Field"]:
+    ) -> Dict[str, type(Field)]:
         use_shape = list(self.maxshape)
         if dummy_axes:
             for axis in dummy_axes:
                 use_shape[axis] = 1
-        elif not full_shape and len(array.shape) < 3 and axis == len(array.shape) - 1:
-            use_shape[1] = 1
         use_shape = tuple(use_shape)
         start = (istart, jstart, kstart)
         if names_4d:
@@ -104,7 +99,6 @@ class TranslateFortranData2Py:
                 origin=start,
                 dummy=dummy_axes,
                 axis=axis,
-                read_only=read_only,
             )
 
     def storage_vars(self):
@@ -172,6 +166,11 @@ class TranslateFortranData2Py:
                 inputs[serialname].shape, info
             )
 
+            logger.debug(
+                "Making storage for {} with istart = {}, jstart = {}".format(
+                    d, istart, jstart
+                )
+            )
             names_4d = None
             if len(inputs[serialname].shape) == 4:
                 names_4d = info.get("names_4d", utils.tracer_variables)
@@ -186,8 +185,6 @@ class TranslateFortranData2Py:
                 dummy_axes=dummy_axes,
                 axis=axis,
                 names_4d=names_4d,
-                read_only=d not in self.write_vars,
-                full_shape="full_shape" in storage_vars[d],
             )
             if d != serialname:
                 del inputs[serialname]
@@ -224,8 +221,9 @@ class TranslateFortranData2Py:
                 out[serialname] = var4d
             else:
                 data_result.synchronize()
-                slice_tuple = self.grid.slice_dict(ds, len(data_result.shape))
-                out[serialname] = np.squeeze(np.asarray(data_result)[slice_tuple])
+                out[serialname] = np.squeeze(
+                    np.asarray(data_result)[self.grid.slice_dict(ds)]
+                )
             if "kaxis" in info:
                 out[serialname] = np.moveaxis(out[serialname], 2, info["kaxis"])
         return out
@@ -301,7 +299,6 @@ class TranslateGrid:
                     shape,
                     start=(0, 0, pygrid.halo),
                     axis=axis,
-                    read_only=True,
                 )
         for k, v in self.data.items():
             if type(v) is np.ndarray:
@@ -315,7 +312,7 @@ class TranslateGrid:
                 )
                 origin = (istart, jstart, 0)
                 self.data[k] = utils.make_storage_data(
-                    v, shape, origin=origin, start=origin, read_only=True
+                    v, shape, origin=origin, start=origin
                 )
 
     def python_grid(self):

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -11,7 +11,7 @@ from gt4py import gtscript
 
 import fv3core.utils.global_config as global_config
 from fv3core.utils.mpi import MPI
-from fv3core.utils.typing import DTypes, Field, Float, Int
+from fv3core.utils.typing import DTypes, Field, float_type, int_type
 
 
 try:
@@ -28,8 +28,8 @@ validate_args = True
 managed_memory = True
 
 # [DEPRECATED] field types
-sd = gtscript.Field[Float]
-si = gtscript.Field[Int]
+sd = gtscript.Field[float_type]
+si = gtscript.Field[int_type]
 
 # Number of halo lines for each field and default origin
 halo = 3
@@ -79,15 +79,13 @@ def mark_untested(msg="This is not tested"):
 def make_storage_data(
     data: Field,
     shape: Optional[Tuple[int, int, int]] = None,
-    origin: Tuple[int, int, int] = origin,
     *,
+    origin: Tuple[int, int, int] = origin,
     dtype: DTypes = np.float64,
-    mask: Optional[Tuple[bool, bool, bool]] = None,
+    mask: Tuple[bool, bool, bool] = (True, True, True),
     start: Tuple[int, int, int] = (0, 0, 0),
     dummy: Optional[Tuple[int, int, int]] = None,
     axis: int = 2,
-    max_dim: int = 3,
-    read_only: bool = True,
 ) -> Field:
     """Create a new gt4py storage from the given data.
 
@@ -120,26 +118,10 @@ def make_storage_data(
     if shape is None:
         shape = data.shape
 
-    if not mask:
-        if not read_only:
-            mask = (True, True, True)
-        else:
-            if n_dims == 1:
-                if axis == 1:
-                    # Convert J-fields to IJ-fields
-                    mask = (True, True, False)
-                    shape = (1, shape[axis])
-                else:
-                    mask = tuple([i == axis for i in range(max_dim)])
-            elif dummy or axis != 2:
-                mask = (True, True, True)
-            else:
-                mask = (n_dims * (True,)) + ((max_dim - n_dims) * (False,))
-
     if n_dims == 1:
-        data = _make_storage_data_1d(data, shape, start, dummy, axis, read_only)
+        data = _make_storage_data_1d(data, shape, start, dummy, axis)
     elif n_dims == 2:
-        data = _make_storage_data_2d(data, shape, start, dummy, axis, read_only)
+        data = _make_storage_data_2d(data, shape, start, dummy, axis)
     else:
         data = _make_storage_data_3d(data, shape, start)
 
@@ -161,32 +143,29 @@ def _make_storage_data_1d(
     start: Tuple[int, int, int] = (0, 0, 0),
     dummy: Optional[Tuple[int, int, int]] = None,
     axis: int = 2,
-    read_only: bool = True,
 ) -> Field:
     # axis refers to a repeated axis, dummy refers to a singleton axis
-    axis = min(axis, len(shape) - 1)
-    buffer = zeros(shape[axis])
+    kstart = start[2]
     if dummy:
         axis = list(set((0, 1, 2)).difference(dummy))[0]
-
-    kstart = start[2]
+    buffer = zeros(shape[axis])
     buffer[kstart : kstart + len(data)] = asarray(data, type(buffer))
+    tile_spec = list(shape)
+    tile_spec[axis] = 1
 
-    if not read_only:
-        tile_spec = list(shape)
-        tile_spec[axis] = 1
+    if dummy:
+        if len(dummy) == len(tile_spec) - 1:
+            data = buffer.reshape((shape))
+    else:
         if axis == 2:
-            buffer = tile(buffer, tuple(tile_spec))
+            data = tile(buffer, tuple(tile_spec))
         elif axis == 1:
             x = repeat(buffer[np.newaxis, :], shape[0], axis=0)
-            buffer = repeat(x[:, :, np.newaxis], shape[2], axis=2)
+            data = repeat(x[:, :, np.newaxis], shape[2], axis=2)
         else:
             y = repeat(buffer[:, np.newaxis], shape[1], axis=1)
-            buffer = repeat(y[:, :, np.newaxis], shape[2], axis=2)
-    elif axis == 1:
-        buffer = buffer.reshape((1, buffer.shape[0]))
-
-    return buffer
+            data = repeat(y[:, :, np.newaxis], shape[2], axis=2)
+    return data
 
 
 def _make_storage_data_2d(
@@ -195,34 +174,27 @@ def _make_storage_data_2d(
     start: Tuple[int, int, int] = (0, 0, 0),
     dummy: Optional[Tuple[int, int, int]] = None,
     axis: int = 2,
-    read_only: bool = True,
 ) -> Field:
     # axis refers to which axis should be repeated (when making a full 3d data),
     # dummy refers to a singleton axis
-    do_reshape = dummy or axis != 2
-    if do_reshape:
+    isize, jsize = data.shape
+    istart, jstart = start[0:2]
+    if dummy or axis != 2:
         d_axis = dummy[0] if dummy else axis
         shape2d = shape[:d_axis] + shape[d_axis + 1 :]
-        start2d = start[:d_axis] + start[d_axis + 1 :]
     else:
         shape2d = shape[0:2]
-        start2d = start[0:2]
-
-    start1, start2 = start[0:2]
-    size1, size2 = data.shape
     buffer = zeros(shape2d)
-    buffer[start1 : start1 + size1, start2 : start2 + size2] = asarray(
+    buffer[istart : istart + isize, jstart : jstart + jsize] = asarray(
         data, type(buffer)
     )
-
-    if not read_only:
-        buffer = repeat(buffer[:, :, np.newaxis], shape[axis], axis=2)
+    if dummy:
+        data = buffer.reshape(shape)
+    else:
+        data = repeat(buffer[:, :, np.newaxis], shape[axis], axis=2)
         if axis != 2:
-            buffer = moveaxis(buffer, 2, axis)
-    elif do_reshape:
-        buffer = buffer.reshape(shape)
-
-    return buffer
+            data = moveaxis(data, 2, axis)
+    return data
 
 
 def _make_storage_data_3d(
@@ -344,14 +316,11 @@ def make_storage_from_shape(
     )
     caller_signature = tuple((caller.filename, caller.lineno) for caller in callers)
     key = (args, caller_signature, tuple(sorted(list(kwargs.items()))))
-    if key in storage_shape_outputs:
-        return_value = storage_shape_outputs[key]
-        if kwargs.get("init", False):
-            return_value[:] = 0.0
-    else:
-        return_value = make_storage_from_shape_uncached(*args, **kwargs)
-        storage_shape_outputs[key] = return_value
-
+    if key not in storage_shape_outputs:
+        storage_shape_outputs[key] = make_storage_from_shape_uncached(*args, **kwargs)
+    return_value = storage_shape_outputs[key]
+    if kwargs.get("init", False):
+        return_value[:] = 0.0
     return return_value
 
 
@@ -363,7 +332,7 @@ def make_storage_dict(
     dummy: Optional[Tuple[int, int, int]] = None,
     names: Optional[List[str]] = None,
     axis: int = 2,
-) -> Dict[str, "Field"]:
+) -> Dict[str, type(Field)]:
     assert names is not None, "for 4d variable storages, specify a list of names"
     if shape is None:
         shape = data.shape
@@ -378,27 +347,6 @@ def make_storage_dict(
             axis=axis,
         )
     return data_dict
-
-
-# def k_slice_operation(key, value, ki, dictionary):
-#     if isinstance(value, gt_storage.storage.Storage):
-#         shape = value.shape
-#         mask = dictionary[key].mask if key in dictionary else (True, True, True)
-#         if len(shape) == 1:  # K-field
-#             if mask[2]:
-#                 shape = (1, 1, len(ki))
-#                 dictionary[key] = make_storage_data(value[ki], shape, read_only=True)
-#         elif len(shape) == 2:  # IK-field
-#             if not mask[1]:
-#                 dictionary[key] = make_storage_data(
-#                     value[:, ki], (shape[0], 1, len(ki)), read_only=True
-#                 )
-#         else:  # IJK-field
-#             dictionary[key] = make_storage_data(
-#                 value[:, :, ki], (shape[0], shape[1], len(ki)), read_only=True
-#             )
-#     else:
-#         dictionary[key] = value
 
 
 def storage_dict(st_dict, names, shape, origin):
@@ -495,13 +443,13 @@ def asarray(array, to_type=np.ndarray, dtype=None, order=None):
             return cp.asarray(array, dtype, order)
 
 
-def zeros(shape, dtype=Float):
+def zeros(shape, dtype=float_type):
     storage_type = cp.ndarray if "cuda" in global_config.get_backend() else np.ndarray
     xp = cp if cp and storage_type is cp.ndarray else np
     return xp.zeros(shape)
 
 
-def sum(array, axis=None, dtype=Float, out=None, keepdims=False):
+def sum(array, axis=None, dtype=float_type, out=None, keepdims=False):
     if isinstance(array, gt_storage.storage.Storage):
         array = array.data
     xp = cp if cp and type(array) is cp.ndarray else np
@@ -538,42 +486,3 @@ def squeeze(array, axis: Union[int, Tuple[int]] = None):
         array = array.data
     xp = cp if cp and type(array) is cp.ndarray else np
     return xp.squeeze(array, axis)
-
-
-def reshape(array, new_shape: Tuple[int]):
-    if array.shape != new_shape:
-        old_dims = len(array.shape)
-        new_dims = len(new_shape)
-        if old_dims < new_dims:
-            # Upcast using repeat...
-            if old_dims == 2:  # IJ -> IJK
-                return repeat(array[:, :, np.newaxis], new_shape[2], axis=2)
-            else:  # K -> IJK
-                arr_2d = repeat(array[:, np.newaxis], new_shape[1], axis=1)
-                return repeat(arr_2d[:, :, np.newaxis], new_shape[2], axis=2)
-        else:
-            return array.reshape(new_shape)
-    return array
-
-
-def unique(
-    array,
-    return_index: bool = False,
-    return_inverse: bool = False,
-    return_counts: bool = False,
-    axis: Union[int, Tuple[int]] = None,
-):
-    if isinstance(array, gt_storage.storage.Storage):
-        array = array.data
-    xp = cp if cp and type(array) is cp.ndarray else np
-    return xp.unique(array, return_index, return_inverse, return_counts, axis)
-
-
-def stack(tup, axis: int = 0, out=None):
-    array_tup = []
-    for array in tup:
-        if isinstance(array, gt_storage.storage.Storage):
-            array = array.data
-        array_tup.append(array)
-    xp = cp if cp and type(array_tup[0]) is cp.ndarray else np
-    return xp.stack(array_tup, axis, out)

--- a/fv3core/utils/typing.py
+++ b/fv3core/utils/typing.py
@@ -21,9 +21,9 @@ K = gtscript.K  # noqa: E741
 DTypes = Union[bool, np.bool, int, np.int32, np.int64, float, np.float32, np.float64]
 
 # Default float and int types
-Float = np.float_
-Int = np.int_
-Bool = np.bool_
+float_type = np.float_
+int_type = np.int_
+bool_type = np.bool_
 
 
 class _FieldDescriptor:
@@ -38,12 +38,10 @@ def _FieldDescriptorMaker(dtype):
     return _FieldDescriptor(dtype)
 
 
-FloatField = Field[Float]
-FloatFieldI = Field[Float, gtscript.I]
-FloatFieldIJ = Field[Float, gtscript.IJ]
-FloatFieldK = Field[Float, gtscript.K]
-IntField = Field[Int]
-IntFieldIJ = Field[Int, gtscript.IJ]
-BoolField = _FieldDescriptor(Bool)
+FloatField = Field[float_type]
+FloatFieldIJ = Field[float_type, gtscript.IJ]
+IntField = Field[int_type]
+IntFieldIJ = Field[int_type, gtscript.IJ]
+BoolField = _FieldDescriptor(bool_type)
 
 Index3D = Tuple[int, int, int]

--- a/tests/translate/translate_c_sw.py
+++ b/tests/translate/translate_c_sw.py
@@ -121,7 +121,6 @@ class TranslateDivergenceCorner(TranslateFortranData2Py):
             domain=self.grid.domain_shape_compute(add=(1, 1, 0)),
         )
         return self.slice_output({"divg_d": inputs["divg_d"]})
-        return self.slice_output({"divg_d": inputs["divg_d"]})
 
 
 class TranslateCirculation_Cgrid(TranslateFortranData2Py):

--- a/tests/translate/translate_corners.py
+++ b/tests/translate/translate_corners.py
@@ -1,4 +1,5 @@
-import fv3core.utils.gt4py_utils as utils
+import numpy as np
+
 from fv3core.testing import TranslateFortranData2Py
 from fv3core.utils import corners
 
@@ -24,8 +25,8 @@ class TranslateFillCorners(TranslateFortranData2Py):
         self.out_vars = {"divg_d": {"iend": grid.ied + 1, "jend": grid.jed + 1}}
 
     def compute_from_storage(self, inputs):
-        nord_column = inputs["nord_col"][:]
-        for nord in utils.unique(nord_column):
+        nord_column = inputs["nord_col"].data[0, 0, :]
+        for nord in np.unique(nord_column):
             if nord != 0:
                 ki = [i for i in range(self.grid.npz) if nord_column[i] == nord]
                 if inputs["dir"] == 1:
@@ -77,11 +78,11 @@ class TranslateFillCornersVector(TranslateFortranData2Py):
         self.out_vars = {"vc": grid.y3d_domain_dict(), "uc": grid.x3d_domain_dict()}
 
     def compute(self, inputs):
-        nord_column = inputs["nord_col"][:]
+        nord_column = inputs["nord_col"][0, 0, :]
         self.make_storage_data_input_vars(inputs)
-        for nord in utils.unique(nord_column):
+        for nord in np.unique(nord_column):
             if nord != 0:
-                ki = [k for k in range(self.grid.npz) if nord_column[0, 0, k] == nord]
+                ki = [i for i in range(self.grid.npz) if nord_column[i] == nord]
                 corners.fill_corners_dgrid(
                     inputs["vc"],
                     inputs["uc"],

--- a/tests/translate/translate_d_sw.py
+++ b/tests/translate/translate_d_sw.py
@@ -3,7 +3,7 @@ from gt4py.gtscript import PARALLEL, computation, interval
 from fv3core.decorators import gtstencil
 from fv3core.stencils import d_sw
 from fv3core.testing import TranslateFortranData2Py
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+from fv3core.utils.typing import FloatField
 
 
 class TranslateD_SW(TranslateFortranData2Py):
@@ -72,8 +72,8 @@ class TranslateUbKE(TranslateFortranData2Py):
     def ubke(
         uc: FloatField,
         vc: FloatField,
-        cosa: FloatFieldIJ,
-        rsina: FloatFieldIJ,
+        cosa: FloatField,
+        rsina: FloatField,
         ut: FloatField,
         ub: FloatField,
         dt4: float,
@@ -110,8 +110,8 @@ class TranslateVbKE(TranslateFortranData2Py):
     def vbke(
         vc: FloatField,
         uc: FloatField,
-        cosa: FloatFieldIJ,
-        rsina: FloatFieldIJ,
+        cosa: FloatField,
+        rsina: FloatField,
         vt: FloatField,
         vb: FloatField,
         dt4: float,

--- a/tests/translate/translate_dyncore.py
+++ b/tests/translate/translate_dyncore.py
@@ -101,14 +101,12 @@ class TranslateDynCore(ParallelTranslate2PyState):
             "n_map",
             "ks",
         ]
-
         self._base.out_vars = {}
+
         for v, d in self._base.in_vars["data_vars"].items():
             self._base.out_vars[v] = d
-
         del self._base.out_vars["ak"]
         del self._base.out_vars["bk"]
-        del self._base.out_vars["pfull"]
 
         # TODO: Fix edge_interpolate4 in d2a2c_vect to match closer and the
         # variables here should as well.

--- a/tests/translate/translate_last_step.py
+++ b/tests/translate/translate_last_step.py
@@ -15,12 +15,7 @@ class TranslateLastStep(TranslateFortranData2Py):
             "qgraupel": {},
             "pt": {},
             "pkz": {"istart": grid.is_, "jstart": grid.js},
-            "gz": {
-                "serialname": "gz1d",
-                "kstart": grid.is_,
-                "axis": 0,
-                "full_shape": True,
-            },
+            "gz": {"serialname": "gz1d", "kstart": grid.is_, "axis": 0},
         }
         self.in_vars["parameters"] = ["r_vir", "dtmp"]
         self.out_vars = {
@@ -35,4 +30,3 @@ class TranslateLastStep(TranslateFortranData2Py):
             },
             "pt": {},
         }
-        self.write_vars = ["gz"]

--- a/tests/translate/translate_map1_ppm_2d.py
+++ b/tests/translate/translate_map1_ppm_2d.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import fv3core.stencils.map_single as map_single
+import fv3core.stencils.map_single as Map_Single
 from fv3core.testing import TranslateFortranData2Py, TranslateGrid
 
 
@@ -26,7 +26,7 @@ class TranslateSingleJ(TranslateFortranData2Py):
 class TranslateMap1_PPM_2d(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = map_single.compute
+        self.compute_func = Map_Single.compute
         self.in_vars["data_vars"] = {
             "q1": {"serialname": "var_in"},
             "pe1": {"istart": 3, "iend": grid.ie - 2, "axis": 1},
@@ -36,7 +36,6 @@ class TranslateMap1_PPM_2d(TranslateFortranData2Py):
         self.in_vars["parameters"] = ["j_2d", "i1", "i2", "mode", "kord"]
         self.out_vars = {"var_inout": {}}
         self.max_error = 5e-13
-        self.write_vars = ["qs"]
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)

--- a/tests/translate/translate_map_scalar_2d.py
+++ b/tests/translate/translate_map_scalar_2d.py
@@ -28,7 +28,6 @@ class TranslateMapScalar_2d(TranslateFortranData2Py):
         self.out_vars = {"pt": {}}
         self.is_ = grid.is_
         self.ie = grid.ie
-        self.write_vars = ["qs"]
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)

--- a/tests/translate/translate_moistcvpluspkz_2d.py
+++ b/tests/translate/translate_moistcvpluspkz_2d.py
@@ -22,9 +22,8 @@ class TranslateMoistCVPlusPkz_2d(TranslateFortranData2Py):
             "pt": {},
             "cappa": {},
         }
-        self.write_vars = ["gz", "cvm"]
         for k, v in self.in_vars["data_vars"].items():
-            if k not in self.write_vars:
+            if k not in ["gz", "cvm"]:
                 v["axis"] = 1
 
         self.in_vars["parameters"] = ["r_vir", "j_2d"]
@@ -58,4 +57,6 @@ class TranslateMoistCVPlusPkz_2d(TranslateFortranData2Py):
             inputs["j_2d"] + TranslateGrid.fpy_model_index_offset
         )
         self.compute_func(**inputs)
+        for var in ["gz", "cvm"]:
+            inputs[var] = inputs[var][:, inputs["j_2d"] : inputs["j_2d"] + 1, :]
         return self.slice_output(inputs)

--- a/tests/translate/translate_moistcvpluspt_2d.py
+++ b/tests/translate/translate_moistcvpluspt_2d.py
@@ -21,9 +21,8 @@ class TranslateMoistCVPlusPt_2d(TranslateFortranData2Py):
             "pt": {},
             "cappa": {},
         }
-        self.write_vars = ["gz", "cvm"]
         for k, v in self.in_vars["data_vars"].items():
-            if k not in self.write_vars:
+            if k not in ["gz", "cvm"]:
                 v["axis"] = 1
 
         self.in_vars["parameters"] = ["r_vir", "j_2d"]
@@ -52,4 +51,6 @@ class TranslateMoistCVPlusPt_2d(TranslateFortranData2Py):
             inputs["j_2d"] + TranslateGrid.fpy_model_index_offset
         )
         self.compute_func(**inputs)
+        for var in ["gz", "cvm"]:
+            inputs[var] = inputs[var][:, inputs["j_2d"] : inputs["j_2d"] + 1, :]
         return self.slice_output(inputs)

--- a/tests/translate/translate_qsinit.py
+++ b/tests/translate/translate_qsinit.py
@@ -18,13 +18,11 @@ class TranslateQSInit(TranslateFortranData2Py):
         }
         self.out_vars = self.in_vars["data_vars"]
         self.maxshape = (1, 1, satadjust.QS_LENGTH)
-        self.write_vars = list(self.in_vars["data_vars"].keys())
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
-        index = np.arange(satadjust.QS_LENGTH)
         inputs["index"] = utils.make_storage_data(
-            index, self.maxshape, origin=(0, 0, 0), read_only=False
+            np.arange(satadjust.QS_LENGTH), self.maxshape, origin=(0, 0, 0)
         )
         kwargs = {"origin": (0, 0, 0), "domain": self.maxshape}
         self.compute_func(**inputs, **kwargs)

--- a/tests/translate/translate_remap_profile_2d.py
+++ b/tests/translate/translate_remap_profile_2d.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import fv3core.stencils.remap_profile as profile
+import fv3core.stencils.remap_profile as Profile
 import fv3core.utils.gt4py_utils as utils
 from fv3core.testing import TranslateFortranData2Py
 
@@ -8,7 +8,7 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateCS_Profile_2d(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = profile.compute
+        self.compute_func = Profile.compute
         self.in_vars["data_vars"] = {
             "a4_1": {"serialname": "q4_1"},
             "a4_2": {"serialname": "q4_2"},
@@ -24,7 +24,6 @@ class TranslateCS_Profile_2d(TranslateFortranData2Py):
             "a4_4": {"serialname": "q4_4", "istart": 0, "iend": grid.ie - 2},
         }
         self.ignore_near_zero_errors = {"q4_4": True}
-        self.write_vars = ["qs"]
 
     def make_storage_data_input_vars(self, inputs, storage_vars=None):
         if storage_vars is None:
@@ -38,13 +37,23 @@ class TranslateCS_Profile_2d(TranslateFortranData2Py):
             istart, jstart, kstart = self.collect_start_indices(
                 inputs[serialname].shape, info
             )
+
+            shapes = np.squeeze(inputs[serialname]).shape
+            if len(shapes) == 2:
+                # suppress j
+                dummy_axes = [1]
+            elif len(shapes) == 1:
+                # suppress j and k
+                dummy_axes = [1, 2]
+            else:
+                dummy_axes = None
+
             inputs[d] = self.make_storage_data(
                 np.squeeze(inputs[serialname]),
                 istart=istart,
                 jstart=jstart,
                 kstart=kstart,
-                axis=len(inputs[serialname].shape) - 1,
-                read_only=d not in self.write_vars,
+                dummy_axes=dummy_axes,
             )
             if d != serialname:
                 del inputs[serialname]
@@ -73,7 +82,7 @@ class TranslateCS_Profile_2d(TranslateFortranData2Py):
 class TranslateCS_Profile_2d_2(TranslateCS_Profile_2d):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = profile.compute
+        self.compute_func = Profile.compute
         self.in_vars["data_vars"] = {
             "qs": {"serialname": "qs_column_2", "kstart": 0, "kend": grid.npz},
             "a4_1": {"serialname": "q4_1_2"},

--- a/tests/translate/translate_remapping.py
+++ b/tests/translate/translate_remapping.py
@@ -79,7 +79,6 @@ class TranslateRemapping(TranslateFortranData2Py):
             "nq",
         ]
         self.out_vars = {}
-        self.write_vars = ["wsd"]
         for k in [
             "pe",
             "pkz",

--- a/tests/translate/translate_remapping_part1.py
+++ b/tests/translate/translate_remapping_part1.py
@@ -54,17 +54,11 @@ class TranslateRemapping_Part1(TranslateFortranData2Py):
             # column variables...
             "ak": {},
             "bk": {},
-            "gz": {
-                "serialname": "gz1d",
-                "kstart": grid.is_,
-                "axis": 0,
-                "full_shape": True,
-            },
-            "cvm": {"kstart": grid.is_, "axis": 0, "full_shape": True},
+            "gz": {"serialname": "gz1d", "kstart": grid.is_, "axis": 0},
+            "cvm": {"kstart": grid.is_, "axis": 0},
         }
         self.in_vars["parameters"] = ["ptop", "akap", "r_vir", "nq"]
         self.out_vars = {}
-        self.write_vars = ["gz", "cvm", "wsd"]
         for k in [
             "pe",
             "pkz",

--- a/tests/translate/translate_remapping_part2.py
+++ b/tests/translate/translate_remapping_part2.py
@@ -23,13 +23,8 @@ class TranslateRemapping_Part2(TranslateFortranData2Py):
             "delp": {},
             "cappa": {},
             "q_con": {},
-            "gz": {
-                "serialname": "gz1d",
-                "kstart": grid.is_,
-                "axis": 0,
-                "full_shape": True,
-            },
-            "cvm": {"kstart": grid.is_, "axis": 0, "full_shape": True},
+            "gz": {"serialname": "gz1d", "kstart": grid.is_, "axis": 0},
+            "cvm": {"kstart": grid.is_, "axis": 0},
             "pkz": grid.compute_dict(),
             "pk": {
                 "istart": grid.is_,
@@ -56,6 +51,14 @@ class TranslateRemapping_Part2(TranslateFortranData2Py):
             },
             "hs": {},
             "pfull": {},
+            "te_2d": {
+                "istart": grid.is_,
+                "iend": grid.ie,
+                "jstart": grid.js,
+                "jend": grid.je,
+                "kstart": grid.npz - 1,
+                "kend": grid.npz - 1,
+            },
             "te0_2d": {
                 "istart": grid.is_,
                 "iend": grid.ie,
@@ -65,6 +68,14 @@ class TranslateRemapping_Part2(TranslateFortranData2Py):
                 "kend": grid.npz - 1,
             },
             "te": {},
+            "zsum1": {
+                "istart": grid.is_,
+                "jstart": grid.js,
+                "iend": grid.ie,
+                "jend": grid.je,
+                "kstart": grid.npz - 1,
+                "kend": grid.npz - 1,
+            },
         }
         self.in_vars["parameters"] = [
             "ptop",
@@ -95,8 +106,9 @@ class TranslateRemapping_Part2(TranslateFortranData2Py):
             "delz",
             "q_con",
             "te",
+            "te_2d",
             "te0_2d",
+            "zsum1",
         ]:
             self.out_vars[k] = self.in_vars["data_vars"][k]
         self.max_error = 2e-14
-        self.write_vars = ["gz", "cvm"]

--- a/tests/translate/translate_updatedzd.py
+++ b/tests/translate/translate_updatedzd.py
@@ -29,5 +29,7 @@ class TranslateUpdateDzD(TranslateFortranData2Py):
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
+        inputs["ndif"] = inputs["ndif"][0, 0, :]
+        inputs["damp_vtd"] = inputs["damp_vtd"][0, 0, :]
         self.compute_func(**inputs)
         return self.slice_output(inputs)


### PR DESCRIPTION
## Purpose
This reverts commit 415cfb9356a6c9cea697c6cea70989865eb2ca3b that introduced using lower dimensional storages throughout the dycore. (#269)

We really don't want to do this, but are blocked on merging other code after this one went in as gt backend tests no longer pass (though they did for this PR), and haven't been able to get gt backend timing updates on the impact of that branch. Opening a PR  to see if reverting works to unblock other code in flight. 