### PR TITLE
Reduce remaining files upon successful CI execution

### DIFF
--- a/.jenkins/actions/run_standalone.sh
+++ b/.jenkins/actions/run_standalone.sh
@@ -117,6 +117,7 @@ if [ "${DO_PROFILE}" == "true" ] ; then
 fi
 
 # remove venv (too many files!)
+rm -rf $ROOT_DIR/external/*
 rm -rf $ROOT_DIR/venv
 
 echo "=== Done ======================================="


### PR DESCRIPTION
## Purpose

This PR removes externals/* if the execution of profiling or performance testing is successful. Helps reduce the number of files on Daint.

