### PR TITLE
Feature/set in stencils

### DIFF
--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -55,11 +55,6 @@ def compute(
     # transliterated fortran 3d or 2d validate, not bit-for bit
     tracer_list = [tracers[q] for q in utils.tracer_variables[0:nq]]
     for tracer in tracer_list:
-        # q4_1[:] = tracer[:]
-        # q4_2[:] = 0.0
-        # q4_3[:] = 0.0
-        q4_4[:] = 0.0
-
         set_components(
             tracer,
             q4_1,

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -4,9 +4,24 @@ import fv3core._config as spec
 import fv3core.stencils.fillz as fillz
 import fv3core.stencils.map_single as map_single
 import fv3core.stencils.remap_profile as remap_profile
+from fv3core.decorators import gtstencil
+from gt4py.gtscript import PARALLEL, computation, interval
 import fv3core.utils.gt4py_utils as utils
 from fv3core.utils.typing import FloatField
 
+@gtstencil
+def set_components(
+    tracer: FloatField, 
+    a4_1: FloatField,
+    a4_2: FloatField,
+    a4_3: FloatField,
+    a4_4: FloatField,
+):
+    with computation(PARALLEL), interval(...):
+        a4_1 = tracer
+        a4_2 = 0.0
+        a4_3 = 0.0
+        a4_4 = 0.0
 
 def compute(
     pe1: FloatField,
@@ -37,10 +52,21 @@ def compute(
     # transliterated fortran 3d or 2d validate, not bit-for bit
     tracer_list = [tracers[q] for q in utils.tracer_variables[0:nq]]
     for tracer in tracer_list:
-        q4_1[:] = tracer[:]
-        q4_2[:] = 0.0
-        q4_3[:] = 0.0
+        # q4_1[:] = tracer[:]
+        # q4_2[:] = 0.0
+        # q4_3[:] = 0.0
         q4_4[:] = 0.0
+
+        set_components(
+            tracer,
+            q4_1,
+            q4_2, 
+            q4_3, 
+            q4_4, 
+            origin=(spec.grid.is_, spec.grid.js, 0), 
+            domain=(spec.grid.npx, spec.grid.npy, spec.grid.npz)
+        )
+
         q4_1, q4_2, q4_3, q4_4 = remap_profile.compute(
             qs,
             q4_1,

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -39,6 +39,12 @@ def compute(
     j_2d: Optional[int] = None,
     version: str = "stencil",
 ):
+    domain_compute = (
+        spec.grid.ie - spec.grid.is_ + 1,
+        spec.grid.je - spec.grid.js + 1,
+        spec.grid.npz + 1,
+    )
+
     qs = utils.make_storage_from_shape(pe1.shape, origin=(0, 0, 0))
     (
         dp1,
@@ -62,7 +68,7 @@ def compute(
             q4_3,
             q4_4,
             origin=(spec.grid.is_, spec.grid.js, 0),
-            domain=(spec.grid.npx, spec.grid.npy, spec.grid.npz),
+            domain=domain_compute,
         )
 
         q4_1, q4_2, q4_3, q4_4 = remap_profile.compute(

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -1,17 +1,19 @@
 from typing import Dict, Optional
 
+from gt4py.gtscript import PARALLEL, computation, interval
+
 import fv3core._config as spec
 import fv3core.stencils.fillz as fillz
 import fv3core.stencils.map_single as map_single
 import fv3core.stencils.remap_profile as remap_profile
-from fv3core.decorators import gtstencil
-from gt4py.gtscript import PARALLEL, computation, interval
 import fv3core.utils.gt4py_utils as utils
+from fv3core.decorators import gtstencil
 from fv3core.utils.typing import FloatField
+
 
 @gtstencil
 def set_components(
-    tracer: FloatField, 
+    tracer: FloatField,
     a4_1: FloatField,
     a4_2: FloatField,
     a4_3: FloatField,
@@ -22,6 +24,7 @@ def set_components(
         a4_2 = 0.0
         a4_3 = 0.0
         a4_4 = 0.0
+
 
 def compute(
     pe1: FloatField,
@@ -60,11 +63,11 @@ def compute(
         set_components(
             tracer,
             q4_1,
-            q4_2, 
-            q4_3, 
-            q4_4, 
-            origin=(spec.grid.is_, spec.grid.js, 0), 
-            domain=(spec.grid.npx, spec.grid.npy, spec.grid.npz)
+            q4_2,
+            q4_3,
+            q4_4,
+            origin=(spec.grid.is_, spec.grid.js, 0),
+            domain=(spec.grid.npx, spec.grid.npy, spec.grid.npz),
         )
 
         q4_1, q4_2, q4_3, q4_4 = remap_profile.compute(


### PR DESCRIPTION
## Purpose

Improves performance by setting the initial values of the interpolation parameters inside a stencil rather than in Python code.

## Code changes:

- added a `set_components` stencil to mapn_tracer that sets the initial values of the 4 interpolation fields, rather than doing this in Python.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
