### PR TITLE
Remove prints from fv3core on all ranks

### DIFF
--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -170,6 +170,8 @@ if __name__ == "__main__":
         # warm-up timestep.
         # We're intentionally not passing the timer here to exclude
         # warmup/compilation from the internal timers
+        if rank == 0:
+            print("timestep 1")
         dycore.step_dynamics(
             state,
             input_data["consv_te"],
@@ -185,6 +187,8 @@ if __name__ == "__main__":
 
     with timer.clock("mainloop"):
         for i in range(args.time_step - 1):
+            if rank == 0:
+                print(f"timestep {i+2}")
             dycore.step_dynamics(
                 state,
                 input_data["consv_te"],
@@ -217,5 +221,5 @@ if __name__ == "__main__":
         filename = now.strftime("%Y-%m-%d-%H-%M-%S")
         write_global_timings(experiment, filename, comm)
 
-    if comm.Get_rank() == 0:
+    if rank == 0:
         print("SUCCESS")

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -59,7 +59,9 @@ def compute_preamble(state, comm, grid, namelist):
 
     if namelist.hydrostatic:
         raise Exception("Hydrostatic is not implemented")
-    print("FV Setup", grid.rank)
+    if __debug__:
+        if grid.rank == 0:
+            print("FV Setup")
     moist_cv.fv_setup(
         state.pt,
         state.pkz,
@@ -81,7 +83,9 @@ def compute_preamble(state, comm, grid, namelist):
     if state.consv_te > 0 and not state.do_adiabatic_init:
         # NOTE: Not run in default configuration (turned off consv_te so we don't
         # need a global allreduce).
-        print("Compute Total Energy", grid.rank)
+        if __debug__:
+            if grid.rank == 0:
+                print("Compute Total Energy")
         moist_cv.compute_total_energy(
             state.u,
             state.v,
@@ -105,7 +109,9 @@ def compute_preamble(state, comm, grid, namelist):
 
     if (not namelist.rf_fast) and namelist.tau != 0:
         if grid.grid_type < 4:
-            print("Rayleigh Super", grid.rank)
+            if __debug__:
+                if grid.rank == 0:
+                    print("Rayleigh Super")
             rayleigh_super.compute(
                 state.u,
                 state.v,
@@ -126,7 +132,9 @@ def compute_preamble(state, comm, grid, namelist):
             "unimplemented namelist options adiabatic with positive kord_tm"
         )
     else:
-        print("Adjust pt", grid.rank)
+        if __debug__:
+            if grid.rank == 0:
+                print("Adjust pt")
         pt_adjust(
             state.pkz,
             state.dp1,
@@ -140,7 +148,9 @@ def compute_preamble(state, comm, grid, namelist):
 def post_remap(state, comm, grid, namelist):
     grid = grid
     if not namelist.hydrostatic:
-        print("Omega", grid.rank)
+        if __debug__:
+            if grid.rank == 0:
+                print("Omega")
         set_omega(
             state.delp,
             state.delz,
@@ -150,14 +160,18 @@ def post_remap(state, comm, grid, namelist):
             domain=grid.domain_shape_compute(),
         )
     if namelist.nf_omega > 0:
-        print("Del2Cubed", grid.rank)
+        if __debug__:
+            if grid.rank == 0:
+                print("Del2Cubed")
         if global_config.get_do_halo_exchange():
             comm.halo_update(state.omga_quantity, n_points=utils.halo)
         del2cubed.compute(state.omga, namelist.nf_omega, 0.18 * grid.da_min, grid.npz)
 
 
 def wrapup(state, comm: fv3gfs.util.CubedSphereCommunicator, grid):
-    print("Neg Adj 3", grid.rank)
+    if __debug__:
+        if grid.rank == 0:
+            print("Neg Adj 3")
     neg_adj3.compute(
         state.qvapor,
         state.qliquid,
@@ -172,7 +186,9 @@ def wrapup(state, comm: fv3gfs.util.CubedSphereCommunicator, grid):
         state.peln,
     )
 
-    print("CubedToLatLon", grid.rank)
+    if __debug__:
+        if grid.rank == 0:
+            print("CubedToLatLon")
     c2l_ord.compute_cubed_to_latlon(
         state.u_quantity, state.v_quantity, state.ua, state.va, comm, True
     )
@@ -359,7 +375,9 @@ class DynamicalCore:
                 # issue is that set_val in map_single expects a 3D field for the
                 # "surface" array
                 state.wsd_3d[:] = utils.reshape(state.wsd, state.wsd_3d.shape)
-                print("Remapping", self.grid.rank)
+                if __debug__:
+                    if self.grid.rank == 0:
+                        print("Remapping")
                 with timer.clock("Remapping"):
                     lagrangian_to_eulerian.compute(
                         state.__dict__,
@@ -409,11 +427,15 @@ class DynamicalCore:
             origin=self.grid.full_origin(),
             domain=self.grid.domain_shape_full(),
         )
-        print("DynCore", self.grid.rank)
+        if __debug__:
+            if self.grid.rank == 0:
+                print("DynCore")
         with timer.clock("DynCore"):
             dyn_core.compute(state, self.comm)
         if self.namelist.z_tracer:
-            print("Tracer2D1L", self.grid.rank)
+            if __debug__:
+                if self.grid.rank == 0:
+                    print("Tracer2D1L")
             with timer.clock("TracerAdvection"):
                 self.tracer_advection(
                     state.__dict__,

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -59,7 +59,6 @@ def compute_preamble(state, comm, grid, namelist):
 
     if namelist.hydrostatic:
         raise Exception("Hydrostatic is not implemented")
-    print("FV Setup", grid.rank)
     moist_cv.fv_setup(
         state.pt,
         state.pkz,
@@ -81,7 +80,6 @@ def compute_preamble(state, comm, grid, namelist):
     if state.consv_te > 0 and not state.do_adiabatic_init:
         # NOTE: Not run in default configuration (turned off consv_te so we don't
         # need a global allreduce).
-        print("Compute Total Energy", grid.rank)
         moist_cv.compute_total_energy(
             state.u,
             state.v,
@@ -105,7 +103,6 @@ def compute_preamble(state, comm, grid, namelist):
 
     if (not namelist.rf_fast) and namelist.tau != 0:
         if grid.grid_type < 4:
-            print("Rayleigh Super", grid.rank)
             rayleigh_super.compute(
                 state.u,
                 state.v,
@@ -126,7 +123,6 @@ def compute_preamble(state, comm, grid, namelist):
             "unimplemented namelist options adiabatic with positive kord_tm"
         )
     else:
-        print("Adjust pt", grid.rank)
         pt_adjust(
             state.pkz,
             state.dp1,
@@ -140,7 +136,6 @@ def compute_preamble(state, comm, grid, namelist):
 def post_remap(state, comm, grid, namelist):
     grid = grid
     if not namelist.hydrostatic:
-        print("Omega", grid.rank)
         set_omega(
             state.delp,
             state.delz,
@@ -150,14 +145,12 @@ def post_remap(state, comm, grid, namelist):
             domain=grid.domain_shape_compute(),
         )
     if namelist.nf_omega > 0:
-        print("Del2Cubed", grid.rank)
         if global_config.get_do_halo_exchange():
             comm.halo_update(state.omga_quantity, n_points=utils.halo)
         del2cubed.compute(state.omga, namelist.nf_omega, 0.18 * grid.da_min, grid.npz)
 
 
 def wrapup(state, comm: fv3gfs.util.CubedSphereCommunicator, grid):
-    print("Neg Adj 3", grid.rank)
     neg_adj3.compute(
         state.qvapor,
         state.qliquid,
@@ -172,7 +165,6 @@ def wrapup(state, comm: fv3gfs.util.CubedSphereCommunicator, grid):
         state.peln,
     )
 
-    print("CubedToLatLon", grid.rank)
     c2l_ord.compute_cubed_to_latlon(
         state.u_quantity, state.v_quantity, state.ua, state.va, comm, True
     )
@@ -359,7 +351,6 @@ class DynamicalCore:
                 # issue is that set_val in map_single expects a 3D field for the
                 # "surface" array
                 state.wsd_3d[:] = utils.reshape(state.wsd, state.wsd_3d.shape)
-                print("Remapping", self.grid.rank)
                 with timer.clock("Remapping"):
                     lagrangian_to_eulerian.compute(
                         state.__dict__,
@@ -409,11 +400,9 @@ class DynamicalCore:
             origin=self.grid.full_origin(),
             domain=self.grid.domain_shape_full(),
         )
-        print("DynCore", self.grid.rank)
         with timer.clock("DynCore"):
             dyn_core.compute(state, self.comm)
         if self.namelist.z_tracer:
-            print("Tracer2D1L", self.grid.rank)
             with timer.clock("TracerAdvection"):
                 self.tracer_advection(
                     state.__dict__,


### PR DESCRIPTION
## Purpose

We should not be printing from within the dycore from all ranks. This PR removes those prints and adds some basic timestepping information to stdout for the standalone dynamical core.

## Code changes:

- `fv_dynamics.py` - print()'s removed
- `dynamics.py` - print()'s of current timestep on root rank added

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
