### PR TITLE
Update GT4PY_VERSION to v20

### DIFF
--- a/docker/Makefile.image_names
+++ b/docker/Makefile.image_names
@@ -1,7 +1,7 @@
 
 # update this if you need everything to rebuild for backwards-incompatible changes
 VERSION = v0.3.0
-GT4PY_VERSION ?=v17
+GT4PY_VERSION ?=v20
 GCR_URL ?= us.gcr.io/vcm-ml
 CUDA ?= n
 TEST_ARGS ?=-v -s -rsx


### PR DESCRIPTION
## Purpose

This PR updates the GT4Py develop branch version tag from `v17` to `v20`.