### PR TITLE
remove storage initialization and uncached copies

### DIFF
--- a/fv3core/stencils/basic_operations.py
+++ b/fv3core/stencils/basic_operations.py
@@ -30,7 +30,7 @@ def copy_stencil_2d(q_in: FloatFieldIJ, q_out: FloatFieldIJ):
         q_out = q_in
 
 
-def copy(q_in, origin=(0, 0, 0), domain=None, use_cache=True):
+def copy(q_in, origin=(0, 0, 0), domain=None, cache_key=None):
     """Copy q_in inside the origin and domain, and zero outside.
 
     Args:
@@ -51,9 +51,9 @@ def copy(q_in, origin=(0, 0, 0), domain=None, use_cache=True):
         domain = (domain[0], domain[1], 1)
         origin = origin[0:2]
         copy_fxn = copy_stencil_2d
-    if use_cache:
+    if cache_key:
         q_out = utils.make_storage_from_shape(
-            q_in.shape, q_in.default_origin, init=True
+            q_in.shape, q_in.default_origin, cache_key=cache_key
         )
     else:
         q_out = utils.make_storage_from_shape_uncached(

--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -310,11 +310,14 @@ def update_meridional_velocity(
         flux = vorticity[0, 0, 0] if tmp_flux > 0.0 else vorticity[1, 0, 0]
         velocity_c = velocity_c - tmp_flux * flux + rdyc * (ke[0, -1, 0] - ke)
 
+
 @gtstencil
 def initialize_delpc_ptc(delpc: FloatField, ptc: FloatField):
     with computation(PARALLEL), interval(...):
         delpc = 0.0
         ptc = 0.0
+
+
 def vorticitytransport_cgrid(
     uc: FloatField,
     vc: FloatField,
@@ -372,7 +375,9 @@ def compute(delp, pt, u, v, w, uc, vc, ua, va, ut, vt, divgd, omga, dt2):
     ptc = utils.make_storage_from_shape(
         pt.shape, origin=origin_halo1, cache_key="c_sw_ptc"
     )
-    initialize_delpc_ptc(delpc, ptc, origin=grid.full_origin(), domain=grid.domain_shape_full())
+    initialize_delpc_ptc(
+        delpc, ptc, origin=grid.full_origin(), domain=grid.domain_shape_full()
+    )
     d2a2c.compute(dord4, uc, vc, u, v, ua, va, ut, vt)
     if spec.namelist.nord > 0:
         divergence_corner(

--- a/fv3core/stencils/delnflux.py
+++ b/fv3core/stencils/delnflux.py
@@ -4,7 +4,7 @@ import fv3core._config as spec
 import fv3core.utils.corners as corners
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.stencils.basic_operations import copy
+from fv3core.stencils.basic_operations import copy_stencil
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -158,7 +158,7 @@ def compute_no_sg(q, fx2, fy2, nord, damp_c, d2, kstart=0, nk=None, mass=None):
     if mass is None:
         d2_damp(q, d2, damp_c, origin=origin_d2, domain=domain_d2)
     else:
-        d2 = copy(q, origin=origin_d2, domain=domain_d2, cache_key="delnflux_d2_nosg")
+        copy_stencil(q, d2, origin=origin_d2, domain=domain_d2)
 
     if nord > 0:
         corners.copy_corners_x_stencil(

--- a/fv3core/stencils/delnflux.py
+++ b/fv3core/stencils/delnflux.py
@@ -158,7 +158,7 @@ def compute_no_sg(q, fx2, fy2, nord, damp_c, d2, kstart=0, nk=None, mass=None):
     if mass is None:
         d2_damp(q, d2, damp_c, origin=origin_d2, domain=domain_d2)
     else:
-        d2 = copy(q, origin=origin_d2, domain=domain_d2)
+        d2 = copy(q, origin=origin_d2, domain=domain_d2, cache_key="delnflux_d2_nosg")
 
     if nord > 0:
         corners.copy_corners_x_stencil(

--- a/fv3core/stencils/fillz.py
+++ b/fv3core/stencils/fillz.py
@@ -16,8 +16,6 @@ def fix_tracer(
     dm: FloatField,
     dm_pos: FloatField,
     zfix: IntFieldIJ,
-    upper_fix: FloatField,
-    lower_fix: FloatField,
     sum0: FloatFieldIJ,
     sum1: FloatFieldIJ,
 ):
@@ -65,7 +63,7 @@ def fix_tracer(
                 )
                 q = q + dq / dp
                 lower_fix = dq
-    with computation(PARALLEL), interval(...):
+    with computation(PARALLEL), interval(0, -1):
         if upper_fix[0, 0, 1] != 0.0:
             # If a lower layer borrowed from this one, account for that here
             q = q - upper_fix[0, 0, 1] / dp
@@ -124,12 +122,6 @@ def compute(
     )
     # setting initial value of upper_fix to zero is only needed
     # for validation. The values in the compute domain are set to zero in the stencil.
-    upper_fix = utils.make_storage_from_shape(
-        shape, origin=(0, 0, 0), init=True, cache_key="fillz_upper_Fix"
-    )
-    lower_fix = utils.make_storage_from_shape(
-        shape, origin=(0, 0, 0), init=True, cache_key="fillz_lower_fix"
-    )
     zfix = utils.make_storage_from_shape(
         shape_ij, dtype=np.int, origin=(0, 0), cache_key="fillz_zfix"
     )
@@ -148,8 +140,6 @@ def compute(
             dm,
             dm_pos,
             zfix,
-            upper_fix,
-            lower_fix,
             sum0,
             sum1,
             origin=(i1, js, 0),

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -472,37 +472,23 @@ def compute(state, nq, dt):
         raise Exception("Hydrostatic not supported for fv_subgridz")
     q0 = {}
     for tracername in utils.tracer_variables:
-        q0[tracername] = copy(state.__dict__[tracername], cache_key=tracername+"-subgridz")
+        q0[tracername] = copy(
+            state.__dict__[tracername], cache_key=tracername + "-subgridz"
+        )
     origin = grid.compute_origin()
     shape = state.delp.shape
 
-    u0 = utils.make_storage_from_shape(
-        shape, origin,  cache_key="fv_subgridz_u0"
-    )
-    v0 = utils.make_storage_from_shape(
-        shape, origin,  cache_key="fv_subgridz_v0"
-    )
-    w0 = utils.make_storage_from_shape(
-        shape, origin,  cache_key="fv_subgridz_w0"
-    )
-    gzh = utils.make_storage_from_shape(
-        shape, origin,  cache_key="fv_subgridz_gzh"
-    )
-    gz = utils.make_storage_from_shape(
-        shape, origin,  cache_key="fv_subgridz_gz"
-    )
-    t0 = utils.make_storage_from_shape(
-        shape, origin,  cache_key="fv_subgridz_t0"
-    )
-    pm = utils.make_storage_from_shape(
-        shape, origin,  cache_key="fv_subgridz_pm"
-    )
+    u0 = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_u0")
+    v0 = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_v0")
+    w0 = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_w0")
+    gzh = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_gzh")
+    gz = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_gz")
+    t0 = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_t0")
+    pm = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_pm")
     hd = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_hd")
     te = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_te")
     den = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_den")
-    qcon = utils.make_storage_from_shape(
-        shape, origin,  cache_key="fv_subgridz_qcon"
-    )
+    qcon = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_qcon")
     cvm = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_cvm")
     cpm = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_cpm")
 

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -472,23 +472,38 @@ def compute(state, nq, dt):
         raise Exception("Hydrostatic not supported for fv_subgridz")
     q0 = {}
     for tracername in utils.tracer_variables:
-        q0[tracername] = copy(
-            state.__dict__[tracername], cache_key=tracername + "-subgridz"
-        )
+        q0[tracername] = copy(state.__dict__[tracername], use_cache=False)
     origin = grid.compute_origin()
     shape = state.delp.shape
-
-    u0 = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_u0")
-    v0 = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_v0")
-    w0 = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_w0")
-    gzh = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_gzh")
-    gz = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_gz")
-    t0 = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_t0")
-    pm = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_pm")
+    # not 100% sure which of these require init=True,
+    # if you figure it out please remove unnecessary ones and this comment
+    u0 = utils.make_storage_from_shape(
+        shape, origin, init=True, cache_key="fv_subgridz_u0"
+    )
+    v0 = utils.make_storage_from_shape(
+        shape, origin, init=True, cache_key="fv_subgridz_v0"
+    )
+    w0 = utils.make_storage_from_shape(
+        shape, origin, init=True, cache_key="fv_subgridz_w0"
+    )
+    gzh = utils.make_storage_from_shape(
+        shape, origin, init=True, cache_key="fv_subgridz_gzh"
+    )
+    gz = utils.make_storage_from_shape(
+        shape, origin, init=True, cache_key="fv_subgridz_gz"
+    )
+    t0 = utils.make_storage_from_shape(
+        shape, origin, init=True, cache_key="fv_subgridz_t0"
+    )
+    pm = utils.make_storage_from_shape(
+        shape, origin, init=True, cache_key="fv_subgridz_pm"
+    )
     hd = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_hd")
     te = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_te")
     den = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_den")
-    qcon = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_qcon")
+    qcon = utils.make_storage_from_shape(
+        shape, origin, init=True, cache_key="fv_subgridz_qcon"
+    )
     cvm = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_cvm")
     cpm = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_cpm")
 

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -472,7 +472,9 @@ def compute(state, nq, dt):
         raise Exception("Hydrostatic not supported for fv_subgridz")
     q0 = {}
     for tracername in utils.tracer_variables:
-        q0[tracername] = copy(state.__dict__[tracername], use_cache=False)
+        q0[tracername] = copy(
+            state.__dict__[tracername], cache_key="fv_subgridz_" + tracername
+        )
     origin = grid.compute_origin()
     shape = state.delp.shape
     # not 100% sure which of these require init=True,

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -472,37 +472,36 @@ def compute(state, nq, dt):
         raise Exception("Hydrostatic not supported for fv_subgridz")
     q0 = {}
     for tracername in utils.tracer_variables:
-        q0[tracername] = copy(state.__dict__[tracername], use_cache=False)
+        q0[tracername] = copy(state.__dict__[tracername], cache_key=tracername+"-subgridz")
     origin = grid.compute_origin()
     shape = state.delp.shape
-    # not 100% sure which of these require init=True,
-    # if you figure it out please remove unnecessary ones and this comment
+
     u0 = utils.make_storage_from_shape(
-        shape, origin, init=True, cache_key="fv_subgridz_u0"
+        shape, origin,  cache_key="fv_subgridz_u0"
     )
     v0 = utils.make_storage_from_shape(
-        shape, origin, init=True, cache_key="fv_subgridz_v0"
+        shape, origin,  cache_key="fv_subgridz_v0"
     )
     w0 = utils.make_storage_from_shape(
-        shape, origin, init=True, cache_key="fv_subgridz_w0"
+        shape, origin,  cache_key="fv_subgridz_w0"
     )
     gzh = utils.make_storage_from_shape(
-        shape, origin, init=True, cache_key="fv_subgridz_gzh"
+        shape, origin,  cache_key="fv_subgridz_gzh"
     )
     gz = utils.make_storage_from_shape(
-        shape, origin, init=True, cache_key="fv_subgridz_gz"
+        shape, origin,  cache_key="fv_subgridz_gz"
     )
     t0 = utils.make_storage_from_shape(
-        shape, origin, init=True, cache_key="fv_subgridz_t0"
+        shape, origin,  cache_key="fv_subgridz_t0"
     )
     pm = utils.make_storage_from_shape(
-        shape, origin, init=True, cache_key="fv_subgridz_pm"
+        shape, origin,  cache_key="fv_subgridz_pm"
     )
     hd = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_hd")
     te = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_te")
     den = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_den")
     qcon = utils.make_storage_from_shape(
-        shape, origin, init=True, cache_key="fv_subgridz_qcon"
+        shape, origin,  cache_key="fv_subgridz_qcon"
     )
     cvm = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_cvm")
     cpm = utils.make_storage_from_shape(shape, origin, cache_key="fv_subgridz_cpm")

--- a/fv3core/stencils/map_single.py
+++ b/fv3core/stencils/map_single.py
@@ -201,7 +201,7 @@ def setup_data(
     dp1 = utils.make_storage_from_shape(
         q1.shape, origin=origin, cache_key="map_single_dp1"
     )
-    q4_1 = copy(q1, origin=(0, 0, 0), domain=grid.domain_shape_full())
+    q4_1 = copy(q1, origin=(0, 0, 0), domain=grid.domain_shape_full(), cache_key="map_single_q1")
     q4_2 = utils.make_storage_from_shape(
         q4_1.shape, origin=(grid.is_, 0, 0), cache_key="map_single_q4_2"
     )

--- a/fv3core/stencils/map_single.py
+++ b/fv3core/stencils/map_single.py
@@ -201,7 +201,9 @@ def setup_data(
     dp1 = utils.make_storage_from_shape(
         q1.shape, origin=origin, cache_key="map_single_dp1"
     )
-    q4_1 = copy(q1, origin=(0, 0, 0), domain=grid.domain_shape_full(), cache_key="map_single_q1")
+    q4_1 = copy(
+        q1, origin=(0, 0, 0), domain=grid.domain_shape_full(), cache_key="map_single_q1"
+    )
     q4_2 = utils.make_storage_from_shape(
         q4_1.shape, origin=(grid.is_, 0, 0), cache_key="map_single_q4_2"
     )

--- a/fv3core/stencils/map_single.py
+++ b/fv3core/stencils/map_single.py
@@ -7,7 +7,7 @@ import fv3core._config as spec
 import fv3core.stencils.remap_profile as remap_profile
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.stencils.basic_operations import copy
+from fv3core.stencils.basic_operations import copy_stencil
 from fv3core.utils.grid import Grid
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
@@ -201,8 +201,8 @@ def setup_data(
     dp1 = utils.make_storage_from_shape(
         q1.shape, origin=origin, cache_key="map_single_dp1"
     )
-    q4_1 = copy(
-        q1, origin=(0, 0, 0), domain=grid.domain_shape_full(), cache_key="map_single_q1"
+    q4_1 = utils.make_storage_from_shape(
+        q1.shape, origin=(grid.is_, 0, 0), cache_key="map_single_q4_1"
     )
     q4_2 = utils.make_storage_from_shape(
         q4_1.shape, origin=(grid.is_, 0, 0), cache_key="map_single_q4_2"
@@ -212,6 +212,12 @@ def setup_data(
     )
     q4_4 = utils.make_storage_from_shape(
         q4_1.shape, origin=(grid.is_, 0, 0), cache_key="map_single_q4_4"
+    )
+    copy_stencil(
+        q1,
+        q4_1,
+        origin=(0, 0, 0),
+        domain=grid.domain_shape_full(),
     )
     set_dp(dp1, pe1, origin=origin, domain=domain)
     return dp1, q4_1, q4_2, q4_3, q4_4, origin, domain, jslice, i_extent

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -214,7 +214,7 @@ def compute(
 
     # do_omega = hydrostatic and last_step # TODO pull into inputs
     domain_jextra = (grid.nic, grid.njc + 1, grid.npz + 1)
-    pe1 = copy(pe, origin=grid.compute_origin(), domain=domain_jextra)
+    pe1 = copy(pe, origin=grid.compute_origin(), domain=domain_jextra, cache_key="remapping_part1_pe1")
     pe2 = utils.make_storage_from_shape(
         pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe2"
     )

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -117,7 +117,7 @@ def copy_j_adjacent(pe2: FloatField):
 
 
 @gtstencil()
-def pn2_and_pk(
+def pn2_pk_delp(
     dp2: FloatField,
     delp: FloatField,
     pe2: FloatField,
@@ -279,7 +279,7 @@ def compute(
     copy_j_adjacent(
         pe2, origin=(grid.is_, grid.je + 1, 1), domain=(grid.nic, 1, grid.npz - 1)
     )
-    pn2_and_pk(
+    pn2_pk_delp(
         dp2,
         delp,
         pe2,

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -8,7 +8,7 @@ import fv3core.stencils.mapn_tracer as mapn_tracer
 import fv3core.stencils.moist_cv as moist_cv
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.stencils.basic_operations import copy, copy_stencil
+from fv3core.stencils.basic_operations import copy_stencil
 from fv3core.stencils.moist_cv import moist_pt_func
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
@@ -17,12 +17,14 @@ CONSV_MIN = 0.001
 
 
 @gtstencil()
-def init_pe2(pe: FloatField, pe2: FloatField, ptop: float):
+def init_pe(pe: FloatField, pe1: FloatField, pe2: FloatField, ptop: float):
     with computation(PARALLEL):
         with interval(0, 1):
             pe2 = ptop
         with interval(-1, None):
             pe2 = pe
+    with computation(PARALLEL), interval(...):
+        pe1 = pe
 
 
 @gtstencil()
@@ -116,8 +118,9 @@ def copy_j_adjacent(pe2: FloatField):
 
 
 @gtstencil()
-def pn2_and_pk(pe2: FloatField, pn2: FloatField, pk: FloatField, akap: float):
+def pn2_and_pk(dp2: FloatField, delp: FloatField, pe2: FloatField, pn2: FloatField, pk: FloatField, akap: float):
     with computation(PARALLEL), interval(...):
+        delp = dp2
         pn2 = log(pe2)
         pk = exp(akap * pn2)
 
@@ -214,12 +217,10 @@ def compute(
 
     # do_omega = hydrostatic and last_step # TODO pull into inputs
     domain_jextra = (grid.nic, grid.njc + 1, grid.npz + 1)
-    pe1 = copy(
-        pe,
-        origin=grid.compute_origin(),
-        domain=domain_jextra,
-        cache_key="remapping_part1_pe1",
-    )
+    
+    pe1 = utils.make_storage_from_shape(
+        pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe1")
+    
     pe2 = utils.make_storage_from_shape(
         pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe2"
     )
@@ -236,7 +237,7 @@ def compute(
         pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe3"
     )
 
-    init_pe2(pe, pe2, ptop, origin=grid.compute_origin(), domain=domain_jextra)
+    init_pe(pe, pe1, pe2, ptop, origin=grid.compute_origin(), domain=domain_jextra)
 
     moist_cv_pt_pressure(
         tracers["qvapor"],
@@ -271,11 +272,9 @@ def compute(
     copy_j_adjacent(
         pe2, origin=(grid.is_, grid.je + 1, 1), domain=(grid.nic, 1, grid.npz - 1)
     )
-    copy_stencil(
-        dp2, delp, origin=grid.compute_origin(), domain=grid.domain_shape_compute()
-    )
-
     pn2_and_pk(
+        dp2,
+        delp,
         pe2,
         pn2,
         pk,

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -8,7 +8,6 @@ import fv3core.stencils.mapn_tracer as mapn_tracer
 import fv3core.stencils.moist_cv as moist_cv
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.stencils.basic_operations import copy_stencil
 from fv3core.stencils.moist_cv import moist_pt_func
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
@@ -118,7 +117,14 @@ def copy_j_adjacent(pe2: FloatField):
 
 
 @gtstencil()
-def pn2_and_pk(dp2: FloatField, delp: FloatField, pe2: FloatField, pn2: FloatField, pk: FloatField, akap: float):
+def pn2_and_pk(
+    dp2: FloatField,
+    delp: FloatField,
+    pe2: FloatField,
+    pn2: FloatField,
+    pk: FloatField,
+    akap: float,
+):
     with computation(PARALLEL), interval(...):
         delp = dp2
         pn2 = log(pe2)
@@ -217,10 +223,11 @@ def compute(
 
     # do_omega = hydrostatic and last_step # TODO pull into inputs
     domain_jextra = (grid.nic, grid.njc + 1, grid.npz + 1)
-    
+
     pe1 = utils.make_storage_from_shape(
-        pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe1")
-    
+        pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe1"
+    )
+
     pe2 = utils.make_storage_from_shape(
         pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe2"
     )

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -214,7 +214,12 @@ def compute(
 
     # do_omega = hydrostatic and last_step # TODO pull into inputs
     domain_jextra = (grid.nic, grid.njc + 1, grid.npz + 1)
-    pe1 = copy(pe, origin=grid.compute_origin(), domain=domain_jextra, cache_key="remapping_part1_pe1")
+    pe1 = copy(
+        pe,
+        origin=grid.compute_origin(),
+        domain=domain_jextra,
+        cache_key="remapping_part1_pe1",
+    )
     pe2 = utils.make_storage_from_shape(
         pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe2"
     )

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -16,12 +16,15 @@ import fv3core.stencils.sim1_solver as sim1_solver
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.stencils.basic_operations import copy
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
 @gtstencil()
 def precompute(
+    delp: FloatField,
+    cappa: FloatField,
+    pe: FloatField,
+    pe_init: FloatField,
     cp3: FloatField,
     dm: FloatField,
     zh: FloatField,
@@ -40,6 +43,10 @@ def precompute(
     rgrav: float,
     akap: float,
 ):
+    with computation(PARALLEL), interval(...):
+         dm = delp
+         cp3 = cappa
+         pe_init = pe
     with computation(FORWARD):
         with interval(0, 1):
             pem = ptop
@@ -60,8 +67,7 @@ def precompute(
     with computation(PARALLEL), interval(0, -1):
         pm = (peg[0, 0, 1] - peg) / (pelng[0, 0, 1] - pelng)
         dz = zh[0, 0, 1] - zh
-
-
+         
 @gtstencil()
 def last_call_copy(
     peln_run: FloatField,
@@ -137,15 +143,13 @@ def compute(
     km = grid.npz - 1
     peln1 = math.log(ptop)
     ptk = math.exp(akap * peln1)
-    islice = slice(grid.is_, grid.ie + 1)
-    kslice = slice(0, km + 1)
-    kslice_shift = slice(1, km + 2)
     shape = w.shape
     domain = (grid.nic, grid.njc, km + 2)
     riemorigin = (grid.is_, grid.js, 0)
-    dm = copy(delp, cache_key="riem3_dm")
-    cp3 = copy(cappa, cache_key="riem3_cp3")
-    pe_init = copy(pe, cache_key="riem3_pe_init")
+
+    dm =  utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_dm")
+    cp3 =  utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_cp3")
+    pe_init =  utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_pe_init")
     pm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_pm")
     pem = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_pem")
     peln_run = utils.make_storage_from_shape(
@@ -158,6 +162,10 @@ def compute(
     gm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_gm")
 
     precompute(
+        delp,
+        cappa,
+        pe,
+        pe_init,
         cp3,
         dm,
         zh,

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -143,9 +143,9 @@ def compute(
     shape = w.shape
     domain = (grid.nic, grid.njc, km + 2)
     riemorigin = (grid.is_, grid.js, 0)
-    dm = copy(delp)
-    cp3 = copy(cappa)
-    pe_init = copy(pe)
+    dm = copy(delp, cache_key="riem3_dm")
+    cp3 = copy(cappa, cache_key="riem3_cp3")
+    pe_init = copy(pe, cache_key="riem3_pe_init")
     pm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_pm")
     pem = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_pem")
     peln_run = utils.make_storage_from_shape(

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -44,9 +44,9 @@ def precompute(
     akap: float,
 ):
     with computation(PARALLEL), interval(...):
-         dm = delp
-         cp3 = cappa
-         pe_init = pe
+        dm = delp
+        cp3 = cappa
+        pe_init = pe
     with computation(FORWARD):
         with interval(0, 1):
             pem = ptop
@@ -67,7 +67,8 @@ def precompute(
     with computation(PARALLEL), interval(0, -1):
         pm = (peg[0, 0, 1] - peg) / (pelng[0, 0, 1] - pelng)
         dz = zh[0, 0, 1] - zh
-         
+
+
 @gtstencil()
 def last_call_copy(
     peln_run: FloatField,
@@ -147,9 +148,11 @@ def compute(
     domain = (grid.nic, grid.njc, km + 2)
     riemorigin = (grid.is_, grid.js, 0)
 
-    dm =  utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_dm")
-    cp3 =  utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_cp3")
-    pe_init =  utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_pe_init")
+    dm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_dm")
+    cp3 = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_cp3")
+    pe_init = utils.make_storage_from_shape(
+        shape, riemorigin, cache_key="riem3_pe_init"
+    )
     pm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_pm")
     pem = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_pem")
     peln_run = utils.make_storage_from_shape(

--- a/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/stencils/riem_solver_c.py
@@ -99,9 +99,9 @@ def compute(
     shape = w3.shape
     domain = (spec.grid.nic + 2, grid.njc + 2, km + 2)
     riemorigin = (is1, js1, 0)
-    dm = utils.make_storage_from_shape(shape, riemorigin,cache_key="riemc_dm")
-    cp3 = utils.make_storage_from_shape(shape, riemorigin,cache_key="riemc_cp3")
-    w = utils.make_storage_from_shape(shape, riemorigin,cache_key="riemc_w")
+    dm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riemc_dm")
+    cp3 = utils.make_storage_from_shape(shape, riemorigin, cache_key="riemc_cp3")
+    w = utils.make_storage_from_shape(shape, riemorigin, cache_key="riemc_w")
     pem = utils.make_storage_from_shape(
         shape, riemorigin, cache_key="riem_solver_c_pem"
     )
@@ -111,7 +111,10 @@ def compute(
     pm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver_c_pm")
     # it looks like this code sets pef = ptop, and does not otherwise use pef here
     precompute(
-        delpc, cappa, w3,w,
+        delpc,
+        cappa,
+        w3,
+        w,
         cp3,
         gz,
         dm,

--- a/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/stencils/riem_solver_c.py
@@ -92,9 +92,9 @@ def compute(
     shape = w3.shape
     domain = (spec.grid.nic + 2, grid.njc + 2, km + 2)
     riemorigin = (is1, js1, 0)
-    dm = copy(delpc)
-    cp3 = copy(cappa)
-    w = copy(w3)
+    dm = copy(delpc, cache_key="riemc_dm")
+    cp3 = copy(cappa, cache_key="riemc_cp3")
+    w = copy(w3, cache_key="riemc_w")
 
     pem = utils.make_storage_from_shape(
         shape, riemorigin, cache_key="riem_solver_c_pem"

--- a/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/stencils/riem_solver_c.py
@@ -5,12 +5,15 @@ import fv3core.stencils.sim1_solver as sim1_solver
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.stencils.basic_operations import copy
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
 @gtstencil()
 def precompute(
+    delpc: FloatField,
+    cappa: FloatField,
+    w3: FloatField,
+    w: FloatField,
     cp3: FloatField,
     gz: FloatField,
     dm: FloatField,
@@ -21,6 +24,10 @@ def precompute(
     pm: FloatField,
     ptop: float,
 ):
+    with computation(PARALLEL), interval(...):
+        dm = delpc
+        cp3 = cappa
+        w = w3
     with computation(FORWARD):
         with interval(0, 1):
             pem = ptop
@@ -92,10 +99,9 @@ def compute(
     shape = w3.shape
     domain = (spec.grid.nic + 2, grid.njc + 2, km + 2)
     riemorigin = (is1, js1, 0)
-    dm = copy(delpc, cache_key="riemc_dm")
-    cp3 = copy(cappa, cache_key="riemc_cp3")
-    w = copy(w3, cache_key="riemc_w")
-
+    dm = utils.make_storage_from_shape(shape, riemorigin,cache_key="riemc_dm")
+    cp3 = utils.make_storage_from_shape(shape, riemorigin,cache_key="riemc_cp3")
+    w = utils.make_storage_from_shape(shape, riemorigin,cache_key="riemc_w")
     pem = utils.make_storage_from_shape(
         shape, riemorigin, cache_key="riem_solver_c_pem"
     )
@@ -105,6 +111,7 @@ def compute(
     pm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver_c_pm")
     # it looks like this code sets pef = ptop, and does not otherwise use pef here
     precompute(
+        delpc, cappa, w3,w,
         cp3,
         gz,
         dm,

--- a/fv3core/stencils/updatedzc.py
+++ b/fv3core/stencils/updatedzc.py
@@ -246,7 +246,10 @@ def compute(
     gz = copy(gz_in, origin=origin, cache_key="updatedzc_gz")
     gz_x = copy(gz, origin=origin, cache_key="updatedzc_gz_x")
     ws = copy(
-        ws3, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(1, 1, 0)), cache_key="updatedzc_ws"
+        ws3,
+        origin=grid.full_origin(),
+        domain=grid.domain_shape_full(add=(1, 1, 0)),
+        cache_key="updatedzc_ws",
     )
     corners.fill_corners_cells(gz_x, "x")
     gz_y = copy(gz_x, origin=origin, cache_key="updatedzc_gz_y")

--- a/fv3core/stencils/updatedzc.py
+++ b/fv3core/stencils/updatedzc.py
@@ -243,13 +243,13 @@ def compute(
 ):
     grid = spec.grid
     origin = (1, 1, 0)
-    gz = copy(gz_in, origin=origin)
-    gz_x = copy(gz, origin=origin)
+    gz = copy(gz_in, origin=origin, cache_key="updatedzc_gz")
+    gz_x = copy(gz, origin=origin, cache_key="updatedzc_gz_x")
     ws = copy(
-        ws3, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(1, 1, 0))
+        ws3, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(1, 1, 0)), cache_key="updatedzc_ws"
     )
     corners.fill_corners_cells(gz_x, "x")
-    gz_y = copy(gz_x, origin=origin)
+    gz_y = copy(gz_x, origin=origin, cache_key="updatedzc_gz_y")
     corners.fill_corners_cells(gz_y, "y")
     update_dz_c(
         dp_ref,

--- a/fv3core/stencils/updatedzd.py
+++ b/fv3core/stencils/updatedzd.py
@@ -311,7 +311,10 @@ def compute(
         zh.shape, grid.full_origin(), cache_key="updatedzd_fy"
     )
     z2 = copy(
-        zh, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1)), cache_key="updatedzd_z2"
+        zh,
+        origin=grid.full_origin(),
+        domain=grid.domain_shape_full(add=(0, 0, 1)),
+        cache_key="updatedzd_z2",
     )
 
     fvtp2d = utils.cached_stencil_class(FiniteVolumeTransport)(

--- a/fv3core/stencils/updatedzd.py
+++ b/fv3core/stencils/updatedzd.py
@@ -15,7 +15,7 @@ import fv3core.stencils.delnflux as delnflux
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
-from fv3core.stencils.basic_operations import copy
+from fv3core.stencils.basic_operations import copy_stencil
 from fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from fv3core.stencils.fxadv import ra_x_func, ra_y_func
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
@@ -310,11 +310,13 @@ def compute(
     fy = utils.make_storage_from_shape(
         zh.shape, grid.full_origin(), cache_key="updatedzd_fy"
     )
-    z2 = copy(
-        zh,
+    z2 =utils.make_storage_from_shape(
+        zh.shape, grid.full_origin(), cache_key="updatedzd_z2"
+    )
+    copy_stencil(
+        zh, z2,
         origin=grid.full_origin(),
         domain=grid.domain_shape_full(add=(0, 0, 1)),
-        cache_key="updatedzd_z2",
     )
 
     fvtp2d = utils.cached_stencil_class(FiniteVolumeTransport)(

--- a/fv3core/stencils/updatedzd.py
+++ b/fv3core/stencils/updatedzd.py
@@ -310,11 +310,12 @@ def compute(
     fy = utils.make_storage_from_shape(
         zh.shape, grid.full_origin(), cache_key="updatedzd_fy"
     )
-    z2 =utils.make_storage_from_shape(
+    z2 = utils.make_storage_from_shape(
         zh.shape, grid.full_origin(), cache_key="updatedzd_z2"
     )
     copy_stencil(
-        zh, z2,
+        zh,
+        z2,
         origin=grid.full_origin(),
         domain=grid.domain_shape_full(add=(0, 0, 1)),
     )

--- a/fv3core/stencils/updatedzd.py
+++ b/fv3core/stencils/updatedzd.py
@@ -311,7 +311,7 @@ def compute(
         zh.shape, grid.full_origin(), cache_key="updatedzd_fy"
     )
     z2 = copy(
-        zh, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1))
+        zh, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1)), cache_key="updatedzd_z2"
     )
 
     fvtp2d = utils.cached_stencil_class(FiniteVolumeTransport)(

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import math
 from functools import wraps
@@ -297,30 +296,15 @@ def make_storage_from_shape(
     mask: Optional[Tuple[bool, bool, bool]] = None,
     cache_key: Optional[Hashable] = None,
 ) -> Field:
-    """Create a new gt4py storage of a given shape. Outputs are memoized.
-
-    The key used for memoization is the arguments used combined with the
-    calling scope file and line number, as well as the file and line number
-    which called in to that scope. This handles cases where a utility
-    function (such as `copy`) calls our `make_storage_from_shape`, since
-    `copy` will be called from different places each time. This does *not*
-    handle any more deeply nested duplicate calls, such as if another
-    utility function were to call `copy`, and does not handle allocations
-    which take place within for loops, such as tracer allocations. In
-    those cases, memoization will provide the same storage to two
-    conceptually different objects, causing a bug.
-
-    For this reason, and because of the significant overhead cost of
-    `inspect`, we should move away from this implementation in the
-    longer term.
-
+    """Create a new gt4py storage of a given shape. Outputs are memoized
+       using a provided cache_key
     Args:
         shape: Shape of the new storage
         origin: Default origin for gt4py stencil calls
         dtype: Data type
         init: If True, initializes the storage to zero
         mask: Tuple indicating the axes used when initializing the storage
-
+        cache_key: string for memoizing the storage
     Returns:
         Field[dtype]: New storage
 

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -322,16 +322,15 @@ def make_storage_from_shape(
     # We should shift to an explicit caching or array re-use system down
     # the line.
     if cache_key is None:
-        return_value = make_storage_from_shape_uncached(
+        return make_storage_from_shape_uncached(
             shape, origin, dtype=dtype, init=init, mask=mask
         )
-    else:
-        full_key = (shape, origin, cache_key, dtype, init, mask)
-        if full_key not in storage_shape_outputs:
-            storage_shape_outputs[full_key] = make_storage_from_shape_uncached(
-                shape, origin, dtype=dtype, init=init, mask=mask
-            )
-        return_value = storage_shape_outputs[full_key]
+    full_key = (shape, origin, cache_key, dtype, init, mask)
+    if full_key not in storage_shape_outputs:
+        storage_shape_outputs[full_key] = make_storage_from_shape_uncached(
+            shape, origin, dtype=dtype, init=init, mask=mask
+        )
+    return_value = storage_shape_outputs[full_key]
     if init:
         return_value[:] = 0.0
     return return_value

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -322,16 +322,16 @@ def make_storage_from_shape(
     # We should shift to an explicit caching or array re-use system down
     # the line.
     if cache_key is None:
-        return make_storage_from_shape_uncached(
+        return_value = make_storage_from_shape_uncached(
             shape, origin, dtype=dtype, init=init, mask=mask
         )
-
-    full_key = (shape, origin, cache_key, dtype, init, mask)
-    if full_key not in storage_shape_outputs:
-        storage_shape_outputs[full_key] = make_storage_from_shape_uncached(
-            shape, origin, dtype=dtype, init=init, mask=mask
-        )
-    return_value = storage_shape_outputs[full_key]
+    else:
+        full_key = (shape, origin, cache_key, dtype, init, mask)
+        if full_key not in storage_shape_outputs:
+            storage_shape_outputs[full_key] = make_storage_from_shape_uncached(
+                shape, origin, dtype=dtype, init=init, mask=mask
+            )
+        return_value = storage_shape_outputs[full_key]
     if init:
         return_value[:] = 0.0
     return return_value

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -338,14 +338,10 @@ def make_storage_from_shape(
     # We should shift to an explicit caching or array re-use system down
     # the line.
     if cache_key is None:
-        callers = tuple(
-            # only need to look at the calling scope and its calling scope
-            # because we don't have any utility functions that call utility
-            # functions that call this function (only nested 1 deep)
-            inspect.getframeinfo(stack_item[0])
-            for stack_item in inspect.stack()[1:3]
+        return make_storage_from_shape_uncached(
+            shape, origin, dtype=dtype, init=init, mask=mask
         )
-        cache_key = tuple((caller.filename, caller.lineno) for caller in callers)
+
     full_key = (shape, origin, cache_key, dtype, init, mask)
     if full_key not in storage_shape_outputs:
         storage_shape_outputs[full_key] = make_storage_from_shape_uncached(

--- a/tests/test_memoize_storages.py
+++ b/tests/test_memoize_storages.py
@@ -32,7 +32,11 @@ def init(request):
 def test_storage_is_cached(backend, shape, origin, init):
     outputs = []
     for _ in range(2):
-        outputs.append(make_storage_from_shape(shape, origin=origin, init=init, cache_key="test-cached" ))
+        outputs.append(
+            make_storage_from_shape(
+                shape, origin=origin, init=init, cache_key="test-cached"
+            )
+        )
     assert outputs[0] is outputs[1]
 
 

--- a/tests/test_memoize_storages.py
+++ b/tests/test_memoize_storages.py
@@ -32,7 +32,7 @@ def init(request):
 def test_storage_is_cached(backend, shape, origin, init):
     outputs = []
     for _ in range(2):
-        outputs.append(make_storage_from_shape(shape, origin=origin, init=init))
+        outputs.append(make_storage_from_shape(shape, origin=origin, init=init, cache_key="test-cached" ))
     assert outputs[0] is outputs[1]
 
 

--- a/tests/translate/translate_c_sw.py
+++ b/tests/translate/translate_c_sw.py
@@ -57,10 +57,12 @@ class TranslateTransportDelp(TranslateFortranData2Py):
         self.make_storage_data_input_vars(inputs)
         orig = (self.grid.is_ - 1, self.grid.js - 1, 0)
         inputs["delpc"] = utils.make_storage_from_shape(
-            inputs["delp"].shape, origin=orig, 
+            inputs["delp"].shape,
+            origin=orig,
         )
         inputs["ptc"] = utils.make_storage_from_shape(
-            inputs["pt"].shape, origin=orig,
+            inputs["pt"].shape,
+            origin=orig,
         )
         c_sw.transportdelp(
             **inputs,

--- a/tests/translate/translate_c_sw.py
+++ b/tests/translate/translate_c_sw.py
@@ -57,12 +57,10 @@ class TranslateTransportDelp(TranslateFortranData2Py):
         self.make_storage_data_input_vars(inputs)
         orig = (self.grid.is_ - 1, self.grid.js - 1, 0)
         inputs["delpc"] = utils.make_storage_from_shape(
-            inputs["delp"].shape,
-            origin=orig,
+            inputs["delp"].shape, origin=orig, init=True
         )
         inputs["ptc"] = utils.make_storage_from_shape(
-            inputs["pt"].shape,
-            origin=orig,
+            inputs["pt"].shape, origin=orig, init=True
         )
         c_sw.transportdelp(
             **inputs,

--- a/tests/translate/translate_c_sw.py
+++ b/tests/translate/translate_c_sw.py
@@ -57,10 +57,10 @@ class TranslateTransportDelp(TranslateFortranData2Py):
         self.make_storage_data_input_vars(inputs)
         orig = (self.grid.is_ - 1, self.grid.js - 1, 0)
         inputs["delpc"] = utils.make_storage_from_shape(
-            inputs["delp"].shape, origin=orig, init=True
+            inputs["delp"].shape, origin=orig, 
         )
         inputs["ptc"] = utils.make_storage_from_shape(
-            inputs["pt"].shape, origin=orig, init=True
+            inputs["pt"].shape, origin=orig,
         )
         c_sw.transportdelp(
             **inputs,


### PR DESCRIPTION
## Purpose

We are still seeing inspect and storage initialization popping up on the performance profile from the copy method and python assignments from init=True for temporary storage allocation. Added a cache key to the copy method, but in most cases remove copy in favor of merging the copy operation with a nearby stencil, or calling copy_stencil directly. Did not change UpdateDzC extensively because it has another refactor waiting. 
Testing on piz daint resulted in a speedup of ~10 seconds

## Code changes:

- for make_storage_data if a cache_key is not set expressly, the storage is not memoized (removed inspect)
- replaced all calls to make_storage_data that had init=True to not, setting to 0 in the stencil when needed
- removed upper_fix and lower_fix as temporaries outside the FillZ stencil as they are not needed outside of it
- replaced all calls to copy() with copy_stencil, merging the copy operation into another stencil, or using a cache_key for the storage created


## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
