### PR TITLE
Add recent absolute runtime plot

### DIFF
--- a/examples/standalone/benchmarks/perf_plots.json
+++ b/examples/standalone/benchmarks/perf_plots.json
@@ -41,6 +41,28 @@
             "x_axis_label": "Date of benchmark",
             "y_axis_label": "Execution time [s]"
         },
+        "absolute_time_recent": {
+            "backends": [
+                "fortran",
+                "python/gtcuda",
+                "python/gtx86"
+            ],
+            "only_recent": true,
+            "timers": [
+                {
+                    "linestyle": "-o",
+                    "name": "total"
+                },
+                {
+                    "linestyle": "--o",
+                    "name": "initialization"
+                }
+            ],
+            "title": "Performance history of total runtime (last 7 days)",
+            "type": "absolute_time",
+            "x_axis_label": "Date of benchmark",
+            "y_axis_label": "Execution time [s]"
+        },
         "per_timestep": {
             "backends": [
                 "python/gtcuda",
@@ -96,7 +118,7 @@
                     "name": "TracerAdvection"
                 }
             ],
-            "title": "Performance history of components of mainloop",
+            "title": "Performance history of components of mainloop (last 7 days)",
             "type": "per_timestep",
             "x_axis_label": "Date of benchmark",
             "y_axis_label": "Execution time per timestep [s]"


### PR DESCRIPTION
## Purpose

Adaption of plots to add a plot of absolute runtime for the past 7 days as well. Should help us in deciding whether we can increase the number of timesteps.