### PR TITLE
Minor performance improvments

### DIFF
--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -4,7 +4,6 @@ import gt4py.gtscript as gtscript
 from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import fv3core._config as spec
-import fv3core.utils.global_config as global_config
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import StencilWrapper
 from fv3core.utils.typing import FloatField

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -6,8 +6,8 @@ from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, 
 import fv3core._config as spec
 import fv3core.utils.global_config as global_config
 import fv3core.utils.gt4py_utils as utils
-from fv3core.utils.typing import FloatField
 from fv3core.decorators import StencilWrapper
+from fv3core.utils.typing import FloatField
 
 
 @gtscript.function

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -7,6 +7,7 @@ import fv3core._config as spec
 import fv3core.utils.global_config as global_config
 import fv3core.utils.gt4py_utils as utils
 from fv3core.utils.typing import FloatField
+from fv3core.decorators import StencilWrapper
 
 
 @gtscript.function
@@ -535,39 +536,29 @@ class RemapProfile:
             grid.domain_shape_full(add=(0, 0, 1)), origin=self._full_orig
         )
 
-        self._set_values_stencil = gtscript.stencil(
-            definition=set_vals,
+        self._set_values_stencil = StencilWrapper(
+            func=set_vals,
             externals={"iv": iv, "kord": abs(kord)},
-            backend=global_config.get_backend(),
-            rebuild=global_config.get_rebuild(),
         )
 
-        self._apply_constraints_stencil = gtscript.stencil(
-            definition=apply_constraints,
+        self._apply_constraints_stencil = StencilWrapper(
+            func=apply_constraints,
             externals={"iv": iv, "kord": abs(kord)},
-            backend=global_config.get_backend(),
-            rebuild=global_config.get_rebuild(),
         )
 
-        self._set_top_stencil = gtscript.stencil(
-            definition=set_top,
+        self._set_top_stencil = StencilWrapper(
+            func=set_top,
             externals={"iv": iv},
-            backend=global_config.get_backend(),
-            rebuild=global_config.get_rebuild(),
         )
 
-        self._set_set_inner_stencil = gtscript.stencil(
-            definition=set_inner,
+        self._set_set_inner_stencil = StencilWrapper(
+            func=set_inner,
             externals={"iv": iv, "kord": abs(kord)},
-            backend=global_config.get_backend(),
-            rebuild=global_config.get_rebuild(),
         )
 
-        self._set_bottom_stencil = gtscript.stencil(
-            definition=set_bottom,
+        self._set_bottom_stencil = StencilWrapper(
+            func=set_bottom,
             externals={"iv": iv},
-            backend=global_config.get_backend(),
-            rebuild=global_config.get_rebuild(),
         )
 
     def __call__(

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -372,7 +372,7 @@ class Grid:
             return 0, 0
 
 
-@functools.lru_cache
+@functools.cache
 def axis_offsets(
     grid: Grid,
     origin: Tuple[int, ...],

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -372,7 +372,7 @@ class Grid:
             return 0, 0
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def axis_offsets(
     grid: Grid,
     origin: Tuple[int, ...],


### PR DESCRIPTION
## Purpose

- There was still one set of stencils calling `validate_args` as they were still `gtscript.stencil`s so converting them to `StencilWrapper` should get rid of the overhead there.
- The LRU cache for `axis_offsets` was limited to 128 entries so we increased the size there to shave off addtional 3% of our runtime

## Code changes:

- Increase the LRU cache size for `axis_offsets`
- Make the stencils in `remap_profile` `StencilWrapper`s

## Checklist
Before submitting this PR, please make sure:

- [X] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
