### PR TITLE
perform tracer halo updates in parallel

### DIFF
--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -285,9 +285,10 @@ class Tracer2D1L:
             )
 
         if self.do_halo_exchange:
+            reqs = {}
             for qname in utils.tracer_variables[0:nq]:
                 q = tracers[qname + "_quantity"]
-                self.comm.halo_update(q, n_points=utils.halo)
+                reqs[qname] = self.comm.start_halo_update(q, n_points=utils.halo)
 
         self._ra_update(
             self.grid.area,
@@ -308,6 +309,7 @@ class Tracer2D1L:
             **self.stencil_runtime_args,
         )
         for qname in utils.tracer_variables[0:nq]:
+            reqs[qname].wait()
             q = tracers[qname + "_quantity"]
             self._loop_temporaries_copy(
                 self._tmp_dp1_orig,


### PR DESCRIPTION
## Purpose

Currently tracer halo updates in tracer_2d_1l occur one at a time, blocking between tracers. This PR refactors that logic to start all tracer halo updates, and then only wait on the halo update for a given tracer when it is being worked on. This should be more efficient if it results in more synchronous communication.

## Code changes:

- tracer halo updates in tracer_2d_1l now occur asynchronously

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
