### PR TITLE
monkeypatch automatic check to __getitem__ that device is synced

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -391,12 +391,10 @@ class FrozenStencil(StencilWrapper):
         self.domain = domain
 
     def __call__(self, *args, **kwargs) -> None:
-        assert (
-            "origin" not in kwargs
-        ), "cannot pass origin to FrozenStencil at call time"
-        assert (
-            "domain" not in kwargs
-        ), "cannot pass domain to FrozenStencil at call time"
+        if __debug__ and ("origin" in kwargs):
+            raise TypeError("cannot pass origin to FrozenStencil at call time")
+        if __debug__ and ("domain" in kwargs):
+            raise TypeError("cannot pass domain to FrozenStencil at call time")
         kwargs["normalized_origin"] = self.normalized_origin
         kwargs["normalized_domain"] = self.normalized_domain
         super().__call__(*args, **kwargs)

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -27,10 +27,6 @@ ArgSpec = collections.namedtuple(
 )
 VALID_INTENTS = ["in", "out", "inout", "unknown"]
 
-storage_types = (
-    gt_storage.storage.Storage
-)  # , gt_storage.storage.CPUStorage, gt_storage.storage.GPUStorage)
-
 
 def enable_stencil_report(
     *, path: str, save_args: bool, save_report: bool, include_halos: bool = False
@@ -332,7 +328,7 @@ class FV3StencilObject:
 
 def register_unsafe_storages(args, kwargs):
     for maybe_storage in list(args) + list(kwargs.values()):
-        if isinstance(maybe_storage, storage_types):
+        if isinstance(maybe_storage, gt_storage.storage.Storage):
             safety.PYTHON_UNSAFE_STORAGES.append(maybe_storage)
 
 

--- a/fv3core/stencils/del2cubed.py
+++ b/fv3core/stencils/del2cubed.py
@@ -71,6 +71,7 @@ def corner_fill(grid, q):
         ) * r3
         q[grid.ie + 1, grid.js, :] = q[grid.ie, grid.js, :]
         copy_column(q, origin=(grid.ie, grid.js - 1, 0), domain=(1, 1, grid.npz))
+        utils.device_sync()
 
     if grid.ne_corner:
         q[grid.ie, grid.je, :] = (
@@ -88,6 +89,7 @@ def corner_fill(grid, q):
             + q[grid.is_, grid.je + 1, :]
         ) * r3
         copy_row(q, origin=(grid.is_ - 1, grid.je, 0), domain=(1, 1, grid.npz))
+        utils.device_sync()
         q[grid.is_, grid.je + 1, :] = q[grid.is_, grid.je, :]
 
     return q

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -12,6 +12,8 @@ import fv3core.utils.global_config as global_config
 from fv3core.utils.mpi import MPI
 from fv3core.utils.typing import DTypes, Field, Float, Int
 
+from . import safety
+
 
 try:
     import cupy as cp
@@ -150,6 +152,7 @@ def make_storage_data(
         mask=mask,
         managed_memory=managed_memory,
     )
+    storage.__getitem__ = safety.requires_safe(storage.__getitem__)
     return storage
 
 
@@ -554,6 +557,7 @@ def stack(tup, axis: int = 0, out=None):
 def device_sync() -> None:
     if cp and "cuda" in global_config.get_backend():
         cp.cuda.Device(0).synchronize()
+    safety.PYTHON_UNSAFE_STORAGES.clear()
 
 
 def apply_device_sync(stencil_kwargs: Dict[str, Any]) -> None:

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -152,7 +152,6 @@ def make_storage_data(
         mask=mask,
         managed_memory=managed_memory,
     )
-    storage.__getitem__ = safety.requires_safe(storage.__getitem__)
     return storage
 
 

--- a/fv3core/utils/safety.py
+++ b/fv3core/utils/safety.py
@@ -1,0 +1,33 @@
+import types
+from typing import List
+
+import gt4py
+
+
+PYTHON_UNSAFE_STORAGES: List[gt4py.storage.storage.Storage] = []
+
+
+def _unsafe_storage_access(storages):
+    for s1 in storages:
+        for s2 in PYTHON_UNSAFE_STORAGES:
+            if s1 is s2:
+                return True
+    return False
+
+
+def requires_safe(func, method_parent=None):
+    def wrapped(*args, **kwargs):
+        if __debug__ and _unsafe_storage_access(list(args) + list(kwargs.values())):
+            raise ValueError("operation requires you call utils.device_sync() first")
+        return func(*args, **kwargs)
+
+    if method_parent is not None:
+        wrapped = types.MethodType(wrapped, method_parent)
+    return wrapped
+
+
+for storage_type in (
+    gt4py.storage.storage.CPUStorage,
+    gt4py.storage.storage.GPUStorage,
+):
+    storage_type.__getitem__ = requires_safe(storage_type.__getitem__)

--- a/fv3core/utils/safety.py
+++ b/fv3core/utils/safety.py
@@ -7,6 +7,10 @@ import gt4py
 PYTHON_UNSAFE_STORAGES: List[gt4py.storage.storage.Storage] = []
 
 
+class UnsafeAccess(RuntimeError):
+    pass
+
+
 def _unsafe_storage_access(storages):
     for s1 in storages:
         for s2 in PYTHON_UNSAFE_STORAGES:
@@ -18,7 +22,7 @@ def _unsafe_storage_access(storages):
 def requires_safe(func, method_parent=None):
     def wrapped(*args, **kwargs):
         if __debug__ and _unsafe_storage_access(list(args) + list(kwargs.values())):
-            raise ValueError("operation requires you call utils.device_sync() first")
+            raise UnsafeAccess("operation requires you call utils.device_sync() first")
         return func(*args, **kwargs)
 
     if method_parent is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,11 @@ def data_path(pytestconfig):
     return data_path_from_config(pytestconfig)
 
 
+@pytest.fixture(autouse=True)
+def sync_before_tests():
+    fv3core.utils.gt4py_utils.device_sync()
+
+
 def data_path_from_config(config):
     data_path = config.getoption("data_path")
     namelist_filename = os.path.join(data_path, "input.nml")

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,48 @@
+import pytest
+from gt4py.gtscript import PARALLEL, computation, interval
+
+import fv3core.decorators
+import fv3core.utils.gt4py_utils
+import fv3core.utils.safety
+from fv3core.utils.typing import FloatField
+
+
+@pytest.fixture
+def storage():
+    return fv3core.utils.gt4py_utils.make_storage_from_shape_uncached((3, 3, 3))
+
+
+@pytest.fixture(params=["frozen", "wrapped", "decorated"])
+def stencil(request, storage):
+    def func(storage: FloatField):
+        with computation(PARALLEL), interval(...):
+            storage = 0.0
+
+    if request.param == "frozen":
+        return fv3core.decorators.FrozenStencil(
+            func, origin=(0, 0, 0), domain=storage.shape
+        )
+    elif request.param == "wrapped":
+        return fv3core.decorators.StencilWrapper(func)
+    elif request.param == "decorated":
+        return fv3core.decorators.gtstencil()(func)
+    else:
+        raise NotImplementedError(request.param)
+
+
+def test_access_storage_after_stencil_call_raises(storage, stencil):
+    try:
+        stencil(storage, origin=(0, 0, 0), domain=storage.shape)
+    except TypeError:
+        stencil(storage)
+    with pytest.raises(fv3core.utils.safety.UnsafeAccess):
+        storage[0, 0, 0]
+
+
+def test_access_storage_after_sync(storage, stencil):
+    try:
+        stencil(storage, origin=(0, 0, 0), domain=storage.shape)
+    except TypeError:
+        stencil(storage)
+    fv3core.utils.gt4py_utils.device_sync()
+    storage[0, 0, 0]

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -12,7 +12,7 @@ def storage():
     return fv3core.utils.gt4py_utils.make_storage_from_shape_uncached((3, 3, 3))
 
 
-@pytest.fixture(params=["frozen", "wrapped", "decorated"])
+@pytest.fixture(params=["frozen", "wrapped"])
 def stencil(request, storage):
     def func(storage: FloatField):
         with computation(PARALLEL), interval(...):
@@ -24,8 +24,6 @@ def stencil(request, storage):
         )
     elif request.param == "wrapped":
         return fv3core.decorators.StencilWrapper(func)
-    elif request.param == "decorated":
-        return fv3core.decorators.gtstencil()(func)
     else:
         raise NotImplementedError(request.param)
 

--- a/tests/translate/translate_fillz.py
+++ b/tests/translate/translate_fillz.py
@@ -50,6 +50,7 @@ class TranslateFillz(TranslateFortranData2Py):
         ds = self.grid.default_domain_dict()
         ds.update(self.out_vars["q2tracers"])
         tracers = np.zeros((self.grid.nic, self.grid.npz, len(inputs["tracers"])))
+        utils.device_sync()
         for varname, data in inputs["tracers"].items():
             index = utils.tracer_variables.index(varname)
             tracers[:, :, index] = np.squeeze(data[self.grid.slice_dict(ds)])

--- a/tests/translate/translate_fillz.py
+++ b/tests/translate/translate_fillz.py
@@ -48,9 +48,9 @@ class TranslateFillz(TranslateFortranData2Py):
         inputs["jm"] = 1
         self.compute_func(**inputs)
         ds = self.grid.default_domain_dict()
+        utils.device_sync()
         ds.update(self.out_vars["q2tracers"])
         tracers = np.zeros((self.grid.nic, self.grid.npz, len(inputs["tracers"])))
-        utils.device_sync()
         for varname, data in inputs["tracers"].items():
             index = utils.tracer_variables.index(varname)
             tracers[:, :, index] = np.squeeze(data[self.grid.slice_dict(ds)])


### PR DESCRIPTION
## Purpose

After calling stencils, we must synchronize with the GPU device before running python code on stencil data. Currently this must be ensured manually, and may or may not cause failures in tests.

This PR causes an exception to happen whenever `__getitem__` is called on a storage after a stencil is called with that storage as an argument, and before `utils.device_sync()` is called. This functionality is disabled if __debug__ is False, for performance.

## Code changes:

- Monkeypatched `gt4py.storage.storage.Storage.__getitem__` to check if the storage has been passed to one of our decorated stencils since the last device synchronization, and raise an exception if so
- device syncs added to fillz translate class and to fill_corners routine where needed

## Infrastructure changes:

- `utils.device_sync()` is now called at the start of each test

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes

