### PR TITLE
Compute updated area on the fly

### DIFF
--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -648,12 +648,6 @@ def compute(
         shape, grid().compute_origin(), cache_key="d_sw_gy"
     )
 
-    area_with_x_flux = utils.make_storage_from_shape(
-        shape, grid().compute_origin(), cache_key="d_sw_ra_x"
-    )
-    area_with_y_flux = utils.make_storage_from_shape(
-        shape, grid().compute_origin(), cache_key="d_sw_ra_y"
-    )
     fvtp2d_dp = utils.cached_stencil_class(FiniteVolumeTransport)(
         spec.namelist, spec.namelist.hord_dp, cache_key="d_sw-dp"
     )
@@ -664,9 +658,7 @@ def compute(
         spec.namelist, spec.namelist.hord_tm, cache_key="d_sw-tm"
     )
 
-    fxadv.compute(
-        uc, vc, crx, cry, xfx, yfx, ut, vt, area_with_x_flux, area_with_y_flux, dt
-    )
+    fxadv.compute(uc, vc, crx, cry, xfx, yfx, ut, vt, dt)
 
     fvtp2d_dp(
         delp,
@@ -674,8 +666,6 @@ def compute(
         cry,
         xfx,
         yfx,
-        area_with_x_flux,
-        area_with_y_flux,
         fx,
         fy,
         nord=column_namelist["nord_v"],
@@ -703,8 +693,6 @@ def compute(
             cry,
             xfx,
             yfx,
-            area_with_x_flux,
-            area_with_y_flux,
             gx,
             gy,
             nord=column_namelist["nord_v"],
@@ -729,8 +717,6 @@ def compute(
         cry,
         xfx,
         yfx,
-        area_with_x_flux,
-        area_with_y_flux,
         gx,
         gy,
         nord=column_namelist["nord_t"],
@@ -758,8 +744,6 @@ def compute(
         cry,
         xfx,
         yfx,
-        area_with_x_flux,
-        area_with_y_flux,
         gx,
         gy,
         nord=column_namelist["nord_v"],
@@ -881,7 +865,7 @@ def compute(
         domain=grid().domain_shape_full(),
     )
 
-    fvtp2d_vt(vort, crx, cry, xfx, yfx, area_with_x_flux, area_with_y_flux, fx, fy)
+    fvtp2d_vt(vort, crx, cry, xfx, yfx, fx, fy)
 
     u_and_v_from_ke(
         ke,

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -648,10 +648,10 @@ def compute(
         shape, grid().compute_origin(), cache_key="d_sw_gy"
     )
 
-    ra_x = utils.make_storage_from_shape(
+    area_with_x_flux = utils.make_storage_from_shape(
         shape, grid().compute_origin(), cache_key="d_sw_ra_x"
     )
-    ra_y = utils.make_storage_from_shape(
+    area_with_y_flux = utils.make_storage_from_shape(
         shape, grid().compute_origin(), cache_key="d_sw_ra_y"
     )
     fvtp2d_dp = utils.cached_stencil_class(FiniteVolumeTransport)(
@@ -664,7 +664,9 @@ def compute(
         spec.namelist, spec.namelist.hord_tm, cache_key="d_sw-tm"
     )
 
-    fxadv.compute(uc, vc, crx, cry, xfx, yfx, ut, vt, ra_x, ra_y, dt)
+    fxadv.compute(
+        uc, vc, crx, cry, xfx, yfx, ut, vt, area_with_x_flux, area_with_y_flux, dt
+    )
 
     fvtp2d_dp(
         delp,
@@ -672,8 +674,8 @@ def compute(
         cry,
         xfx,
         yfx,
-        ra_x,
-        ra_y,
+        area_with_x_flux,
+        area_with_y_flux,
         fx,
         fy,
         nord=column_namelist["nord_v"],
@@ -701,8 +703,8 @@ def compute(
             cry,
             xfx,
             yfx,
-            ra_x,
-            ra_y,
+            area_with_x_flux,
+            area_with_y_flux,
             gx,
             gy,
             nord=column_namelist["nord_v"],
@@ -727,8 +729,8 @@ def compute(
         cry,
         xfx,
         yfx,
-        ra_x,
-        ra_y,
+        area_with_x_flux,
+        area_with_y_flux,
         gx,
         gy,
         nord=column_namelist["nord_t"],
@@ -756,8 +758,8 @@ def compute(
         cry,
         xfx,
         yfx,
-        ra_x,
-        ra_y,
+        area_with_x_flux,
+        area_with_y_flux,
         gx,
         gy,
         nord=column_namelist["nord_v"],
@@ -879,7 +881,7 @@ def compute(
         domain=grid().domain_shape_full(),
     )
 
-    fvtp2d_vt(vort, crx, cry, xfx, yfx, ra_x, ra_y, fx, fy)
+    fvtp2d_vt(vort, crx, cry, xfx, yfx, area_with_x_flux, area_with_y_flux, fx, fy)
 
     u_and_v_from_ke(
         ke,

--- a/fv3core/stencils/fvtp2d.py
+++ b/fv3core/stencils/fvtp2d.py
@@ -18,12 +18,12 @@ def q_i_stencil(
     area: FloatFieldIJ,
     yfx: FloatField,
     fy2: FloatField,
-    ra_y: FloatField,
+    area_with_y_flux: FloatField,
     q_i: FloatField,
 ):
     with computation(PARALLEL), interval(...):
         fyy = yfx * fy2
-        q_i = (q * area + fyy - fyy[0, 1, 0]) / ra_y
+        q_i = (q * area + fyy - fyy[0, 1, 0]) / area_with_y_flux
 
 
 def q_j_stencil(
@@ -31,12 +31,13 @@ def q_j_stencil(
     area: FloatFieldIJ,
     xfx: FloatField,
     fx2: FloatField,
-    ra_x: FloatField,
+    area_with_x_flux: FloatField,
     q_j: FloatField,
 ):
     with computation(PARALLEL), interval(...):
         fx1 = xfx * fx2
-        q_j = (q * area + fx1 - fx1[1, 0, 0]) / ra_x
+        # area_with_x_flux = fxadv.apply_x_flux_divergence(area, xfx)
+        q_j = (q * area + fx1 - fx1[1, 0, 0]) / area_with_x_flux
 
 
 @gtscript.function
@@ -107,8 +108,8 @@ class FiniteVolumeTransport:
         cry,
         xfx,
         yfx,
-        ra_x,
-        ra_y,
+        area_with_x_flux,
+        area_with_y_flux,
         fx,
         fy,
         nord=None,
@@ -128,7 +129,7 @@ class FiniteVolumeTransport:
             grid.area,
             yfx,
             self._tmp_fy2,
-            ra_y,
+            area_with_y_flux,
             self._tmp_q_i,
         )
         self.x_piecewise_parabolic_outer(self._tmp_q_i, crx, fx, grid.js, grid.je)
@@ -141,7 +142,7 @@ class FiniteVolumeTransport:
             grid.area,
             xfx,
             self._tmp_fx2,
-            ra_x,
+            area_with_x_flux,
             self._tmp_q_j,
         )
         self.y_piecewise_parabolic_outer(self._tmp_q_j, cry, fy, grid.is_, grid.ie)

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -417,9 +417,6 @@ def area_flux_update(
         area_with_y_flux = apply_y_flux_divergence(area, yfx_interface)
 
 
-flux_divergence_area = gtstencil()(area_flux_update)
-
-
 def compute(
     uc,
     vc,
@@ -429,8 +426,6 @@ def compute(
     yfx_adv,
     ut,
     vt,
-    area_with_x_flux,
-    area_with_y_flux,
     dt,
 ):
     grid = spec.grid
@@ -522,15 +517,6 @@ def compute(
         ut,
         vt,
         dt,
-        origin=grid.full_origin(),
-        domain=grid.domain_shape_full(),
-    )
-    flux_divergence_area(
-        grid.area,
-        xfx_adv,
-        area_with_x_flux,
-        yfx_adv,
-        area_with_y_flux,
         origin=grid.full_origin(),
         domain=grid.domain_shape_full(),
     )

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -154,8 +154,6 @@ class Tracer2D1L:
         origin = self.grid.compute_origin()
         self._tmp_xfx = utils.make_storage_from_shape(shape, origin)
         self._tmp_yfx = utils.make_storage_from_shape(shape, origin)
-        self._tmp_area_with_x_flux = utils.make_storage_from_shape(shape, origin)
-        self._tmp_area_with_y_flux = utils.make_storage_from_shape(shape, origin)
         self._tmp_fx = utils.make_storage_from_shape(shape, origin)
         self._tmp_fy = utils.make_storage_from_shape(shape, origin)
         self._tmp_dp2 = utils.make_storage_from_shape(shape, origin)
@@ -289,13 +287,6 @@ class Tracer2D1L:
                 q = tracers[qname + "_quantity"]
                 self.comm.halo_update(q, n_points=utils.halo)
 
-        self._ra_update(
-            self.grid.area,
-            self._tmp_xfx,
-            self._tmp_area_with_x_flux,
-            self._tmp_yfx,
-            self._tmp_area_with_y_flux,
-        )
         # TODO: Revisit: the loops over q and nsplt have two inefficient options
         # duplicating storages/stencil calls, return to this, maybe you have more
         # options now, or maybe the one chosen here is the worse one.
@@ -330,8 +321,6 @@ class Tracer2D1L:
                         cyd,
                         self._tmp_xfx,
                         self._tmp_yfx,
-                        self._tmp_area_with_x_flux,
-                        self._tmp_area_with_y_flux,
                         self._tmp_fx,
                         self._tmp_fy,
                         mfx=mfxd,
@@ -356,8 +345,6 @@ class Tracer2D1L:
                         cyd,
                         self._tmp_xfx,
                         self._tmp_yfx,
-                        self._tmp_area_with_x_flux,
-                        self._tmp_area_with_y_flux,
                         self._tmp_fx,
                         self._tmp_fy,
                         mfx=mfxd,

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -4,12 +4,12 @@ import gt4py.gtscript as gtscript
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
 import fv3core._config as spec
+import fv3core.stencils.fxadv
 import fv3core.utils
 import fv3core.utils.global_config as global_config
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util
 from fv3core.decorators import FixedOriginStencil
-from fv3core.stencils import updatedzd
 from fv3core.stencils.basic_operations import copy_stencil
 from fv3core.stencils.fvtp2d import FiniteVolumeTransport
 from fv3core.utils.typing import FloatField, FloatFieldIJ
@@ -154,8 +154,8 @@ class Tracer2D1L:
         origin = self.grid.compute_origin()
         self._tmp_xfx = utils.make_storage_from_shape(shape, origin)
         self._tmp_yfx = utils.make_storage_from_shape(shape, origin)
-        self._tmp_ra_x = utils.make_storage_from_shape(shape, origin)
-        self._tmp_ra_y = utils.make_storage_from_shape(shape, origin)
+        self._tmp_area_with_x_flux = utils.make_storage_from_shape(shape, origin)
+        self._tmp_area_with_y_flux = utils.make_storage_from_shape(shape, origin)
         self._tmp_fx = utils.make_storage_from_shape(shape, origin)
         self._tmp_fy = utils.make_storage_from_shape(shape, origin)
         self._tmp_dp2 = utils.make_storage_from_shape(shape, origin)
@@ -186,7 +186,7 @@ class Tracer2D1L:
             externals=local_axis_offsets,
         )
         self._ra_update = FixedOriginStencil(
-            updatedzd.ra_update,
+            fv3core.stencils.fxadv.area_flux_update,
             origin=self.grid.full_origin(),
             domain=self.grid.domain_shape_full(),
             externals=local_axis_offsets,
@@ -292,9 +292,9 @@ class Tracer2D1L:
         self._ra_update(
             self.grid.area,
             self._tmp_xfx,
-            self._tmp_ra_x,
+            self._tmp_area_with_x_flux,
             self._tmp_yfx,
-            self._tmp_ra_y,
+            self._tmp_area_with_y_flux,
         )
         # TODO: Revisit: the loops over q and nsplt have two inefficient options
         # duplicating storages/stencil calls, return to this, maybe you have more
@@ -330,8 +330,8 @@ class Tracer2D1L:
                         cyd,
                         self._tmp_xfx,
                         self._tmp_yfx,
-                        self._tmp_ra_x,
-                        self._tmp_ra_y,
+                        self._tmp_area_with_x_flux,
+                        self._tmp_area_with_y_flux,
                         self._tmp_fx,
                         self._tmp_fy,
                         mfx=mfxd,
@@ -356,8 +356,8 @@ class Tracer2D1L:
                         cyd,
                         self._tmp_xfx,
                         self._tmp_yfx,
-                        self._tmp_ra_x,
-                        self._tmp_ra_y,
+                        self._tmp_area_with_x_flux,
+                        self._tmp_area_with_y_flux,
                         self._tmp_fx,
                         self._tmp_fy,
                         mfx=mfxd,

--- a/fv3core/stencils/updatedzd.py
+++ b/fv3core/stencils/updatedzd.py
@@ -1,65 +1,20 @@
 import gt4py.gtscript as gtscript
-from gt4py.gtscript import (
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    horizontal,
-    interval,
-    region,
-)
+from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import fv3core._config as spec
 import fv3core.stencils.d_sw as d_sw
 import fv3core.stencils.delnflux as delnflux
+import fv3core.stencils.fxadv
 import fv3core.utils
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import FixedOriginStencil
 from fv3core.stencils import basic_operations
 from fv3core.stencils.fvtp2d import FiniteVolumeTransport
-from fv3core.stencils.fxadv import ra_x_func, ra_y_func
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
 
 DZ_MIN = constants.DZ_MIN
-
-# TODO merge with fxadv
-@gtscript.function
-def ra_func(
-    area: FloatFieldIJ,
-    xfx_adv: FloatField,
-    yfx_adv: FloatField,
-    ra_x: FloatField,
-    ra_y: FloatField,
-):
-    from __externals__ import local_ie, local_is, local_je, local_js
-
-    with horizontal(region[local_is : local_ie + 2, :]):
-        ra_x = ra_x_func(area, xfx_adv)
-    with horizontal(region[:, local_js : local_je + 2]):
-        ra_y = ra_y_func(area, yfx_adv)
-    return ra_x, ra_y
-
-
-def ra_update(
-    area: FloatFieldIJ,
-    xfx_adv: FloatField,
-    ra_x: FloatField,
-    yfx_adv: FloatField,
-    ra_y: FloatField,
-):
-    """Updates 'ra' fields.
-    Args:
-       xfx_adv: Finite volume flux form operator in x direction (in)
-       yfx_adv: Finite volume flux form operator in y direction (in)
-       ra_x: Area increased in the x direction due to flux divergence (inout)
-       ra_y: Area increased in the y direction due to flux divergence (inout)
-    Grid input vars:
-       area
-    """
-    with computation(PARALLEL), interval(...):
-        ra_x, ra_y = ra_func(area, xfx_adv, yfx_adv, ra_x, ra_y)
 
 
 @gtscript.function
@@ -68,10 +23,12 @@ def zh_base(
     area: FloatFieldIJ,
     fx: FloatField,
     fy: FloatField,
-    ra_x: FloatField,
-    ra_y: FloatField,
+    area_with_x_flux: FloatField,
+    area_with_y_flux: FloatField,
 ):
-    return (z2 * area + fx - fx[1, 0, 0] + fy - fy[0, 1, 0]) / (ra_x + ra_y - area)
+    return (z2 * area + fx - fx[1, 0, 0] + fy - fy[0, 1, 0]) / (
+        area_with_x_flux + area_with_y_flux - area
+    )
 
 
 def zh_damp(
@@ -79,8 +36,8 @@ def zh_damp(
     z2: FloatField,
     fx: FloatField,
     fy: FloatField,
-    ra_x: FloatField,
-    ra_y: FloatField,
+    area_with_x_flux: FloatField,
+    area_with_y_flux: FloatField,
     fx2: FloatField,
     fy2: FloatField,
     rarea: FloatFieldIJ,
@@ -91,23 +48,23 @@ def zh_damp(
 ):
     """Update geopotential height due to area average flux divergence
     Args:
-       z2: zh that has been advected forward in time (in)
-       fx: Flux in the x direction that transported z2 (in)
-       fy: Flux in the y direction that transported z2(in)
-       ra_x: Area increased in the x direction due to flux divergence (in)
-       ra_y: Area increased in the y direction due to flux divergence (in)
-       fx2: diffusive flux in the x-direction (in)
-       fy2: diffusive flux in the y-direction (in)
-       zh: geopotential height (out)
-       zs: surface geopotential height (in)
-       ws: vertical velocity of the lowest level (to keep it at the surface) (out)
-       dt: acoustic timestep (seconds) (in)
+        z2: zh that has been advected forward in time (in)
+        fx: Flux in the x direction that transported z2 (in)
+        fy: Flux in the y direction that transported z2(in)
+        area_with_x_flux: Area updated with x-direction flux divergence (in)
+        area_with_y_flux: Area updated with y-direction flux divergence (in)
+        fx2: diffusive flux in the x-direction (in)
+        fy2: diffusive flux in the y-direction (in)
+        zh: geopotential height (out)
+        zs: surface geopotential height (in)
+        ws: vertical velocity of the lowest level (to keep it at the surface) (out)
+        dt: acoustic timestep (seconds) (in)
     Grid variable inputs:
-       area
-      rarea
+        area
+        rarea
     """
     with computation(PARALLEL), interval(...):
-        zhbase = zh_base(z2, area, fx, fy, ra_x, ra_y)
+        zhbase = zh_base(z2, area, fx, fy, area_with_x_flux, area_with_y_flux)
         zh = zhbase + (fx2 - fx2[1, 0, 0] + fy2 - fy2[0, 1, 0]) * rarea
     with computation(BACKWARD):
         with interval(-1, None):
@@ -117,119 +74,62 @@ def zh_damp(
             zh = zh if zh > other else other
 
 
-@gtscript.function
-def edge_profile_top(
+def cubic_spline_interpolation_constants(
     dp0: FloatFieldK,
-    q1x: FloatField,
-    q2x: FloatField,
-    qe1x: FloatField,
-    qe2x: FloatField,
-    q1y: FloatField,
-    q2y: FloatField,
-    qe1y: FloatField,
-    qe2y: FloatField,
-):
-    from __externals__ import local_ie, local_is, local_je, local_js
-
-    g0 = dp0[1] / dp0
-    xt1 = 2.0 * g0 * (g0 + 1.0)
-    bet = g0 * (g0 + 0.5)
-    gam = (1.0 + g0 * (g0 + 1.5)) / bet
-
-    with horizontal(region[local_is : local_ie + 2, :]):
-        qe1x = (xt1 * q1x + q1x[0, 0, 1]) / bet
-        qe2x = (xt1 * q2x + q2x[0, 0, 1]) / bet
-    with horizontal(region[:, local_js : local_je + 2]):
-        qe1y = (xt1 * q1y + q1y[0, 0, 1]) / bet
-        qe2y = (xt1 * q2y + q2y[0, 0, 1]) / bet
-
-    return qe1x, qe2x, qe1y, qe2y, gam
-
-
-@gtscript.function
-def edge_profile_reverse(
-    qe1x: FloatField,
-    qe2x: FloatField,
-    qe1y: FloatField,
-    qe2y: FloatField,
-    gam: FloatField,
-):
-    from __externals__ import local_ie, local_is, local_je, local_js
-
-    with horizontal(region[local_is : local_ie + 2, :]):
-        qe1x -= gam * qe1x[0, 0, 1]
-        qe2x -= gam * qe2x[0, 0, 1]
-    with horizontal(region[:, local_js : local_je + 2]):
-        qe1y -= gam * qe1y[0, 0, 1]
-        qe2y -= gam * qe2y[0, 0, 1]
-
-    return qe1x, qe2x, qe1y, qe2y
-
-
-# NOTE: We have not ported the uniform_grid True option as it is never called
-# that way in this model. We have also ignored limite != 0 for the same reason.
-def edge_profile(
-    q1x: FloatField,
-    q2x: FloatField,
-    qe1x: FloatField,
-    qe2x: FloatField,
-    q1y: FloatField,
-    q2y: FloatField,
-    qe1y: FloatField,
-    qe2y: FloatField,
-    dp0: FloatFieldK,
+    gk: FloatField,
+    beta: FloatField,
+    gamma: FloatField,
 ):
     """
-    Args:
-        q1x: ???
-        q2x: ???
-        qe1x: ???
-        qe2x: ???
-        q1y: ???
-        q2y: ???
-        qe1y: ???
-        qe2y: ???
-        dp0 (in): Reference pressure for layer interfaces, assuming a globally uniform
-            reference surface pressure. Used as an approximation of pressure,
-            for efficiency.
+    Computes constants used in cubic spline interpolation.
     """
-    from __externals__ import local_ie, local_is, local_je, local_js
-
     with computation(FORWARD):
         with interval(0, 1):
-            qe1x, qe2x, qe1y, qe2y, gam = edge_profile_top(
-                dp0, q1x, q2x, qe1x, qe2x, q1y, q2y, qe1y, qe2y
-            )
+            gk = dp0[1] / dp0
+            beta = gk * (gk + 0.5)
+            gamma = (1.0 + gk * (gk + 1.5)) / beta
         with interval(1, -1):
             gk = dp0[-1] / dp0
-            bet = 2.0 + 2.0 * gk - gam[0, 0, -1]
-            gam = gk / bet
-            with horizontal(region[local_is : local_ie + 2, :]):
-                qe1x = (3.0 * (q1x[0, 0, -1] + gk * q1x) - qe1x[0, 0, -1]) / bet
-                qe2x = (3.0 * (q2x[0, 0, -1] + gk * q2x) - qe2x[0, 0, -1]) / bet
-            with horizontal(region[:, local_js : local_je + 2]):
-                qe1y = (3.0 * (q1y[0, 0, -1] + gk * q1y) - qe1y[0, 0, -1]) / bet
-                qe2y = (3.0 * (q2y[0, 0, -1] + gk * q2y) - qe2y[0, 0, -1]) / bet
+            beta = 2.0 + 2.0 * gk - gamma[0, 0, -1]
+            gamma = gk / beta
+
+
+def cubic_spline_interpolation_from_layer_center_to_interfaces(
+    q_center: FloatField,
+    q_interface: FloatField,
+    gk: FloatField,
+    beta: FloatField,
+    gamma: FloatField,
+) -> FloatField:
+    """
+    Interpolate a field from layer (vertical) centers to interfaces.
+
+    Args:
+        q_center (in): value on layer centers
+        q_interface (out): value on layer interfaces
+        gk (in): cubic spline interpolation constant
+        beta (in): cubic spline interpolation constant
+        gamma (in): cubic spline interpolation constant
+    """
+    with computation(FORWARD):
+        with interval(0, 1):
+            xt1 = 2.0 * gk * (gk + 1.0)
+            q_interface = (xt1 * q_center + q_center[0, 0, 1]) / beta
+        with interval(1, -1):
+            q_interface = (
+                3.0 * (q_center[0, 0, -1] + gk * q_center) - q_interface[0, 0, -1]
+            ) / beta
         with interval(-1, None):
             a_bot = 1.0 + gk[0, 0, -1] * (gk[0, 0, -1] + 1.5)
             xt1 = 2.0 * gk[0, 0, -1] * (gk[0, 0, -1] + 1.0)
-            xt2 = gk[0, 0, -1] * (gk[0, 0, -1] + 0.5) - a_bot * gam[0, 0, -1]
-            with horizontal(region[local_is : local_ie + 2, :]):
-                qe1x = (
-                    xt1 * q1x[0, 0, -1] + q1x[0, 0, -2] - a_bot * qe1x[0, 0, -1]
-                ) / xt2
-                qe2x = (
-                    xt1 * q2x[0, 0, -1] + q2x[0, 0, -2] - a_bot * qe2x[0, 0, -1]
-                ) / xt2
-            with horizontal(region[:, local_js : local_je + 2]):
-                qe1y = (
-                    xt1 * q1y[0, 0, -1] + q1y[0, 0, -2] - a_bot * qe1y[0, 0, -1]
-                ) / xt2
-                qe2y = (
-                    xt1 * q2y[0, 0, -1] + q2y[0, 0, -2] - a_bot * qe2y[0, 0, -1]
-                ) / xt2
+            xt2 = gk[0, 0, -1] * (gk[0, 0, -1] + 0.5) - a_bot * gamma[0, 0, -1]
+            q_interface = (
+                xt1 * q_center[0, 0, -1]
+                + q_center[0, 0, -2]
+                - a_bot * q_interface[0, 0, -1]
+            ) / xt2
     with computation(BACKWARD), interval(0, -1):
-        qe1x, qe2x, qe1y, qe2y = edge_profile_reverse(qe1x, qe2x, qe1y, qe2y, gam)
+        q_interface -= gamma * q_interface[0, 0, 1]
 
 
 class UpdateDeltaZOnDGrid:
@@ -247,26 +147,25 @@ class UpdateDeltaZOnDGrid:
             raise NotImplementedError("damp <= 1e-5 in column_cols is untested")
         self._k_bounds = k_bounds  # d_sw.k_bounds()
         largest_possible_shape = self.grid.domain_shape_full(add=(1, 1, 1))
-        self._crx_adv = utils.make_storage_from_shape(
+        self._crx_interface = utils.make_storage_from_shape(
             largest_possible_shape, grid.compute_origin(add=(0, -self.grid.halo, 0))
         )
-        self._cry_adv = utils.make_storage_from_shape(
+        self._cry_interface = utils.make_storage_from_shape(
             largest_possible_shape, grid.compute_origin(add=(-self.grid.halo, 0, 0))
         )
-        self._xfx_adv = utils.make_storage_from_shape(
+        self._xfx_interface = utils.make_storage_from_shape(
             largest_possible_shape, grid.compute_origin(add=(0, -self.grid.halo, 0))
         )
-        self._yfx_adv = utils.make_storage_from_shape(
+        self._yfx_interface = utils.make_storage_from_shape(
             largest_possible_shape, grid.compute_origin(add=(-self.grid.halo, 0, 0))
         )
-        self._ra_x = utils.make_storage_from_shape(
+        self._area_with_x_flux = utils.make_storage_from_shape(
             largest_possible_shape,
             grid.compute_origin(add=(0, -self.grid.halo, 0)),
         )
-        self._ra_y = utils.make_storage_from_shape(
+        self._area_with_y_flux = utils.make_storage_from_shape(
             largest_possible_shape,
             grid.compute_origin(add=(-self.grid.halo, 0, 0)),
-            cache_key="updatedzd_ra_y",
         )
         self._wk = utils.make_storage_from_shape(
             largest_possible_shape, grid.full_origin()
@@ -286,6 +185,15 @@ class UpdateDeltaZOnDGrid:
         self._z2 = utils.make_storage_from_shape(
             largest_possible_shape, grid.full_origin()
         )
+        self._gk = utils.make_storage_from_shape(
+            largest_possible_shape, grid.full_origin()
+        )
+        self._gamma = utils.make_storage_from_shape(
+            largest_possible_shape, grid.full_origin()
+        )
+        self._beta = utils.make_storage_from_shape(
+            largest_possible_shape, grid.full_origin()
+        )
 
         self.finite_volume_transport = FiniteVolumeTransport(
             spec.namelist, spec.namelist.hord_tm
@@ -293,17 +201,21 @@ class UpdateDeltaZOnDGrid:
         ax_offsets = fv3core.utils.axis_offsets(
             self.grid, self.grid.full_origin(), self.grid.domain_shape_full()
         )
-        self._ra_update = FixedOriginStencil(
-            ra_update,
+        self._area_flux_update = FixedOriginStencil(
+            fv3core.stencils.fxadv.area_flux_update,
             origin=self.grid.full_origin(),
             domain=self.grid.domain_shape_full(add=(0, 0, 1)),
             externals=ax_offsets,
         )
-        self._edge_profile = FixedOriginStencil(
-            edge_profile,
+        self._cubic_spline_interpolation_constants = FixedOriginStencil(
+            cubic_spline_interpolation_constants,
             origin=self.grid.full_origin(),
             domain=self.grid.domain_shape_full(add=(0, 0, 1)),
-            externals=ax_offsets,
+        )
+        self._interpolate_to_layer_interface = FixedOriginStencil(
+            cubic_spline_interpolation_from_layer_center_to_interfaces,
+            origin=self.grid.full_origin(),
+            domain=self.grid.domain_shape_full(add=(0, 0, 1)),
         )
         self._zh_damp = FixedOriginStencil(
             zh_damp,
@@ -328,30 +240,34 @@ class UpdateDeltaZOnDGrid:
             dp0: ???
             zs: ???
             zh: ???
-            crx: Courant number in x-direction (??? what units)
-            cry: Courant number in y-direction (??? what units)
-            xfx: ???
-            yfx: ???
+            crx: Courant number in x-direction
+            cry: Courant number in y-direction
+            xfx: Mass flux in x-direction
+            yfx: Mass flux in y-direction
             wsd: ???
             dt: ???
         """
-        self._edge_profile(
-            crx,
-            xfx,
-            self._crx_adv,
-            self._xfx_adv,
-            cry,
-            yfx,
-            self._cry_adv,
-            self._yfx_adv,
-            dp0,
+        self._cubic_spline_interpolation_constants(
+            dp0, self._gk, self._beta, self._gamma
         )
-        self._ra_update(
+        self._interpolate_to_layer_interface(
+            crx, self._crx_interface, self._gk, self._beta, self._gamma
+        )
+        self._interpolate_to_layer_interface(
+            xfx, self._xfx_interface, self._gk, self._beta, self._gamma
+        )
+        self._interpolate_to_layer_interface(
+            cry, self._cry_interface, self._gk, self._beta, self._gamma
+        )
+        self._interpolate_to_layer_interface(
+            yfx, self._yfx_interface, self._gk, self._beta, self._gamma
+        )
+        self._area_flux_update(
             self.grid.area,
-            self._xfx_adv,
-            self._ra_x,
-            self._yfx_adv,
-            self._ra_y,
+            self._xfx_interface,
+            self._area_with_x_flux,
+            self._yfx_interface,
+            self._area_with_y_flux,
         )
         basic_operations.copy_stencil(
             zh,
@@ -361,12 +277,12 @@ class UpdateDeltaZOnDGrid:
         )
         self.finite_volume_transport(
             self._z2,
-            self._crx_adv,
-            self._cry_adv,
-            self._xfx_adv,
-            self._yfx_adv,
-            self._ra_x,
-            self._ra_y,
+            self._crx_interface,
+            self._cry_interface,
+            self._xfx_interface,
+            self._yfx_interface,
+            self._area_with_x_flux,
+            self._area_with_y_flux,
             self._fx,
             self._fy,
         )
@@ -386,8 +302,8 @@ class UpdateDeltaZOnDGrid:
             self._z2,
             self._fx,
             self._fy,
-            self._ra_x,
-            self._ra_y,
+            self._area_with_x_flux,
+            self._area_with_y_flux,
             self._fx2,
             self._fy2,
             self.grid.rarea,

--- a/fv3core/stencils/updatedzd.py
+++ b/fv3core/stencils/updatedzd.py
@@ -4,8 +4,6 @@ from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
 import fv3core._config as spec
 import fv3core.stencils.d_sw as d_sw
 import fv3core.stencils.delnflux as delnflux
-import fv3core.stencils.fxadv
-import fv3core.utils
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import FixedOriginStencil
@@ -194,9 +192,6 @@ class UpdateDeltaZOnDGrid:
 
         self.finite_volume_transport = FiniteVolumeTransport(
             spec.namelist, spec.namelist.hord_tm
-        )
-        ax_offsets = fv3core.utils.axis_offsets(
-            self.grid, self.grid.full_origin(), self.grid.domain_shape_full()
         )
         self._cubic_spline_interpolation_constants = FixedOriginStencil(
             cubic_spline_interpolation_constants,

--- a/tests/translate/translate_fvtp2d.py
+++ b/tests/translate/translate_fvtp2d.py
@@ -44,6 +44,8 @@ class TranslateFvTp2d(TranslateFortranData2Py):
             spec.namelist, int(inputs["hord"]), cache_key="regression-test"
         )
         del inputs["hord"]
+        inputs["area_with_x_flux"] = inputs.pop("ra_x")
+        inputs["area_with_y_flux"] = inputs.pop("ra_y")
         self.compute_func(**inputs)
         return inputs
 

--- a/tests/translate/translate_fvtp2d.py
+++ b/tests/translate/translate_fvtp2d.py
@@ -16,8 +16,6 @@ class TranslateFvTp2d(TranslateFortranData2Py):
             "cry": {"jstart": grid.js},
             "xfx": {"istart": grid.is_},
             "yfx": {"jstart": grid.js},
-            "ra_x": {"istart": grid.is_},
-            "ra_y": {"jstart": grid.js},
             "mfx": grid.x3d_compute_dict(),
             "mfy": grid.y3d_compute_dict(),
         }
@@ -44,8 +42,6 @@ class TranslateFvTp2d(TranslateFortranData2Py):
             spec.namelist, int(inputs["hord"]), cache_key="regression-test"
         )
         del inputs["hord"]
-        inputs["area_with_x_flux"] = inputs.pop("ra_x")
-        inputs["area_with_y_flux"] = inputs.pop("ra_y")
         self.compute_func(**inputs)
         return inputs
 

--- a/tests/translate/translate_fxadv.py
+++ b/tests/translate/translate_fxadv.py
@@ -30,11 +30,13 @@ class TranslateFxAdv(TranslateFortranData2Py):
 
     def compute_from_storage(self, inputs):
         grid = self.grid
-        inputs["ra_x"] = utils.make_storage_from_shape(
+        inputs["area_with_x_flux"] = utils.make_storage_from_shape(
             inputs["uc"].shape, grid.compute_origin()
         )
-        inputs["ra_y"] = utils.make_storage_from_shape(
+        inputs["area_with_y_flux"] = utils.make_storage_from_shape(
             inputs["vc"].shape, grid.compute_origin()
         )
         fxadv.compute(**inputs)
+        inputs["ra_x"] = inputs.pop("area_with_x_flux")
+        inputs["ra_y"] = inputs.pop("area_with_y_flux")
         return inputs

--- a/tests/translate/translate_fxadv.py
+++ b/tests/translate/translate_fxadv.py
@@ -1,5 +1,4 @@
 import fv3core.stencils.fxadv as fxadv
-import fv3core.utils.gt4py_utils as utils
 from fv3core.testing import TranslateFortranData2Py
 
 
@@ -20,8 +19,6 @@ class TranslateFxAdv(TranslateFortranData2Py):
         }
         self.in_vars["parameters"] = ["dt"]
         self.out_vars = {
-            "ra_x": {"istart": grid.is_, "iend": grid.ie},
-            "ra_y": {"jstart": grid.js, "jend": grid.je},
             "ut": utinfo,
             "vt": vtinfo,
         }
@@ -29,14 +26,5 @@ class TranslateFxAdv(TranslateFortranData2Py):
             self.out_vars[var] = self.in_vars["data_vars"][var]
 
     def compute_from_storage(self, inputs):
-        grid = self.grid
-        inputs["area_with_x_flux"] = utils.make_storage_from_shape(
-            inputs["uc"].shape, grid.compute_origin()
-        )
-        inputs["area_with_y_flux"] = utils.make_storage_from_shape(
-            inputs["vc"].shape, grid.compute_origin()
-        )
         fxadv.compute(**inputs)
-        inputs["ra_x"] = inputs.pop("area_with_x_flux")
-        inputs["ra_y"] = inputs.pop("area_with_y_flux")
         return inputs


### PR DESCRIPTION
## Purpose

There is currently a lot of logic and control flow dedicated to pre-adding area flux to area and storing it in a temporary storage. Almost all routines passed this temporary are also passed both area flux and area, and could compute the temporary on-the-fly. This PR refactors those modules do so, deleting over 100 lines of code and removing `ra_x` and `ra_y` from several function signatures. This new pattern should also reduce memory pressure.

## Code changes:

- Area after flux update is now computed from area and area flux where used, instead of being passed as a temporary storage

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)