### PR TITLE
YTP_V and XTP_U are classes

### DIFF
--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -828,8 +828,8 @@ def d_sw(
         origin=grid().compute_origin(),
         domain=grid().domain_shape_compute(add=(1, 1, 0)),
     )
-
-    ytp_v.compute(vb, v, ub)
+    ytp_v_obj = ytp_v.YTP_V(spec.namelist)
+    ytp_v_obj(vb, v, ub)
 
     mult_ubke(
         vb,
@@ -845,8 +845,8 @@ def d_sw(
         origin=grid().compute_origin(),
         domain=grid().domain_shape_compute(add=(1, 1, 0)),
     )
-
-    xtp_u.compute(ub, u, vb)
+    xtp_u_obj = xtp_u.XTP_U(spec.namelist)
+    xtp_u_obj(ub, u, vb)
 
     ke_horizontal_vorticity(
         ke,

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -17,12 +17,12 @@ import fv3core.stencils.divergence_damping as divdamp
 import fv3core.stencils.flux_capacitor as fluxcap
 import fv3core.stencils.fvtp2d as fvtp2d
 import fv3core.stencils.fxadv as fxadv
-import fv3core.stencils.xtp_u as xtp_u
-import fv3core.stencils.ytp_v as ytp_v
 import fv3core.utils.corners as corners
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
+from fv3core.stencils.xtp_u import XTP_U
+from fv3core.stencils.ytp_v import YTP_V
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -828,7 +828,7 @@ def d_sw(
         origin=grid().compute_origin(),
         domain=grid().domain_shape_compute(add=(1, 1, 0)),
     )
-    ytp_v_obj = ytp_v.YTP_V(spec.namelist)
+    ytp_v_obj = utils.cached_stencil_class(YTP_V)(spec.namelist, cache_key="ytp_v")
     ytp_v_obj(vb, v, ub)
 
     mult_ubke(
@@ -845,7 +845,7 @@ def d_sw(
         origin=grid().compute_origin(),
         domain=grid().domain_shape_compute(add=(1, 1, 0)),
     )
-    xtp_u_obj = xtp_u.XTP_U(spec.namelist)
+    xtp_u_obj = utils.cached_stencil_class(XTP_U)(spec.namelist, cache_key="xtp_u")
     xtp_u_obj(ub, u, vb)
 
     ke_horizontal_vorticity(

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -129,14 +129,11 @@ class XTP_U:
             raise NotImplementedError(
                 "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
             )
-        grid = spec.grid
-        self.origin = grid.compute_origin()
-        self.domain = grid.domain_shape_compute(add=(1, 1, 0))
-        ax_offsets = axis_offsets(spec.grid, self.origin, self.domain)
+        self.grid = spec.grid
+        self.origin = self.grid.compute_origin()
+        self.domain = self.grid.domain_shape_compute(add=(1, 1, 0))
+        ax_offsets = axis_offsets(self.grid, self.origin, self.domain)
         assert namelist.grid_type < 3
-        self.dxa = grid.dxa
-        self.dx = grid.dx
-        self.rdx = grid.rdx
         self.stencil = gtscript.stencil(
             definition=_compute_stencil,
             externals={
@@ -162,9 +159,9 @@ class XTP_U:
             c,
             u,
             flux,
-            self.dx,
-            self.dxa,
-            self.rdx,
+            self.grid.dx,
+            self.grid.dxa,
+            self.grid.rdx,
             origin=self.origin,
             domain=self.domain,
         )

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -153,7 +153,7 @@ class XTP_U:
         Args:
             c (in): Courant number in flux form
             u (in): x-dir wind on D-grid
-           flux (out): Flux of kinetic energy
+            flux (out): Flux of kinetic energy
         """
         self.stencil(
             c,

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -131,7 +131,7 @@ class XTP_U:
             )
         grid = spec.grid
         self.origin = grid.compute_origin()
-        self.domain = grid.domain_shape_compute(add=(1, 1, 1))
+        self.domain = grid.domain_shape_compute(add=(1, 1, 0))
         ax_offsets = axis_offsets(spec.grid, self.origin, self.domain)
         assert namelist.grid_type < 3
         self.dxa = grid.dxa

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -129,10 +129,13 @@ class XTP_U:
             raise NotImplementedError(
                 "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
             )
-        self.grid = spec.grid
-        self.origin = self.grid.compute_origin()
-        self.domain = self.grid.domain_shape_compute(add=(1, 1, 0))
-        ax_offsets = axis_offsets(self.grid, self.origin, self.domain)
+        grid = spec.grid
+        self.origin = grid.compute_origin()
+        self.domain = grid.domain_shape_compute(add=(1, 1, 0))
+        self.dx = grid.dx
+        self.dxa = grid.dxa
+        self.rdx = grid.rdx
+        ax_offsets = axis_offsets(grid, self.origin, self.domain)
         assert namelist.grid_type < 3
         self.stencil = gtscript.stencil(
             definition=_compute_stencil,
@@ -159,9 +162,9 @@ class XTP_U:
             c,
             u,
             flux,
-            self.grid.dx,
-            self.grid.dxa,
-            self.grid.rdx,
+            self.dx,
+            self.dxa,
+            self.rdx,
             origin=self.origin,
             domain=self.domain,
         )

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -9,8 +9,9 @@ from gt4py.gtscript import (
 )
 
 import fv3core._config as spec
-from fv3core.decorators import gtstencil
+import fv3core.utils.global_config as global_config
 from fv3core.stencils import xppm, yppm
+from fv3core.utils.grid import axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -58,7 +59,7 @@ def _compute_stencil(
     dxa: FloatFieldIJ,
     rdx: FloatFieldIJ,
 ):
-    from __externals__ import i_end, i_start, iord, j_end, j_start, namelist
+    from __externals__ import i_end, i_start, iord, j_end, j_start
 
     with computation(PARALLEL), interval(...):
 
@@ -86,8 +87,6 @@ def _compute_stencil(
             # {
             bl, br = xppm.blbr_iord8(u, al, dm)
             # }
-
-            assert __INLINED(namelist.grid_type < 3)
             # {
             with horizontal(region[i_start - 1, :]):
                 bl, br = xppm.west_edge_iord8plus_0(u, dxa, dm)
@@ -123,37 +122,49 @@ def _compute_stencil(
         flux = _get_flux(u, courant, rdx, bl, br)
 
 
-def compute(c: FloatField, u: FloatField, flux: FloatField):
-    """
-    Compute flux of kinetic energy in x-dir.
-
-    Args:
-        c (in): Courant number in flux form
-        u (in): x-dir wind on D-grid
-        flux (out): Flux of kinetic energy
-    """
-    grid = spec.grid
-    iord = spec.namelist.hord_mt
-    if iord not in (5, 6, 7, 8):
-        raise NotImplementedError(
-            "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
+class XTP_U:
+    def __init__(self, namelist):
+        iord = spec.namelist.hord_mt
+        if iord not in (5, 6, 7, 8):
+            raise NotImplementedError(
+                "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
+            )
+        grid = spec.grid
+        self.origin = grid.compute_origin()
+        self.domain = grid.domain_shape_compute(add=(1, 1, 1))
+        ax_offsets = axis_offsets(spec.grid, self.origin, self.domain)
+        assert namelist.grid_type < 3
+        self.dxa = grid.dxa
+        self.dx = grid.dx
+        self.rdx = grid.rdx
+        self.stencil = gtscript.stencil(
+            definition=_compute_stencil,
+            externals={
+                "iord": iord,
+                "mord": iord,
+                "xt_minmax": False,
+                **ax_offsets,
+            },
+            backend=global_config.get_backend(),
+            rebuild=global_config.get_rebuild(),
         )
 
-    stencil = gtstencil(
-        definition=_compute_stencil,
-        externals={
-            "iord": iord,
-            "mord": iord,
-            "xt_minmax": False,
-        },
-    )
-    stencil(
-        c,
-        u,
-        flux,
-        grid.dx,
-        grid.dxa,
-        grid.rdx,
-        origin=grid.compute_origin(),
-        domain=grid.domain_shape_compute(add=(1, 1, 0)),
-    )
+    def __call__(self, c: FloatField, u: FloatField, flux: FloatField):
+        """
+        Compute flux of kinetic energy in x-dir.
+
+        Args:
+            c (in): Courant number in flux form
+            u (in): x-dir wind on D-grid
+           flux (out): Flux of kinetic energy
+        """
+        self.stencil(
+            c,
+            u,
+            flux,
+            self.dx,
+            self.dxa,
+            self.rdx,
+            origin=self.origin,
+            domain=self.domain,
+        )

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -127,14 +127,11 @@ class YTP_V:
             raise NotImplementedError(
                 "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
             )
-        grid = spec.grid
-        self.origin = grid.compute_origin()
-        self.domain = grid.domain_shape_compute(add=(1, 1, 0))
-        ax_offsets = axis_offsets(spec.grid, self.origin, self.domain)
+        self.grid = spec.grid
+        self.origin = self.grid.compute_origin()
+        self.domain = self.grid.domain_shape_compute(add=(1, 1, 0))
+        ax_offsets = axis_offsets(self.grid, self.origin, self.domain)
         assert namelist.grid_type < 3
-        self.dya = grid.dya
-        self.dy = grid.dy
-        self.rdy = grid.rdy
         self.stencil = gtscript.stencil(
             definition=_compute_stencil,
             externals={
@@ -161,9 +158,9 @@ class YTP_V:
             c,
             v,
             flux,
-            self.dy,
-            self.dya,
-            self.rdy,
+            self.grid.dy,
+            self.grid.dya,
+            self.grid.rdy,
             origin=self.origin,
             domain=self.domain,
         )

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -127,10 +127,13 @@ class YTP_V:
             raise NotImplementedError(
                 "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
             )
-        self.grid = spec.grid
-        self.origin = self.grid.compute_origin()
-        self.domain = self.grid.domain_shape_compute(add=(1, 1, 0))
-        ax_offsets = axis_offsets(self.grid, self.origin, self.domain)
+        grid = spec.grid
+        self.origin = grid.compute_origin()
+        self.domain = grid.domain_shape_compute(add=(1, 1, 0))
+        self.dy = grid.dy
+        self.dya = grid.dya
+        self.rdy = grid.rdy
+        ax_offsets = axis_offsets(grid, self.origin, self.domain)
         assert namelist.grid_type < 3
         self.stencil = gtscript.stencil(
             definition=_compute_stencil,
@@ -158,9 +161,9 @@ class YTP_V:
             c,
             v,
             flux,
-            self.grid.dy,
-            self.grid.dya,
-            self.grid.rdy,
+            self.dy,
+            self.dya,
+            self.rdy,
             origin=self.origin,
             domain=self.domain,
         )

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -9,8 +9,9 @@ from gt4py.gtscript import (
 )
 
 import fv3core._config as spec
-from fv3core.decorators import gtstencil
+import fv3core.utils.global_config as global_config
 from fv3core.stencils import yppm
+from fv3core.utils.grid import axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -56,7 +57,7 @@ def _compute_stencil(
     dya: FloatFieldIJ,
     rdy: FloatFieldIJ,
 ):
-    from __externals__ import i_end, i_start, j_end, j_start, jord, namelist
+    from __externals__ import i_end, i_start, j_end, j_start, jord
 
     with computation(PARALLEL), interval(...):
 
@@ -84,8 +85,6 @@ def _compute_stencil(
             # {
             bl, br = yppm.blbr_jord8(v, al, dm)
             # }
-
-            assert __INLINED(namelist.grid_type < 3)
             # {
             with horizontal(region[:, j_start - 1]):
                 bl, br = yppm.south_edge_jord8plus_0(v, dy, dm)
@@ -121,37 +120,50 @@ def _compute_stencil(
         flux = _get_flux(v, courant, rdy, bl, br)
 
 
-def compute(c: FloatField, v: FloatField, flux: FloatField):
-    """
-    Compute flux of kinetic energy in y-dir.
+class YTP_V:
+    def __init__(self, namelist):
+        jord = spec.namelist.hord_mt
+        if jord not in (5, 6, 7, 8):
+            raise NotImplementedError(
+                "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
+            )
+        grid = spec.grid
+        self.origin = grid.compute_origin()
+        self.domain = grid.domain_shape_compute(add=(1, 1, 0))
+        ax_offsets = axis_offsets(spec.grid, self.origin, self.domain)
+        assert namelist.grid_type < 3
+        self.dya = grid.dya
+        self.dy = grid.dy
+        self.rdy = grid.rdy
+        self.stencil = gtscript.stencil(
+            definition=_compute_stencil,
+            externals={
+                "jord": jord,
+                "mord": jord,
+                "xt_minmax": False,
+                **ax_offsets,
+            },
+            backend=global_config.get_backend(),
+            rebuild=global_config.get_rebuild(),
+        )
 
-    Args:
+    def __call__(self, c: FloatField, v: FloatField, flux: FloatField):
+        """
+        Compute flux of kinetic energy in y-dir.
+
+        Args:
         c (in): Courant number in flux form
         v (in): y-dir wind on Arakawa D-grid
         flux (out): Flux of kinetic energy
-    """
-    grid = spec.grid
-    jord = spec.namelist.hord_mt
-    if jord not in (5, 6, 7, 8):
-        raise NotImplementedError(
-            "Currently ytp_v is only supported for hord_mt == 5,6,7,8"
-        )
+        """
 
-    stencil = gtstencil(
-        definition=_compute_stencil,
-        externals={
-            "jord": jord,
-            "mord": jord,
-            "xt_minmax": False,
-        },
-    )
-    stencil(
-        c,
-        v,
-        flux,
-        grid.dy,
-        grid.dya,
-        grid.rdy,
-        origin=grid.compute_origin(),
-        domain=grid.domain_shape_compute(add=(1, 1, 0)),
-    )
+        self.stencil(
+            c,
+            v,
+            flux,
+            self.dy,
+            self.dya,
+            self.rdy,
+            origin=self.origin,
+            domain=self.domain,
+        )

--- a/tests/translate/translate_xtp_u.py
+++ b/tests/translate/translate_xtp_u.py
@@ -1,4 +1,5 @@
-import fv3core.stencils.xtp_u as xtpu
+import fv3core._config as spec
+import fv3core.stencils.xtp_u as xtp_u
 
 from .translate_ytp_v import TranslateYTP_V
 
@@ -6,10 +7,11 @@ from .translate_ytp_v import TranslateYTP_V
 class TranslateXTP_U(TranslateYTP_V):
     def __init__(self, grid):
         super().__init__(grid)
+        self.in_vars["data_vars"]["u"] = {}
         self.in_vars["data_vars"]["c"]["serialname"] = "ub"
         self.in_vars["data_vars"]["flux"]["serialname"] = "vb"
 
-    def compute(self, inputs):
-        self.make_storage_data_input_vars(inputs)
-        xtpu.compute(inputs["c"], inputs["u"], inputs["flux"])
-        return self.slice_output(inputs)
+    def compute_from_storage(self, inputs):
+        xtp_obj = xtp_u.XTP_U(spec.namelist)
+        xtp_obj(inputs["c"], inputs["u"], inputs["flux"])
+        return inputs

--- a/tests/translate/translate_ytp_v.py
+++ b/tests/translate/translate_ytp_v.py
@@ -1,4 +1,5 @@
-import fv3core.stencils.ytp_v as ytpv
+import fv3core._config as spec
+import fv3core.stencils.ytp_v as ytp_v
 from fv3core.testing import TranslateFortranData2Py
 
 
@@ -9,11 +10,11 @@ class TranslateYTP_V(TranslateFortranData2Py):
         c_info["serialname"] = "vb"
         flux_info = self.grid.compute_dict_buffer_2d()
         flux_info["serialname"] = "ub"
-        self.in_vars["data_vars"] = {"c": c_info, "u": {}, "v": {}, "flux": flux_info}
+        self.in_vars["data_vars"] = {"c": c_info, "v": {}, "flux": flux_info}
         self.in_vars["parameters"] = []
         self.out_vars = {"flux": flux_info}
 
-    def compute(self, inputs):
-        self.make_storage_data_input_vars(inputs)
-        ytpv.compute(inputs["c"], inputs["v"], inputs["flux"])
-        return self.slice_output(inputs)
+    def compute_from_storage(self, inputs):
+        ytp_obj = ytp_v.YTP_V(spec.namelist)
+        ytp_obj(inputs["c"], inputs["v"], inputs["flux"])
+        return inputs


### PR DESCRIPTION
## Purpose

In our aim to separate compilation from runtime via OOP, YTP_V and XTP_U are now classes and d_sw initializes (memoized) and calls these objects. When D_SW is an object, the initialization will no longer happen in runtime. 
Jira card https://vulcan.atlassian.net/browse/DSL-481


## Code changes:

- xtp_u and ytp_v are both changed to be classes in our OOP framework
- d_sw calls these the new way
- xtp_u and ytp_v test code is updated

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
