### PR TITLE
Oop/dyn core

### DIFF
--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -230,6 +230,7 @@ class AcousticDynamics:
         }
         self._p_grad_c = FixedOriginStencil(p_grad_c_stencil, **pgradc_kwargs)
         self._initialize_data = FixedOriginStencil(initialize_data, origin=self.grid.full_origin(), domain=self.grid.domain_shape_full(), externals={"hydrostatic":self.namelist.hydrostatic})
+        
     def __call__(self, state):
         # u, v, w, delz, delp, pt, pe, pk, phis, wsd, omga, ua, va, uc, vc, mfxd,
         # mfyd, cxd, cyd, pkz, peln, q_con, ak, bk, diss_estd, cappa, mdt, n_split,

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -36,19 +36,32 @@ from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
 HUGE_R = 1.0e40
 
-def initialize_data(mfxd: FloatField, mfyd: FloatField, cxd: FloatField, cyd: FloatField, gz: FloatField, pk3: FloatField,diss_estd: FloatField,  init_step: bool):
+
+def initialize_data(
+    mfxd: FloatField,
+    mfyd: FloatField,
+    cxd: FloatField,
+    cyd: FloatField,
+    gz: FloatField,
+    pk3: FloatField,
+    diss_estd: FloatField,
+    init_step: bool,
+):
     with computation(PARALLEL), interval(...):
         from __externals__ import hydrostatic
+
         mfxd = 0.0
         mfyd = 0.0
         cxd = 0.0
         cyd = 0.0
         if init_step:
             gz = HUGE_R
-            with horizontal(region[3: -3, 3:-3]):
+            with horizontal(region[3:-3, 3:-3]):
                 diss_estd = 0.0
             if __INLINED(not hydrostatic):
                 pk3 = HUGE_R
+
+
 # NOTE in Fortran these are columns
 def dp_ref_compute(
     ak: FloatFieldK,
@@ -229,8 +242,13 @@ class AcousticDynamics:
             "externals": {"hydrostatic": self.namelist.hydrostatic, **ax_offsets},
         }
         self._p_grad_c = FixedOriginStencil(p_grad_c_stencil, **pgradc_kwargs)
-        self._initialize_data = FixedOriginStencil(initialize_data, origin=self.grid.full_origin(), domain=self.grid.domain_shape_full(), externals={"hydrostatic":self.namelist.hydrostatic})
-        
+        self._initialize_data = FixedOriginStencil(
+            initialize_data,
+            origin=self.grid.full_origin(),
+            domain=self.grid.domain_shape_full(),
+            externals={"hydrostatic": self.namelist.hydrostatic},
+        )
+
     def __call__(self, state):
         # u, v, w, delz, delp, pt, pe, pk, phis, wsd, omga, ua, va, uc, vc, mfxd,
         # mfyd, cxd, cyd, pkz, peln, q_con, ak, bk, diss_estd, cappa, mdt, n_split,
@@ -269,7 +287,16 @@ class AcousticDynamics:
 
         state.__dict__.update(self._temporaries)
 
-        self._initialize_data(state.mfxd, state.mfyd, state.cxd, state.cyd, state.gz, state.pk3, state.diss_estd, init_step)
+        self._initialize_data(
+            state.mfxd,
+            state.mfyd,
+            state.cxd,
+            state.cyd,
+            state.gz,
+            state.pk3,
+            state.diss_estd,
+            init_step,
+        )
         if not hydrostatic:
             # k1k = akap / (1.0 - akap)
             self._dp_ref_compute(

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -27,16 +27,15 @@ import fv3core.utils.global_config as global_config
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util as fv3util
-from fv3core.decorators import gtstencil
 from fv3core.stencils.basic_operations import copy_stencil
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
-
-
+from fv3core.decorators import FixedOriginStencil
+import fv3gfs.util
+from fv3core.utils.grid import axis_offsets
 HUGE_R = 1.0e40
 
 
 # NOTE in Fortran these are columns
-@gtstencil()
 def dp_ref_compute(
     ak: FloatFieldK,
     bk: FloatFieldK,
@@ -51,7 +50,6 @@ def dp_ref_compute(
         zs = phis * rgrav
 
 
-@gtstencil()
 def set_gz(zs: FloatFieldIJ, delz: FloatField, gz: FloatField):
     with computation(BACKWARD):
         with interval(-1, None):
@@ -60,7 +58,6 @@ def set_gz(zs: FloatFieldIJ, delz: FloatField, gz: FloatField):
             gz[0, 0, 0] = gz[0, 0, 1] - delz
 
 
-@gtstencil()
 def set_pem(delp: FloatField, pem: FloatField, ptop: float):
     with computation(FORWARD):
         with interval(0, 1):
@@ -69,19 +66,6 @@ def set_pem(delp: FloatField, pem: FloatField, ptop: float):
             pem[0, 0, 0] = pem[0, 0, -1] + delp
 
 
-@gtstencil()
-def heatadjust_temperature_lowlevel(
-    pt: FloatField,
-    heat_source: FloatField,
-    delp: FloatField,
-    pkz: FloatField,
-    cp_air: float,
-):
-    with computation(PARALLEL), interval(...):
-        pt[0, 0, 0] = pt + heat_source / (cp_air * delp * pkz)
-
-
-@gtstencil()
 def p_grad_c_stencil(
     rdxc: FloatFieldIJ,
     rdyc: FloatFieldIJ,
@@ -111,10 +95,10 @@ def p_grad_c_stencil(
     Grid variable inputs:
         rdxc, rdyc
     """
-    from __externals__ import local_ie, local_is, local_je, local_js, namelist
+    from __externals__ import local_ie, local_is, local_je, local_js, hydrostatic
 
     with computation(PARALLEL), interval(...):
-        if __INLINED(namelist.hydrostatic):
+        if __INLINED(hydrostatic):
             wk = pkc[0, 0, 1] - pkc
         else:
             wk = delpc
@@ -132,22 +116,21 @@ def p_grad_c_stencil(
             )
 
 
-def get_n_con():
-    if spec.namelist.convert_ke or spec.namelist.vtdm4 > 1.0e-4:
-        n_con = spec.grid.npz
+def get_n_con(namelist, grid):
+    if namelist.convert_ke or namelist.vtdm4 > 1.0e-4:
+        n_con = grid.npz
     else:
-        if spec.namelist.d2_bg_k1 < 1.0e-3:
+        if namelist.d2_bg_k1 < 1.0e-3:
             n_con = 0
         else:
-            if spec.namelist.d2_bg_k2 < 1.0e-3:
+            if namelist.d2_bg_k2 < 1.0e-3:
                 n_con = 1
             else:
                 n_con = 2
     return n_con
 
 
-def dyncore_temporaries(shape):
-    grid = spec.grid
+def dyncore_temporaries(shape, namelist, grid):
     tmps = {}
     utils.storage_dict(
         tmps,
@@ -155,6 +138,14 @@ def dyncore_temporaries(shape):
         shape,
         grid.full_origin(),
     )
+    if not namelist.hydrostatic:
+        # To write in parallel region, these need to be 3D first 
+        utils.storage_dict(
+            tmps,
+            ["dp_ref", "zs"],
+            shape,
+            grid.full_origin(),
+        )
     utils.storage_dict(
         tmps,
         ["ws3"],
@@ -179,381 +170,381 @@ def dyncore_temporaries(shape):
         "divgd",
         dims=[fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
     )
+
     return tmps
 
-
-def compute(state, comm):
-    # u, v, w, delz, delp, pt, pe, pk, phis, wsd, omga, ua, va, uc, vc, mfxd,
-    # mfyd, cxd, cyd, pkz, peln, q_con, ak, bk, diss_estd, cappa, mdt, n_split,
-    # akap, ptop, pfull, n_map, comm):
-    grid = spec.grid
-    nonhydrostatic_pressure = utils.cached_stencil_class(
-        nh_p_grad.NonHydrostaticPressureGradient
-    )(cache_key="dyn_core_nhpgrad")
-    init_step = state.n_map == 1
-    end_step = state.n_map == spec.namelist.k_split
-    akap = constants.KAPPA
-    # peln1 = math.log(ptop)
-    # ptk = ptop**akap
-    dt = state.mdt / spec.namelist.n_split
-    dt2 = 0.5 * dt
-    hydrostatic = spec.namelist.hydrostatic
-    rgrav = 1.0 / constants.GRAV
-    n_split = spec.namelist.n_split
-    # TODO: Put defaults into code.
-    # m_split = 1. + abs(dt_atmos)/real(k_split*n_split*abs(p_split))
-    # n_split = nint( real(n0split)/real(k_split*abs(p_split)) * stretch_fac + 0.5 )
-    ms = max(1, spec.namelist.m_split / 2.0)
-    shape = state.delz.shape
-    # NOTE: In Fortran model the halo update starts happens in fv_dynamics, not here.
-    reqs = {}
-    if global_config.get_do_halo_exchange():
-        for halovar in [
-            "q_con_quantity",
-            "cappa_quantity",
-            "delp_quantity",
-            "pt_quantity",
-        ]:
-            reqs[halovar] = comm.start_halo_update(
-                state.__getattribute__(halovar), n_points=utils.halo
+class AcousticDynamics:
+    """
+    Fortran name is dyn_core
+    Peforms the Lagrangian acoustic dynamics described by Lin 2004
+    """
+    def __init__(self, comm: fv3gfs.util.CubedSphereCommunicator, namelist):
+        self.comm = comm
+        self.namelist = namelist
+        self.grid = spec.grid
+        self.do_halo_exchange = global_config.get_do_halo_exchange()
+        self.n_con = get_n_con(namelist, self.grid)
+        self.nonhydrostatic_pressure = nh_p_grad.NonHydrostaticPressureGradient()
+        self._temporaries = dyncore_temporaries(self.grid.domain_shape_full(add=(1, 1, 1)), self.namelist, self.grid)
+        self._dp_ref_compute = FixedOriginStencil(dp_ref_compute, origin=self.grid.full_origin(),domain=self.grid.domain_shape_full(add=(0, 0, 1)))
+        self._set_gz = FixedOriginStencil(set_gz, origin=self.grid.compute_origin(), domain=self.grid.domain_shape_compute(add=(0, 0, 1)))
+        self._set_pem = FixedOriginStencil(set_pem, origin=self.grid.compute_origin(add=(-1, -1, 0)), domain=self.grid.domain_shape_compute(add=(2, 2, 0)))
+        pgradc_origin = self.grid.compute_origin()
+        pgradc_domain= self.grid.domain_shape_compute(add=(1, 1, 0))
+        ax_offsets = axis_offsets(self.grid, pgradc_origin, pgradc_domain)
+        pgradc_kwargs = {"origin":  pgradc_origin, "domain": pgradc_domain, "externals":{"hydrostatic": self.namelist.hydrostatic, **ax_offsets}}
+        self._p_grad_c = FixedOriginStencil(p_grad_c_stencil,  **pgradc_kwargs)
+                            
+    def __call__(self, state):
+        # u, v, w, delz, delp, pt, pe, pk, phis, wsd, omga, ua, va, uc, vc, mfxd,
+        # mfyd, cxd, cyd, pkz, peln, q_con, ak, bk, diss_estd, cappa, mdt, n_split,
+        # akap, ptop, pfull, n_map, comm):
+        grid = self.grid
+        init_step = state.n_map == 1
+        end_step = state.n_map == self.namelist.k_split
+        akap = constants.KAPPA
+        dt = state.mdt / self.namelist.n_split
+        dt2 = 0.5 * dt
+        hydrostatic = self.namelist.hydrostatic
+        rgrav = 1.0 / constants.GRAV
+        n_split = self.namelist.n_split
+        # TODO: Put defaults into code.
+        # m_split = 1. + abs(dt_atmos)/real(k_split*n_split*abs(p_split))
+        # n_split = nint( real(n0split)/real(k_split*abs(p_split)) * stretch_fac + 0.5 )
+        ms = max(1, self.namelist.m_split / 2.0)
+        shape = state.delz.shape
+        # NOTE: In Fortran model the halo update starts happens in fv_dynamics, not here.
+        reqs = {}
+        if self.do_halo_exchange:
+            for halovar in [
+                "q_con_quantity",
+                "cappa_quantity",
+                "delp_quantity",
+                "pt_quantity",
+            ]:
+                reqs[halovar] = self.comm.start_halo_update(
+                    state.__getattribute__(halovar), n_points=utils.halo
+                )
+            reqs_vector = self.comm.start_vector_halo_update(
+                state.u_quantity, state.v_quantity, n_points=utils.halo
             )
-        reqs_vector = comm.start_vector_halo_update(
-            state.u_quantity, state.v_quantity, n_points=utils.halo
-        )
-        reqs["q_con_quantity"].wait()
-        reqs["cappa_quantity"].wait()
+            reqs["q_con_quantity"].wait()
+            reqs["cappa_quantity"].wait()
 
-    state.__dict__.update(dyncore_temporaries(shape))
-    if init_step:
-        state.gz[:-1, :-1, :] = HUGE_R
-        state.diss_estd[grid.slice_dict(grid.compute_dict())] = 0.0
-        if not hydrostatic:
-            state.pk3[:-1, :-1, :] = HUGE_R
-    state.mfxd[grid.slice_dict(grid.x3d_compute_dict())] = 0.0
-    state.mfyd[grid.slice_dict(grid.y3d_compute_dict())] = 0.0
-    state.cxd[grid.slice_dict(grid.x3d_compute_domain_y_dict())] = 0.0
-    state.cyd[grid.slice_dict(grid.y3d_compute_domain_x_dict())] = 0.0
-
-    if not hydrostatic:
-        # k1k = akap / (1.0 - akap)
-
-        # To write in parallel region, these need to be 3D first
-        state.dp_ref = utils.make_storage_from_shape(
-            shape, grid.full_origin(), cache_key="dyn_core_dp_ref"
-        )
-        state.zs = utils.make_storage_from_shape(
-            shape, grid.full_origin(), cache_key="dyn_core_zs"
-        )
-        dp_ref_compute(
-            state.ak,
-            state.bk,
-            state.phis,
-            state.dp_ref,
-            state.zs,
-            rgrav,
-            origin=grid.full_origin(),
-            domain=grid.domain_shape_full(add=(0, 0, 1)),
-        )
-        # After writing, make 'dp_ref' a K-field and 'zs' an IJ-field
-        state.dp_ref = utils.make_storage_data(state.dp_ref[0, 0, :], (shape[2],), (0,))
-        state.zs = utils.make_storage_data(state.zs[:, :, 0], shape[0:2], (0, 0))
-    n_con = get_n_con()
-
-    # "acoustic" loop
-    # called this because its timestep is usually limited by horizontal sound-wave
-    # processes. Note this is often not the limiting factor near the poles, where
-    # the speed of the polar night jets can exceed two-thirds of the speed of sound.
-    for it in range(n_split):
-        # the Lagrangian dynamics have two parts. First we advance the C-grid winds
-        # by half a time step (c_sw). Then the C-grid winds are used to define advective
-        # fluxes to advance the D-grid prognostic fields a full time step
-        # (the rest of the routines).
-        #
-        # Along-surface flux terms (mass, heat, vertical momentum, vorticity,
-        # kinetic energy gradient terms) are evaluated forward-in-time.
-        #
-        # The pressure gradient force and elastic terms are then evaluated
-        # backwards-in-time, to improve stability.
-        remap_step = False
-        if spec.namelist.breed_vortex_inline or (it == n_split - 1):
-            remap_step = True
-        if not hydrostatic:
-            if global_config.get_do_halo_exchange():
-                reqs["w_quantity"] = comm.start_halo_update(
-                    state.w_quantity, n_points=utils.halo
-                )
-            if it == 0:
-                set_gz(
-                    state.zs,
-                    state.delz,
-                    state.gz,
-                    origin=grid.compute_origin(),
-                    domain=(grid.nic, grid.njc, grid.npz + 1),
-                )
-                if global_config.get_do_halo_exchange():
-                    reqs["gz_quantity"] = comm.start_halo_update(
-                        state.gz_quantity, n_points=utils.halo
-                    )
-        if it == 0:
-            if global_config.get_do_halo_exchange():
-                reqs["delp_quantity"].wait()
-                reqs["pt_quantity"].wait()
-
-        if it == n_split - 1 and end_step:
-            if spec.namelist.use_old_omega:  # apparently True
-                set_pem(
-                    state.delp,
-                    state.pem,
-                    state.ptop,
-                    origin=(grid.is_ - 1, grid.js - 1, 0),
-                    domain=(grid.nic + 2, grid.njc + 2, grid.npz),
-                )
-        if global_config.get_do_halo_exchange():
-            reqs_vector.wait()
+        state.__dict__.update(self._temporaries)
+        if init_step:
+            state.gz[:-1, :-1, :] = HUGE_R
+            state.diss_estd[grid.slice_dict(grid.compute_dict())] = 0.0
             if not hydrostatic:
-                reqs["w_quantity"].wait()
+                state.pk3[:-1, :-1, :] = HUGE_R
+        state.mfxd[grid.slice_dict(grid.x3d_compute_dict())] = 0.0
+        state.mfyd[grid.slice_dict(grid.y3d_compute_dict())] = 0.0
+        state.cxd[grid.slice_dict(grid.x3d_compute_domain_y_dict())] = 0.0
+        state.cyd[grid.slice_dict(grid.y3d_compute_domain_x_dict())] = 0.0
 
-        # compute the c-grid winds at t + 1/2 timestep
-        state.delpc, state.ptc = c_sw.compute(
-            state.delp,
-            state.pt,
-            state.u,
-            state.v,
-            state.w,
-            state.uc,
-            state.vc,
-            state.ua,
-            state.va,
-            state.ut,
-            state.vt,
-            state.divgd,
-            state.omga,
-            dt2,
-        )
-
-        if spec.namelist.nord > 0 and global_config.get_do_halo_exchange():
-            reqs["divgd_quantity"] = comm.start_halo_update(
-                state.divgd_quantity, n_points=utils.halo
-            )
         if not hydrostatic:
-            if it == 0:
-                if global_config.get_do_halo_exchange():
-                    reqs["gz_quantity"].wait()
-                copy_stencil(
-                    state.gz,
-                    state.zh,
-                    origin=grid.full_origin(),
-                    domain=grid.domain_shape_full(add=(0, 0, 1)),
-                )
-            else:
-                copy_stencil(
-                    state.zh,
-                    state.gz,
-                    origin=grid.full_origin(),
-                    domain=grid.domain_shape_full(add=(0, 0, 1)),
-                )
-        if not hydrostatic:
-            updatedzc.compute(
-                state.dp_ref, state.zs, state.ut, state.vt, state.gz, state.ws3, dt2
-            )
-            riem_solver_c.compute(
-                ms,
-                dt2,
-                akap,
-                state.cappa,
-                state.ptop,
+            # k1k = akap / (1.0 - akap)
+            self._dp_ref_compute(
+                state.ak,
+                state.bk,
                 state.phis,
-                state.omga,
-                state.ptc,
-                state.q_con,
-                state.delpc,
-                state.gz,
-                state.pkc,
-                state.ws3,
-            )
-
-        p_grad_c_stencil(
-            grid.rdxc,
-            grid.rdyc,
-            state.uc,
-            state.vc,
-            state.delpc,
-            state.pkc,
-            state.gz,
-            dt2,
-            origin=grid.compute_origin(),
-            domain=grid.domain_shape_compute(add=(1, 1, 0)),
-        )
-        if global_config.get_do_halo_exchange():
-            reqc_vector = comm.start_vector_halo_update(
-                state.uc_quantity, state.vc_quantity, n_points=utils.halo
-            )
-            if spec.namelist.nord > 0:
-                reqs["divgd_quantity"].wait()
-            reqc_vector.wait()
-        # use the computed c-grid winds to evolve the d-grid winds forward
-        # by 1 timestep
-        d_sw.compute(
-            state.vt,
-            state.delp,
-            state.ptc,
-            state.pt,
-            state.u,
-            state.v,
-            state.w,
-            state.uc,
-            state.vc,
-            state.ua,
-            state.va,
-            state.divgd,
-            state.mfxd,
-            state.mfyd,
-            state.cxd,
-            state.cyd,
-            state.crx,
-            state.cry,
-            state.xfx,
-            state.yfx,
-            state.q_con,
-            state.zh,
-            state.heat_source,
-            state.diss_estd,
-            dt,
-        )
-        # note that uc and vc are not needed at all past this point.
-        # they will be re-computed from scratch on the next acoustic timestep.
-
-        if global_config.get_do_halo_exchange():
-            for halovar in ["delp_quantity", "pt_quantity", "q_con_quantity"]:
-                comm.halo_update(state.__getattribute__(halovar), n_points=utils.halo)
-
-        # Not used unless we implement other betas and alternatives to nh_p_grad
-        # if spec.namelist.d_ext > 0:
-        #    raise 'Unimplemented namelist option d_ext > 0'
-        # else:
-        #    divg2 = utils.make_storage_from_shape(delz.shape, grid.compute_origin())
-
-        if not hydrostatic:
-            updatedzd.compute(
                 state.dp_ref,
                 state.zs,
-                state.zh,
+                rgrav,
+            )
+            # After writing, make 'dp_ref' a K-field and 'zs' an IJ-field
+            state.dp_ref = utils.make_storage_data(state.dp_ref[0, 0, :], (shape[2],), (0,))
+            state.zs = utils.make_storage_data(state.zs[:, :, 0], shape[0:2], (0, 0))
+
+        # "acoustic" loop
+        # called this because its timestep is usually limited by horizontal sound-wave
+        # processes. Note this is often not the limiting factor near the poles, where
+        # the speed of the polar night jets can exceed two-thirds of the speed of sound.
+        for it in range(n_split):
+            # the Lagrangian dynamics have two parts. First we advance the C-grid winds
+            # by half a time step (c_sw). Then the C-grid winds are used to define advective
+            # fluxes to advance the D-grid prognostic fields a full time step
+            # (the rest of the routines).
+            #
+            # Along-surface flux terms (mass, heat, vertical momentum, vorticity,
+            # kinetic energy gradient terms) are evaluated forward-in-time.
+            #
+            # The pressure gradient force and elastic terms are then evaluated
+            # backwards-in-time, to improve stability.
+            remap_step = False
+            if self.namelist.breed_vortex_inline or (it == n_split - 1):
+                remap_step = True
+            if not hydrostatic:
+                if self.do_halo_exchange:
+                    reqs["w_quantity"] = self.comm.start_halo_update(
+                        state.w_quantity, n_points=utils.halo
+                    )
+                if it == 0:
+                    self._set_gz(
+                        state.zs,
+                        state.delz,
+                        state.gz,
+                    )
+                    if self.do_halo_exchange:
+                        reqs["gz_quantity"] = self.comm.start_halo_update(
+                            state.gz_quantity, n_points=utils.halo
+                        )
+            if it == 0:
+                if self.do_halo_exchange:
+                    reqs["delp_quantity"].wait()
+                    reqs["pt_quantity"].wait()
+
+            if it == n_split - 1 and end_step:
+                if self.namelist.use_old_omega:  # apparently True
+                    self._set_pem(
+                        state.delp,
+                        state.pem,
+                        state.ptop,
+                    )
+            if self.do_halo_exchange:
+                reqs_vector.wait()
+                if not hydrostatic:
+                    reqs["w_quantity"].wait()
+
+            # compute the c-grid winds at t + 1/2 timestep
+            state.delpc, state.ptc = c_sw.compute(
+                state.delp,
+                state.pt,
+                state.u,
+                state.v,
+                state.w,
+                state.uc,
+                state.vc,
+                state.ua,
+                state.va,
+                state.ut,
+                state.vt,
+                state.divgd,
+                state.omga,
+                dt2,
+            )
+
+            if self.namelist.nord > 0 and self.do_halo_exchange:
+                reqs["divgd_quantity"] = self.comm.start_halo_update(
+                    state.divgd_quantity, n_points=utils.halo
+                )
+            if not hydrostatic:
+                if it == 0:
+                    if self.do_halo_exchange:
+                        reqs["gz_quantity"].wait()
+                    copy_stencil(
+                        state.gz,
+                        state.zh,
+                        origin=grid.full_origin(),
+                        domain=grid.domain_shape_full(add=(0, 0, 1)),
+                    )
+                else:
+                    copy_stencil(
+                        state.zh,
+                        state.gz,
+                        origin=grid.full_origin(),
+                        domain=grid.domain_shape_full(add=(0, 0, 1)),
+                    )
+            if not hydrostatic:
+                updatedzc.compute(
+                    state.dp_ref, state.zs, state.ut, state.vt, state.gz, state.ws3, dt2
+                )
+                riem_solver_c.compute(
+                    ms,
+                    dt2,
+                    akap,
+                    state.cappa,
+                    state.ptop,
+                    state.phis,
+                    state.omga,
+                    state.ptc,
+                    state.q_con,
+                    state.delpc,
+                    state.gz,
+                    state.pkc,
+                    state.ws3,
+                )
+
+            self._p_grad_c(
+                grid.rdxc,
+                grid.rdyc,
+                state.uc,
+                state.vc,
+                state.delpc,
+                state.pkc,
+                state.gz,
+                dt2,
+            )
+            if self.do_halo_exchange:
+                reqc_vector = self.comm.start_vector_halo_update(
+                    state.uc_quantity, state.vc_quantity, n_points=utils.halo
+                )
+                if self.namelist.nord > 0:
+                    reqs["divgd_quantity"].wait()
+                reqc_vector.wait()
+            # use the computed c-grid winds to evolve the d-grid winds forward
+            # by 1 timestep
+            d_sw.compute(
+                state.vt,
+                state.delp,
+                state.ptc,
+                state.pt,
+                state.u,
+                state.v,
+                state.w,
+                state.uc,
+                state.vc,
+                state.ua,
+                state.va,
+                state.divgd,
+                state.mfxd,
+                state.mfyd,
+                state.cxd,
+                state.cyd,
                 state.crx,
                 state.cry,
                 state.xfx,
                 state.yfx,
-                state.wsd,
-                dt,
-            )
-
-            riem_solver3.compute(
-                remap_step,
-                dt,
-                akap,
-                state.cappa,
-                state.ptop,
-                state.zs,
-                state.w,
-                state.delz,
                 state.q_con,
-                state.delp,
-                state.pt,
                 state.zh,
-                state.pe,
-                state.pkc,
-                state.pk3,
-                state.pk,
-                state.peln,
-                state.wsd,
+                state.heat_source,
+                state.diss_estd,
+                dt,
             )
+            # note that uc and vc are not needed at all past this point.
+            # they will be re-computed from scratch on the next acoustic timestep.
 
-            if global_config.get_do_halo_exchange():
-                reqs["zh_quantity"] = comm.start_halo_update(
-                    state.zh_quantity, n_points=utils.halo
+            if self.do_halo_exchange:
+                for halovar in ["delp_quantity", "pt_quantity", "q_con_quantity"]:
+                    self.comm.halo_update(state.__getattribute__(halovar), n_points=utils.halo)
+
+            # Not used unless we implement other betas and alternatives to nh_p_grad
+            # if self.namelist.d_ext > 0:
+            #    raise 'Unimplemented namelist option d_ext > 0'
+            # else:
+            #    divg2 = utils.make_storage_from_shape(delz.shape, grid.compute_origin())
+
+            if not hydrostatic:
+                updatedzd.compute(
+                    state.dp_ref,
+                    state.zs,
+                    state.zh,
+                    state.crx,
+                    state.cry,
+                    state.xfx,
+                    state.yfx,
+                    state.wsd,
+                    dt,
                 )
-                if grid.npx == grid.npy:
-                    reqs["pkc_quantity"] = comm.start_halo_update(
-                        state.pkc_quantity, n_points=2
+
+                riem_solver3.compute(
+                    remap_step,
+                    dt,
+                    akap,
+                    state.cappa,
+                    state.ptop,
+                    state.zs,
+                    state.w,
+                    state.delz,
+                    state.q_con,
+                    state.delp,
+                    state.pt,
+                    state.zh,
+                    state.pe,
+                    state.pkc,
+                    state.pk3,
+                    state.pk,
+                    state.peln,
+                    state.wsd,
+                )
+
+                if self.do_halo_exchange:
+                    reqs["zh_quantity"] = self.comm.start_halo_update(
+                        state.zh_quantity, n_points=utils.halo
+                    )
+                    if grid.npx == grid.npy:
+                        reqs["pkc_quantity"] = self.comm.start_halo_update(
+                            state.pkc_quantity, n_points=2
+                        )
+                    else:
+                        reqs["pkc_quantity"] = self.comm.start_halo_update(
+                            state.pkc_quantity, n_points=utils.halo
+                        )
+                if remap_step:
+                    pe_halo.compute(state.pe, state.delp, state.ptop)
+                if self.namelist.use_logp:
+                    raise Exception("unimplemented namelist option use_logp=True")
+                else:
+                    pk3_halo.compute(state.pk3, state.delp, state.ptop, akap)
+            if not hydrostatic:
+                if self.do_halo_exchange:
+                    reqs["zh_quantity"].wait()
+                    if grid.npx != grid.npy:
+                        reqs["pkc_quantity"].wait()
+                basic.multiply_constant(
+                    state.zh,
+                    state.gz,
+                    constants.GRAV,
+                    origin=(grid.is_ - 2, grid.js - 2, 0),
+                    domain=(grid.nic + 4, grid.njc + 4, grid.npz + 1),
+                )
+                if grid.npx == grid.npy and self.do_halo_exchange:
+                    reqs["pkc_quantity"].wait()
+                if self.namelist.beta != 0:
+                    raise Exception(
+                        "Unimplemented namelist option -- we only support beta=0"
+                    )
+                self.nonhydrostatic_pressure(
+                    state.u,
+                    state.v,
+                    state.pkc,
+                    state.gz,
+                    state.pk3,
+                    state.delp,
+                    dt,
+                    state.ptop,
+                    akap,
+                )
+
+            if self.namelist.rf_fast:
+                # TODO: Pass through ks, or remove, inconsistent representation vs Fortran.
+                ray_fast.compute(
+                    state.u,
+                    state.v,
+                    state.w,
+                    state.dp_ref,
+                    state.pfull,
+                    dt,
+                    state.ptop,
+                    state.ks,
+                )
+
+            if self.do_halo_exchange:
+                if it != n_split - 1:
+                    reqs_vector = self.comm.start_vector_halo_update(
+                        state.u_quantity, state.v_quantity, n_points=utils.halo
                     )
                 else:
-                    reqs["pkc_quantity"] = comm.start_halo_update(
-                        state.pkc_quantity, n_points=utils.halo
-                    )
-            if remap_step:
-                pe_halo.compute(state.pe, state.delp, state.ptop)
-            if spec.namelist.use_logp:
-                raise Exception("unimplemented namelist option use_logp=True")
-            else:
-                pk3_halo.compute(state.pk3, state.delp, state.ptop, akap)
-        if not hydrostatic:
-            if global_config.get_do_halo_exchange():
-                reqs["zh_quantity"].wait()
-                if grid.npx != grid.npy:
-                    reqs["pkc_quantity"].wait()
-            basic.multiply_constant(
-                state.zh,
-                state.gz,
-                constants.GRAV,
-                origin=(grid.is_ - 2, grid.js - 2, 0),
-                domain=(grid.nic + 4, grid.njc + 4, grid.npz + 1),
-            )
-            if grid.npx == grid.npy and global_config.get_do_halo_exchange():
-                reqs["pkc_quantity"].wait()
-            if spec.namelist.beta != 0:
-                raise Exception(
-                    "Unimplemented namelist option -- we only support beta=0"
+                    if self.namelist.grid_type < 4:
+                        self.comm.synchronize_vector_interfaces(
+                            state.u_quantity, state.v_quantity
+                        )
+
+        if self.n_con != 0 and self.namelist.d_con > 1.0e-5:
+            nf_ke = min(3, self.namelist.nord + 1)
+
+            if self.do_halo_exchange:
+                self.comm.halo_update(state.heat_source_quantity, n_points=utils.halo)
+            cd = constants.CNST_0P20 * grid.da_min
+            del2cubed.compute(state.heat_source, nf_ke, cd, grid.npz)
+            if not hydrostatic:
+                temperature_adjust.compute(
+                    state.pt,
+                    state.pkz,
+                    state.heat_source,
+                    state.delz,
+                    state.delp,
+                    state.cappa,
+                    self.n_con,
+                    dt,
                 )
-            nonhydrostatic_pressure(
-                state.u,
-                state.v,
-                state.pkc,
-                state.gz,
-                state.pk3,
-                state.delp,
-                dt,
-                state.ptop,
-                akap,
-            )
-
-        if spec.namelist.rf_fast:
-            # TODO: Pass through ks, or remove, inconsistent representation vs Fortran.
-            ray_fast.compute(
-                state.u,
-                state.v,
-                state.w,
-                state.dp_ref,
-                state.pfull,
-                dt,
-                state.ptop,
-                state.ks,
-            )
-
-        if global_config.get_do_halo_exchange():
-            if it != n_split - 1:
-                reqs_vector = comm.start_vector_halo_update(
-                    state.u_quantity, state.v_quantity, n_points=utils.halo
-                )
-            else:
-                if spec.namelist.grid_type < 4:
-                    comm.synchronize_vector_interfaces(
-                        state.u_quantity, state.v_quantity
-                    )
-
-    if n_con != 0 and spec.namelist.d_con > 1.0e-5:
-        nf_ke = min(3, spec.namelist.nord + 1)
-
-        if global_config.get_do_halo_exchange():
-            comm.halo_update(state.heat_source_quantity, n_points=utils.halo)
-        cd = constants.CNST_0P20 * grid.da_min
-        del2cubed.compute(state.heat_source, nf_ke, cd, grid.npz)
-        if not hydrostatic:
-            temperature_adjust.compute(
-                state.pt,
-                state.pkz,
-                state.heat_source,
-                state.delz,
-                state.delp,
-                state.cappa,
-                n_con,
-                dt,
-            )

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -4,7 +4,7 @@ from gt4py.gtscript import PARALLEL, computation, interval, log
 
 import fv3core._config as spec
 import fv3core.stencils.del2cubed as del2cubed
-import fv3core.stencils.dyn_core as dyn_core
+from fv3core.stencils.dyn_core import AcousticDynamics
 import fv3core.stencils.moist_cv as moist_cv
 import fv3core.stencils.neg_adj3 as neg_adj3
 import fv3core.stencils.rayleigh_super as rayleigh_super
@@ -280,6 +280,7 @@ class DynamicalCore:
         self.do_halo_exchange = global_config.get_do_halo_exchange()
 
         self.tracer_advection = Tracer2D1L(comm, namelist)
+        self.acoustic_dynamics = AcousticDynamics(comm, namelist)
         # npx and npy are number of interfaces, npz is number of centers
         # and shapes should be the full data shape
 
@@ -411,7 +412,7 @@ class DynamicalCore:
         )
         print("DynCore", self.grid.rank)
         with timer.clock("DynCore"):
-            dyn_core.compute(state, self.comm)
+            self.acoustic_dynamics(state)
         if self.namelist.z_tracer:
             print("Tracer2D1L", self.grid.rank)
             with timer.clock("TracerAdvection"):

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -4,7 +4,6 @@ from gt4py.gtscript import PARALLEL, computation, interval, log
 
 import fv3core._config as spec
 import fv3core.stencils.del2cubed as del2cubed
-from fv3core.stencils.dyn_core import AcousticDynamics
 import fv3core.stencils.moist_cv as moist_cv
 import fv3core.stencils.neg_adj3 as neg_adj3
 import fv3core.stencils.rayleigh_super as rayleigh_super
@@ -16,6 +15,7 @@ import fv3gfs.util
 from fv3core.decorators import ArgSpec, get_namespace, gtstencil
 from fv3core.stencils import c2l_ord
 from fv3core.stencils.basic_operations import copy_stencil
+from fv3core.stencils.dyn_core import AcousticDynamics
 from fv3core.stencils.tracer_2d_1l import Tracer2D1L
 from fv3core.utils.typing import FloatField, FloatFieldK
 

--- a/fv3core/testing/parallel_translate.py
+++ b/fv3core/testing/parallel_translate.py
@@ -176,7 +176,7 @@ class ParallelTranslate2Py(ParallelTranslate):
 
 
 class ParallelTranslate2PyState(ParallelTranslate2Py):
-    def compute_parallel(self, inputs):
+    def compute_parallel(self, inputs, communicator):
         self._base.make_storage_data_input_vars(inputs)
         for name, properties in self.inputs.items():
             self.grid.quantity_dict_update(

--- a/fv3core/testing/parallel_translate.py
+++ b/fv3core/testing/parallel_translate.py
@@ -176,13 +176,13 @@ class ParallelTranslate2Py(ParallelTranslate):
 
 
 class ParallelTranslate2PyState(ParallelTranslate2Py):
-    def compute_parallel(self, inputs, communicator):
+    def compute_parallel(self, inputs):
         self._base.make_storage_data_input_vars(inputs)
         for name, properties in self.inputs.items():
             self.grid.quantity_dict_update(
                 inputs, name, dims=properties["dims"], units=properties["units"]
             )
         statevars = SimpleNamespace(**inputs)
-        state = {"state": statevars, "comm": communicator}
+        state = {"state": statevars}
         self._base.compute_func(**state)
         return self._base.slice_output(vars(state["state"]))

--- a/tests/translate/translate_dyncore.py
+++ b/tests/translate/translate_dyncore.py
@@ -119,7 +119,7 @@ class TranslateDynCore(ParallelTranslate2PyState):
 
     def compute_parallel(self, inputs, communicator):
         self._base.compute_func = dyn_core.AcousticDynamics(communicator, spec.namelist)
-        return super().compute_parallel(inputs)
+        return super().compute_parallel(inputs, communicator)
 
 
 class TranslatePGradC(TranslateFortranData2Py):

--- a/tests/translate/translate_dyncore.py
+++ b/tests/translate/translate_dyncore.py
@@ -1,7 +1,11 @@
+from gt4py import gtscript
+
 import fv3core._config as spec
 import fv3core.stencils.dyn_core as dyn_core
+import fv3core.utils.global_config as global_config
 import fv3gfs.util as fv3util
 from fv3core.testing import ParallelTranslate2PyState, TranslateFortranData2Py
+from fv3core.utils.grid import axis_offsets
 
 
 class TranslateDynCore(ParallelTranslate2PyState):
@@ -132,11 +136,22 @@ class TranslatePGradC(TranslateFortranData2Py):
         self.out_vars = {"uc": grid.x3d_domain_dict(), "vc": grid.y3d_domain_dict()}
 
     def compute_from_storage(self, inputs):
-        dyn_core.p_grad_c_stencil(
+        origin = self.grid.compute_origin()
+        domain = self.grid.domain_shape_compute(add=(1, 1, 0))
+        ax_offsets = axis_offsets(self.grid, origin, domain)
+        pgradc = gtscript.stencil(
+            externals={
+                "hydrostatic": spec.namelist.hydrostatic,
+                **ax_offsets,
+            },
+            backend=global_config.get_backend(),
+            rebuild=global_config.get_rebuild(),
+        )(dyn_core.p_grad_c_stencil)
+        pgradc(
             rdxc=self.grid.rdxc,
             rdyc=self.grid.rdyc,
             **inputs,
-            origin=self.grid.compute_origin(),
-            domain=self.grid.domain_shape_compute(add=(1, 1, 0)),
+            origin=origin,
+            domain=domain,
         )
         return inputs

--- a/tests/translate/translate_dyncore.py
+++ b/tests/translate/translate_dyncore.py
@@ -1,7 +1,8 @@
-from fv3core.stencils.dyn_core import AcousticDynamics
+import fv3core._config as spec
+import fv3core.stencils.dyn_core as dyn_core
 import fv3gfs.util as fv3util
 from fv3core.testing import ParallelTranslate2PyState, TranslateFortranData2Py
-import fv3core._config as spec
+
 
 class TranslateDynCore(ParallelTranslate2PyState):
     inputs = {
@@ -113,9 +114,10 @@ class TranslateDynCore(ParallelTranslate2PyState):
         self.max_error = 2e-6
 
     def compute_parallel(self, inputs, communicator):
-        self._base.compute_func = AcousticDynamics(communicator, spec.namelist) 
+        self._base.compute_func = dyn_core.AcousticDynamics(communicator, spec.namelist)
         return super().compute_parallel(inputs)
-   
+
+
 class TranslatePGradC(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)

--- a/tests/translate/translate_dyncore.py
+++ b/tests/translate/translate_dyncore.py
@@ -1,7 +1,7 @@
-import fv3core.stencils.dyn_core as dyn_core
+from fv3core.stencils.dyn_core import AcousticDynamics
 import fv3gfs.util as fv3util
 from fv3core.testing import ParallelTranslate2PyState, TranslateFortranData2Py
-
+import fv3core._config as spec
 
 class TranslateDynCore(ParallelTranslate2PyState):
     inputs = {
@@ -39,7 +39,6 @@ class TranslateDynCore(ParallelTranslate2PyState):
 
     def __init__(self, grids):
         super().__init__(grids)
-        self._base.compute_func = dyn_core.compute
         grid = grids[0]
         self._base.in_vars["data_vars"] = {
             "cappa": {},
@@ -113,7 +112,10 @@ class TranslateDynCore(ParallelTranslate2PyState):
         # variables here should as well.
         self.max_error = 2e-6
 
-
+    def compute_parallel(self, inputs, communicator):
+        self._base.compute_func = AcousticDynamics(communicator, spec.namelist) 
+        return super().compute_parallel(inputs)
+   
 class TranslatePGradC(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)

--- a/tests/translate/translate_map1_ppm_2d.py
+++ b/tests/translate/translate_map1_ppm_2d.py
@@ -53,7 +53,6 @@ class TranslateMap1_PPM_2d(TranslateFortranData2Py):
         inputs["j1"] = inputs["j_2d"]
         inputs["j2"] = inputs["j_2d"]
         del inputs["j_2d"]
-        print("qs", inputs["qs"].shape)
         var_inout = self.compute_func(**inputs)
         return self.slice_output(inputs, {"var_inout": var_inout})
 

--- a/tests/translate/translate_map1_ppm_2d.py
+++ b/tests/translate/translate_map1_ppm_2d.py
@@ -53,6 +53,7 @@ class TranslateMap1_PPM_2d(TranslateFortranData2Py):
         inputs["j1"] = inputs["j_2d"]
         inputs["j2"] = inputs["j_2d"]
         del inputs["j_2d"]
+        print("qs", inputs["qs"].shape)
         var_inout = self.compute_func(**inputs)
         return self.slice_output(inputs, {"var_inout": var_inout})
 


### PR DESCRIPTION
## Purpose

The purpose is to gain a little speedup and unclutter the performance profile from python code. dyn_core has some python code setting data fields -- moved those into stencils, and turn dyn_core into a class AcousticDynamics to take advantage of the speedups we get from having normalize_origin in the init stages. There also are still some uncached storages here that are removed with the class.  

## Code changes:

- dyn_core now is a class AcousticDynamics
- the DynamicalCore(fv_dynamics) object now as an instance of AcousticDynamics as an attribute
- p_grad_c updated to work as an object attribute
- tests for DynCore and PGradC updated to work

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
