### PR TITLE
Remove python code from updatedzc

### DIFF
--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -353,7 +353,7 @@ def compute(state, comm):
                     domain=grid.domain_shape_full(add=(0, 0, 1)),
                 )
         if not hydrostatic:
-            state.gz, state.ws3 = updatedzc.compute(
+            updatedzc.compute(
                 state.dp_ref, state.zs, state.ut, state.vt, state.gz, state.ws3, dt2
             )
             riem_solver_c.compute(

--- a/fv3core/stencils/updatedzc.py
+++ b/fv3core/stencils/updatedzc.py
@@ -4,7 +4,7 @@ from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
 import fv3core._config as spec
 import fv3core.utils.global_constants as constants
 from fv3core.decorators import gtstencil
-from fv3core.stencils.basic_operations import copy
+from fv3core.stencils.basic_operations import copy, copy_stencil
 from fv3core.utils import corners
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
@@ -12,154 +12,23 @@ from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 DZ_MIN = constants.DZ_MIN
 
 
-# def copy(q_in):
-#    q_out = utils.make_storage_from_shape(q_in.shape, origin)
-#    copy_stencil(q_in, q_out)#, origin=(0,0,0),
-# domain=grid.domain_shape_full(add=(1, 1, 1)))
-#    return q_out
-
-
-# call update_dz_c(is, ie, js, je, npz, ng, dt2, dp_ref, zs, gridstruct%area, ut, vt, gz, ws3, & # noqa: E501
-#              npx, npy, gridstruct%sw_corner, gridstruct%se_corner, &
-#              gridstruct%ne_corner, gridstruct%nw_corner, bd, gridstruct%grid_type)
-
-# subroutine update_dz_c(is, ie, js, je, km, ng, dt, dp0, zs, area, ut, vt, gz, ws, &
-#        npx, npy, sw_corner, se_corner, ne_corner, nw_corner, bd, grid_type)
-# ! !INPUT PARAMETERS:
-#   type(fv_grid_bounds_type), intent(IN) :: bd
-#   integer, intent(in):: is, ie, js, je, ng, km, npx, npy, grid_type
-#   logical, intent(IN):: sw_corner, se_corner, ne_corner, nw_corner
-#   real, intent(in):: dt
-#   real, intent(in):: dp0(km)
-#   real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: ut, vt
-#   real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng):: area
-#   real, intent(inout):: gz(is-ng:ie+ng,js-ng:je+ng,km+1)
-#   real, intent(in   ):: zs(is-ng:ie+ng, js-ng:je+ng)
-#   real, intent(  out):: ws(is-ng:ie+ng, js-ng:je+ng)
-# ! Local Work array:
-#   real:: gz2(is-ng:ie+ng,js-ng:je+ng)
-#   real, dimension(is-1:ie+2,js-1:je+1):: xfx, fx
-#   real, dimension(is-1:ie+1,js-1:je+2):: yfx, fy
-#   real, parameter:: r14 = 1./14.
-#   integer  i, j, k
-#   integer:: is1, ie1, js1, je1
-#   integer:: ie2, je2
-#   real:: rdt, top_ratio, bot_ratio, int_ratio
-
-
-#   rdt = 1. / dt
-
-
-#   is1 = is - 1
-#   js1 = js - 1
-
-#   ie1 = ie + 1
-#   je1 = je + 1
-
-#   ie2 = ie + 2
-#   je2 = je + 2
-
-#   do k = 1, km+1
-
-#   top_ratio = dp0(1 ) / (dp0(   1)+dp0(2 ))
-#
-#      if ( k==1 ) then   ! top
-#         do j=js1, je1
-#            do i=is1, ie2
-#               xfx(i,j) = ut(i,j,1) + (ut(i,j,1)-ut(i,j,2))*top_ratio
-#            enddo
-#         enddo
-#         do j=js1, je2
-#            do i=is1, ie1
-#               yfx(i,j) = vt(i,j,1) + (vt(i,j,1)-vt(i,j,2))*top_ratio
-#            enddo
-#         enddo
-
-
 @gtscript.function
 def p_weighted_average_top(vel, dp0):
     # TODO: ratio is a constant, where should this be placed?
     ratio = dp0 / (dp0 + dp0[1])
-    # return (1. + ratio) * vel - ratio * vel[0, 0, 1]
     return vel + (vel - vel[0, 0, 1]) * ratio
-
-
-#   bot_ratio = dp0(km) / (dp0(km-1)+dp0(km))
-#
-#      elseif ( k==km+1 ) then  ! bottom
-#         do j=js1, je1
-#            do i=is1, ie2
-#               xfx(i,j) = ut(i,j,km) + (ut(i,j,km)-ut(i,j,km-1))*bot_ratio
-#            enddo
-#         enddo
-#         do j=js1, je2
-#            do i=is1, ie1
-#               yfx(i,j) = vt(i,j,km) + (vt(i,j,km)-vt(i,j,km-1))*bot_ratio
-#            enddo
-#         enddo
 
 
 @gtscript.function
 def p_weighted_average_bottom(vel, dp0):
     ratio = dp0[-1] / (dp0[-2] + dp0[-1])
-    # return (1. + ratio ) * vel[0, 0, -1] - ratio * vel[0, 0, -2]
     return vel[0, 0, -1] + (vel[0, 0, -1] - vel[0, 0, -2]) * ratio
-
-
-#      else     ! compute domain
-#         int_ratio = 1./(dp0(k-1)+dp0(k))
-#         do j=js1, je1
-#            do i=is1, ie2
-#               xfx(i,j) = (dp0(k)*ut(i,j,k-1)+dp0(k-1)*ut(i,j,k))*int_ratio
-#            enddo
-#         enddo
-#         do j=js1, je2
-#            do i=is1, ie1
-#               yfx(i,j) = (dp0(k)*vt(i,j,k-1)+dp0(k-1)*vt(i,j,k))*int_ratio
-#            enddo
-#         enddo
-#      endif
 
 
 @gtscript.function
 def p_weighted_average_domain(vel, dp0):
-    # ratio = dp0 / ( dp0[-1] + dp0 )
-    # return ratio * vel[0, 0, -1] + (1. - ratio) * vel
     int_ratio = 1.0 / (dp0[-1] + dp0)
     return (dp0 * vel[0, 0, -1] + dp0[-1] * vel) * int_ratio
-
-
-#      do j=js-ng, je+ng
-#         do i=is-ng, ie+ng
-#            gz2(i,j) = gz(i,j,k)
-#         enddo
-#      enddo
-
-#      if (grid_type < 3) call fill_4corners(gz2, 1, bd, npx, npy, sw_corner, se_corner, ne_corner, nw_corner) # noqa: E501
-
-#      do j=js1, je1
-#         do i=is1, ie2
-#            if( xfx(i,j) > 0.0 ) then
-#                fx(i,j) = gz2(i-1,j)
-#            else
-#                fx(i,j) = gz2(i  ,j)
-#            endif
-#            fx(i,j) = xfx(i,j)*fx(i,j)
-#         enddo
-#      enddo
-
-#      if (grid_type < 3) call fill_4corners(gz2, 2, bd, npx, npy, sw_corner, se_corner, ne_corner, nw_corner) # noqa: E501
-
-#      do j=js1,je2
-#         do i=is1,ie1
-#            if( yfx(i,j) > 0.0 ) then
-#                fy(i,j) = gz2(i,j-1)
-#            else
-#                fy(i,j) = gz2(i,j)
-#            endif
-#            fy(i,j) = yfx(i,j)*fy(i,j)
-#         enddo
-#      enddo
 
 
 @gtscript.function
@@ -169,29 +38,13 @@ def xy_flux(gz_x, gz_y, xfx, yfx):
     return fx, fy
 
 
-#      do j=js1, je1
-#         do i=is1,ie1
-#            gz(i,j,k) = (gz2(i,j)*area(i,j) +  fx(i,j)- fx(i+1,j)+ fy(i,j)- fy(i,j+1)) & # noqa: E501
-#                      / (         area(i,j) + xfx(i,j)-xfx(i+1,j)+yfx(i,j)-yfx(i,j+1)) # noqa: E501
-#         enddo
-#      enddo
-
-#   end do
-
-# ! Enforce monotonicity of height to prevent blowup
-#   do i=is1, ie1
-#      do j=js1, je1
-#         ws(i,j) = ( zs(i,j) - gz(i,j,km+1) ) * rdt
-#      enddo
-#   end do
-
-#   do k = km, 1, -1
-#      do j=js1, je1
-#         do i=is1, ie1
-#            gz(i,j,k) = max( gz(i,j,k), gz(i,j,k+1) + dz_min )
-#         enddo
-#      enddo
-#   enddo
+@gtstencil
+def set_zero_2d(out_field: FloatFieldIJ):
+    with computation(FORWARD):
+        with interval(0, 1):
+            out_field = 0.0  # in_field
+        with interval(1, None):
+            out_field = out_field
 
 
 @gtstencil()
@@ -204,7 +57,7 @@ def update_dz_c(
     gz: FloatField,
     gz_x: FloatField,
     gz_y: FloatField,
-    ws3: FloatFieldIJ,
+    ws: FloatFieldIJ,
     *,
     dt: float,
 ):
@@ -226,7 +79,7 @@ def update_dz_c(
         )
     with computation(FORWARD), interval(-1, None):
         rdt = 1.0 / dt
-        ws3 = (zs - gz) * rdt
+        ws = (zs - gz) * rdt
     with computation(BACKWARD), interval(0, -1):
         gz_kp1 = gz[0, 0, 1] + DZ_MIN
         gz = gz if gz > gz_kp1 else gz_kp1
@@ -237,23 +90,20 @@ def compute(
     zs: FloatFieldIJ,
     ut: FloatField,
     vt: FloatField,
-    gz_in: FloatField,
-    ws3: FloatFieldIJ,
+    gz: FloatField,
+    ws: FloatFieldIJ,
     dt2: float,
 ):
     grid = spec.grid
     origin = (1, 1, 0)
-    gz = copy(gz_in, origin=origin, cache_key="updatedzc_gz")
+    gz_in = copy(gz, origin=origin, cache_key="updatedzc_gz")
     gz_x = copy(gz, origin=origin, cache_key="updatedzc_gz_x")
-    ws = copy(
-        ws3,
-        origin=grid.full_origin(),
-        domain=grid.domain_shape_full(add=(1, 1, 0)),
-        cache_key="updatedzc_ws",
-    )
-    corners.fill_corners_cells(gz_x, "x")
+
+    #corners.fill_corners_cells(gz_x, "x")
+    corners.fill_corners_2cells_x_stencil(gz_x, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1)))
     gz_y = copy(gz_x, origin=origin, cache_key="updatedzc_gz_y")
-    corners.fill_corners_cells(gz_y, "y")
+    #corners.fill_corners_cells(gz_y, "y")
+    corners.fill_corners_2cells_y_stencil(gz_y, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1)))
     update_dz_c(
         dp_ref,
         zs,
@@ -263,11 +113,13 @@ def compute(
         gz,
         gz_x,
         gz_y,
-        ws3,
+        ws,
         dt=dt2,
         origin=origin,
         domain=(grid.nic + 3, grid.njc + 3, grid.npz + 1),
     )
-    grid.overwrite_edges(gz, gz_in, 2, 2)
-    grid.overwrite_edges(ws3, ws, 2, 2)
-    return gz, ws3
+
+    set_zero_2d(ws, origin=(1, 1, 0), domain=(1, grid.njc + 3, 1))
+    set_zero_2d(ws, origin=(1, 1, 0), domain=(grid.nic + 3, 1, 1))
+    copy_stencil(gz_in, gz, origin=(1, 1, 0), domain=(1, grid.njc + 3, grid.npz + 1))
+    copy_stencil(gz_in, gz, origin=(1, 1, 0), domain=(grid.nic + 3, 1, grid.npz + 1))

--- a/fv3core/stencils/updatedzc.py
+++ b/fv3core/stencils/updatedzc.py
@@ -99,11 +99,15 @@ def compute(
     gz_in = copy(gz, origin=origin, cache_key="updatedzc_gz")
     gz_x = copy(gz, origin=origin, cache_key="updatedzc_gz_x")
 
-    #corners.fill_corners_cells(gz_x, "x")
-    corners.fill_corners_2cells_x_stencil(gz_x, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1)))
+    # corners.fill_corners_cells(gz_x, "x")
+    corners.fill_corners_2cells_x_stencil(
+        gz_x, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1))
+    )
     gz_y = copy(gz_x, origin=origin, cache_key="updatedzc_gz_y")
-    #corners.fill_corners_cells(gz_y, "y")
-    corners.fill_corners_2cells_y_stencil(gz_y, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1)))
+    # corners.fill_corners_cells(gz_y, "y")
+    corners.fill_corners_2cells_y_stencil(
+        gz_y, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1))
+    )
     update_dz_c(
         dp_ref,
         zs,

--- a/fv3core/utils/corners.py
+++ b/fv3core/utils/corners.py
@@ -48,6 +48,15 @@ def fill_corners_2cells_mult_x(
     return q
 
 
+@gtstencil()
+def fill_corners_2cells_x_stencil(q: FloatField):
+    with computation(PARALLEL), interval(...):
+        q = fill_corners_2cells_mult_x(q, q, 1.0, 1.0, 1.0, 1.0)
+@gtstencil()
+def fill_corners_2cells_y_stencil(q: FloatField):
+    with computation(PARALLEL), interval(...):
+        q = fill_corners_2cells_mult_y(q, q, 1.0, 1.0, 1.0, 1.0)
+
 @gtscript.function
 def fill_corners_2cells_x(q: FloatField):
     """

--- a/fv3core/utils/corners.py
+++ b/fv3core/utils/corners.py
@@ -52,10 +52,13 @@ def fill_corners_2cells_mult_x(
 def fill_corners_2cells_x_stencil(q: FloatField):
     with computation(PARALLEL), interval(...):
         q = fill_corners_2cells_mult_x(q, q, 1.0, 1.0, 1.0, 1.0)
+
+
 @gtstencil()
 def fill_corners_2cells_y_stencil(q: FloatField):
     with computation(PARALLEL), interval(...):
         q = fill_corners_2cells_mult_y(q, q, 1.0, 1.0, 1.0, 1.0)
+
 
 @gtscript.function
 def fill_corners_2cells_x(q: FloatField):

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -340,54 +340,6 @@ class Grid:
     def vvar_edge_halo(self, var):
         return self.copy_right_edge(var, self.ie + 1, self.je + 2)
 
-    def edge_offset_halos(self, uvar, vvar):
-        u_edge_i, u_edge_j = self.uvar_edge_halo(uvar)
-        v_edge_i, v_edge_j = self.vvar_edge_halo(vvar)
-        return u_edge_i, u_edge_j, v_edge_i, v_edge_j
-
-    def insert_edge(self, var, edge_data, index):
-        var[index] = edge_data
-
-    def append_edges(self, uvar, u_edge_i, u_edge_j, vvar, v_edge_i, v_edge_j):
-        self.insert_right_edge(uvar, u_edge_i, self.ie + 2, u_edge_j, self.je + 1)
-        self.insert_right_edge(vvar, v_edge_i, self.ie + 1, v_edge_j, self.je + 2)
-
-    def overwrite_edges(self, var, edgevar, left_i_index, left_j_index):
-        if len(var.shape) < 3:
-            self.insert_left_edge(
-                var,
-                edgevar[:left_i_index, :],
-                left_i_index,
-                edgevar[:, :left_j_index],
-                left_j_index,
-            )
-            right_i_index = self.ie + left_i_index
-            right_j_index = self.ie + left_j_index
-            self.insert_right_edge(
-                var,
-                edgevar[right_i_index:, :],
-                right_i_index,
-                edgevar[:, right_j_index:],
-                right_j_index,
-            )
-        else:
-            self.insert_left_edge(
-                var,
-                edgevar[:left_i_index, :, :],
-                left_i_index,
-                edgevar[:, :left_j_index, :],
-                left_j_index,
-            )
-            right_i_index = self.ie + left_i_index
-            right_j_index = self.ie + left_j_index
-            self.insert_right_edge(
-                var,
-                edgevar[right_i_index:, :, :],
-                right_i_index,
-                edgevar[:, right_j_index:, :],
-                right_j_index,
-            )
-
     def compute_origin(self, add: Tuple[int, int, int] = (0, 0, 0)):
         """Start of the compute domain (e.g. (halo, halo, 0))"""
         return (self.is_ + add[0], self.js + add[1], add[2])

--- a/tests/translate/translate_updatedzc.py
+++ b/tests/translate/translate_updatedzc.py
@@ -11,16 +11,11 @@ class TranslateUpdateDzC(TranslateFortranData2Py):
             "zs": {},
             "ut": {"serialname": "utc"},
             "vt": {"serialname": "vtc"},
-            "gz_in": {"serialname": "gz"},
-            "ws3": {"serialname": "ws"},
+            "gz": {},
+            "ws": {},
         }
         self.in_vars["parameters"] = ["dt2"]
         self.out_vars = {
             "gz": grid.default_buffer_k_dict(),
             "ws": {"kstart": -1, "kend": None},
         }
-
-    def compute(self, inputs):
-        self.make_storage_data_input_vars(inputs)
-        gz, ws = self.compute_func(**inputs)
-        return self.slice_output(inputs, {"gz": gz, "ws": ws})


### PR DESCRIPTION
## Purpose

We have a waiting PR  #247 that does all of updatedzc in a single stencil, the problem is it doesn't work for the gtx86 backend, likely due to the corners calls. While we wait for regions to solve this, just doing the minimal here to get validation and remove python functions from this. We are not doing the renaming or the docstrings or that stuff here, as that is part of the other PR that will be done soon. Let's just unmuddy the profile waters


## Code changes:

- updatedzc calls a fill_corners stencil rather than a routine that spawns a gtscript runtime function
- udpatedzc no longer uses the python code overwrite_edges and instead uses copy methods for stencils
- python code for overwriting edges is removed
- updatedzc test code is simplified as we do not need to return different variables than we pass in

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
