### PR TITLE
perform pert_ppm correction for all regions at once in xppm/yppm

### DIFF
--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -259,26 +259,25 @@ def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
 
     with horizontal(region[i_start - 1, :]):
         bl, br = west_edge_iord8plus_0(q, dxa, dm)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_start, :]):
         bl, br = west_edge_iord8plus_1(q, dxa, dm)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_start + 1, :]):
         bl, br = west_edge_iord8plus_2(q, dm, al)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_end - 1, :]):
         bl, br = east_edge_iord8plus_0(q, dm, al)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_end, :]):
         bl, br = east_edge_iord8plus_1(q, dxa, dm)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_end + 1, :]):
         bl, br = east_edge_iord8plus_2(q, dxa, dm)
+
+    with horizontal(
+        region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]
+    ):
         bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     return bl, br

--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -112,8 +112,6 @@ def xt_dxa_edge_0(q, dxa):
     from __externals__ import xt_minmax
 
     xt = xt_dxa_edge_0_base(q, dxa)
-    minq = 0.0
-    maxq = 0.0
     if __INLINED(xt_minmax):
         minq = min(min(min(q[-1, 0, 0], q), q[1, 0, 0]), q[2, 0, 0])
         maxq = max(max(max(q[-1, 0, 0], q), q[1, 0, 0]), q[2, 0, 0])
@@ -126,8 +124,6 @@ def xt_dxa_edge_1(q, dxa):
     from __externals__ import xt_minmax
 
     xt = xt_dxa_edge_1_base(q, dxa)
-    minq = 0.0
-    maxq = 0.0
     if __INLINED(xt_minmax):
         minq = min(min(min(q[-2, 0, 0], q[-1, 0, 0]), q), q[1, 0, 0])
         maxq = max(max(max(q[-2, 0, 0], q[-1, 0, 0]), q), q[1, 0, 0])

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -205,9 +205,6 @@ def north_edge_jord8plus_2(q: FloatField, dya: FloatFieldIJ, dm: FloatField):
 def pert_ppm_positive_definite_constraint_fcn(
     a0: FloatField, al: FloatField, ar: FloatField
 ):
-    da1 = 0.0
-    a4 = 0.0
-    fmin = 0.0
     if a0 <= 0.0:
         al = 0.0
         ar = 0.0
@@ -238,9 +235,6 @@ def pert_ppm_positive_definite_constraint(
 
 @gtscript.function
 def pert_ppm_standard_constraint_fcn(a0: FloatField, al: FloatField, ar: FloatField):
-    da1 = 0.0
-    da2 = 0.0
-    a6da = 0.0
     if al * ar < 0.0:
         da1 = al - ar
         da2 = da1 ** 2

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -317,26 +317,25 @@ def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
 
     with horizontal(region[:, j_start - 1]):
         bl, br = south_edge_jord8plus_0(q, dya, dm)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_start]):
         bl, br = south_edge_jord8plus_1(q, dya, dm)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_start + 1]):
         bl, br = south_edge_jord8plus_2(q, dm, al)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_end - 1]):
         bl, br = north_edge_jord8plus_0(q, dm, al)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_end]):
         bl, br = north_edge_jord8plus_1(q, dya, dm)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_end + 1]):
         bl, br = north_edge_jord8plus_2(q, dya, dm)
+
+    with horizontal(
+        region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]
+    ):
         bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     return bl, br


### PR DESCRIPTION
## Purpose

This PR reduces the run time of xppm and yppm significantly by performing an operation across six regions in a single operation as opposed to six separate operations.

## Code changes:

- Optimization to xppm and yppm by performing an operation across six regions in a single operation as opposed to six separate operations, and removed unneeded zero initialization for temporaries

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)