### PR TITLE
revert if check to assertion for error in FixedOriginStencil

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -355,10 +355,12 @@ class FixedOriginStencil:
         )
 
     def __call__(self, *args, **kwargs) -> None:
-        if "origin" in kwargs:
-            raise ValueError("cannot pass origin to FixedOriginStencil at call time")
-        if "domain" in kwargs:
-            raise ValueError("cannot pass domain to FixedOriginStencil at call time")
+        assert (
+            "origin" not in kwargs
+        ), "cannot pass origin to FixedOriginStencil at call time"
+        assert (
+            "domain" not in kwargs
+        ), "cannot pass domain to FixedOriginStencil at call time"
         self.stencil_object(
             *args,
             **kwargs,


### PR DESCRIPTION
A previous PR changed an assert statement to an if check, this PR reverts that change and adds the error message for the assert statement instead.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
