### PR TITLE
Hot fix for rebuild flag in FV3StencilObject

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -394,7 +394,7 @@ class FV3StencilObject(StencilWrapper):
         # Can optimize this by marking stencils that need these
         axis_offsets = fv3core.utils.axis_offsets(spec.grid, origin, domain)
 
-        regenerate_stencil = not self.built or self.rebuild
+        regenerate_stencil = not self.built or global_config.get_rebuild()
 
         # Check if we really do need to regenerate
         if not regenerate_stencil:


### PR DESCRIPTION
## Purpose

Modifies `FV3StencilObject.__call__` to use `global_config.get_rebuild()` rather than `self.rebuild` to prevent object version from being set before global version.
