### PR TITLE
Patch/nhppgrad

### DIFF
--- a/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/stencils/nh_p_grad.py
@@ -166,10 +166,6 @@ class NonHydrostaticPressureGradient:
         ptk = ptop ** akap
         top_value = ptk  # = peln1 if spec.namelist.use_logp else ptk
 
-        print(pp.shape)
-        print(pk3.shape)
-        print("!!!!!!!!!!!!")
-
         self._set_k0_stencil(
             pp,
             pk3,

--- a/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/stencils/nh_p_grad.py
@@ -115,6 +115,10 @@ class NonHydrostaticPressureGradient:
             grid.domain_shape_full(add=(1, 0, 0)), origin=self.orig
         )
 
+        self.stencil_runtime_args = {
+            "validate_args": global_config.get_validate_args(),
+        }
+
         self._set_k0_stencil = stencil(
             definition=set_k0,
             backend=global_config.get_backend(),
@@ -171,7 +175,12 @@ class NonHydrostaticPressureGradient:
         top_value = ptk  # = peln1 if spec.namelist.use_logp else ptk
 
         self._set_k0_stencil(
-            pp, pk3, top_value, origin=self.orig, domain=self.domain_k1
+            pp,
+            pk3,
+            top_value,
+            origin=self.orig,
+            domain=self.domain_k1,
+            **self.stencil_runtime_args
         )
 
         a2b_ord4.compute(pp, self._tmp_wk1, kstart=1, nk=self.nk, replace=True)
@@ -181,7 +190,11 @@ class NonHydrostaticPressureGradient:
         a2b_ord4.compute(delp, self._tmp_wk1)
 
         self._calc_wk_stencil(
-            pk3, self._tmp_wk, origin=self.orig, domain=self.domain_full_k
+            pk3,
+            self._tmp_wk,
+            origin=self.orig,
+            domain=self.domain_full_k,
+            **self.stencil_runtime_args
         )
 
         self._calc_u_stencil(
@@ -196,6 +209,7 @@ class NonHydrostaticPressureGradient:
             dt,
             origin=self.orig,
             domain=self.u_domain,
+            **self.stencil_runtime_args
         )
 
         self._calc_v_stencil(
@@ -210,5 +224,6 @@ class NonHydrostaticPressureGradient:
             dt,
             origin=self.orig,
             domain=self.v_domain,
+            **self.stencil_runtime_args
         )
         # return u, v, pp, gz, pk3, delp

--- a/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/stencils/nh_p_grad.py
@@ -176,7 +176,7 @@ class NonHydrostaticPressureGradient:
             top_value,
             origin=self.orig,
             domain=self.domain_k1,
-            **self.stencil_runtime_args
+            **self.stencil_runtime_args,
         )
 
         a2b_ord4.compute(pp, self._tmp_wk1, kstart=1, nk=self.nk, replace=True)
@@ -190,7 +190,7 @@ class NonHydrostaticPressureGradient:
             self._tmp_wk,
             origin=self.orig,
             domain=self.domain_full_k,
-            **self.stencil_runtime_args
+            **self.stencil_runtime_args,
         )
 
         self._calc_u_stencil(
@@ -204,7 +204,7 @@ class NonHydrostaticPressureGradient:
             dt,
             origin=self.orig,
             domain=self.u_domain,
-            **self.stencil_runtime_args
+            **self.stencil_runtime_args,
         )
 
         self._calc_v_stencil(
@@ -218,5 +218,5 @@ class NonHydrostaticPressureGradient:
             dt,
             origin=self.orig,
             domain=self.v_domain,
-            **self.stencil_runtime_args
+            **self.stencil_runtime_args,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,7 @@ def generate_parallel_stencil_tests(metafunc):
 def _generate_stencil_tests(metafunc, arg_names, savepoint_cases, get_param):
     param_list = []
     for case in savepoint_cases:
+        fv3core._config.set_grid(case.grid)
         testobj = get_test_class_instance(case.test_name, case.grid)
         max_call_count = min(len(case.input_savepoints), len(case.output_savepoints))
         for i, (savepoint_in, savepoint_out) in enumerate(

--- a/tests/translate/translate_nh_p_grad.py
+++ b/tests/translate/translate_nh_p_grad.py
@@ -5,6 +5,7 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateNH_P_Grad(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
+        self.compute_func = NH_P_Grad.NonHydrostaticPressureGradient()
         self.in_vars["data_vars"] = {
             "u": {},
             "v": {},
@@ -24,7 +25,6 @@ class TranslateNH_P_Grad(TranslateFortranData2Py):
         }
 
     def compute(self, inputs):
-        compute_func = NH_P_Grad.NonHydrostaticPressureGradient()
         self.make_storage_data_input_vars(inputs)
-        compute_func(**inputs)
+        self.compute_func(**inputs)
         return self.slice_output(inputs)

--- a/tests/translate/translate_nh_p_grad.py
+++ b/tests/translate/translate_nh_p_grad.py
@@ -5,7 +5,6 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateNH_P_Grad(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = NH_P_Grad.NonHydrostaticPressureGradient()
         self.in_vars["data_vars"] = {
             "u": {},
             "v": {},
@@ -25,6 +24,7 @@ class TranslateNH_P_Grad(TranslateFortranData2Py):
         }
 
     def compute(self, inputs):
+        compute_func = NH_P_Grad.NonHydrostaticPressureGradient()
         self.make_storage_data_input_vars(inputs)
-        self.compute_func(**inputs)
+        compute_func(**inputs)
         return self.slice_output(inputs)


### PR DESCRIPTION
## Purpose

This patch fixes a bug that caused the nh_p_grad tests to fail on cron and also turns validate_args off in nh_p_grad

## Code changes:

- Moved the compute function from init to compute in `translate_nh_p_grad.py`
- `du` and `dv` are now temporaries
- `validate_args` is turned off for `NonHydrostaticPressureGradient`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes
