### PR TITLE
More timesteps for benchmarking in CI

### DIFF
--- a/.jenkins/actions/run_standalone.sh
+++ b/.jenkins/actions/run_standalone.sh
@@ -60,6 +60,9 @@ fi
 if [ ! -d "${BENCHMARK_DIR}" ] ; then
     exitError 1005 ${LINENO} "Benchmark directory ${BENCHMARK_DIR} does not exist"
 fi
+if [ "${SAVE_CACHE}" == "true" ] ; then
+    TIMESTEPS=2
+fi
 
 # echo config
 echo "=== $0 configuration ==========================="

--- a/.jenkins/actions/run_standalone.sh
+++ b/.jenkins/actions/run_standalone.sh
@@ -41,7 +41,7 @@ SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
 DATA_VERSION=`grep 'FORTRAN_SERIALIZED_DATA_VERSION *=' ${ROOT_DIR}/Makefile | cut -d '=' -f 2`
-TIMESTEPS=2
+TIMESTEPS=6
 RANKS=6
 BENCHMARK_DIR=${ROOT_DIR}/examples/standalone/benchmarks
 DATA_DIR="/project/s1053/fv3core_serialized_test_data/${DATA_VERSION}/${experiment}"


### PR DESCRIPTION
## Purpose

Increase the number of timesteps we run for benchmarking in our CI. We can afford this (see [here](https://jenkins.ginko.ch/job/fv3core-performance-plots/lastSuccessfulBuild/slave=daint_submit/artifact/history_absolute_time_recent.png)) and this could help with stabilizing our performance results.

## Code changes:

- `.jenkins/actions/run_standalone.sh`

## Infrastructure changes:

- This will increase the runtime of the performance benchmarking and profiling on Jenkins CI.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes

Additionally, if this PR contains code authored by new contributors:

- [x] The names of all the new contributors have been added to CONTRIBUTORS.md
