### PR TITLE
hotfix for Map1_PPm_2d tests with 54 ranks

### DIFF
--- a/tests/translate/translate_map1_ppm_2d.py
+++ b/tests/translate/translate_map1_ppm_2d.py
@@ -43,7 +43,7 @@ class TranslateMap1_PPM_2d(TranslateFortranData2Py):
         self.out_vars = {"var_inout": {}}
         self.max_error = 5e-13
         self.write_vars = ["qs"]
-        self.nj = grid.npy
+        self.nj = self.maxshape[1]
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)


### PR DESCRIPTION
## Purpose

A recent commit broke Map1_PPM_2d tests for 54 ranks (just test code, so doesn't impact results of the full model), this fixes it. 
