### PR TITLE
Ensure global rebuild flag is always used

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -394,7 +394,8 @@ class FV3StencilObject(StencilWrapper):
         # Can optimize this by marking stencils that need these
         axis_offsets = fv3core.utils.axis_offsets(spec.grid, origin, domain)
 
-        regenerate_stencil = not self.built or global_config.get_rebuild()
+        self.rebuild = global_config.get_rebuild()
+        regenerate_stencil = not self.built or self.rebuild
 
         # Check if we really do need to regenerate
         if not regenerate_stencil:


### PR DESCRIPTION
## Purpose

This PR sets `self.rebuild` to `global_config.get_rebuild()` in every call to ensure it is always set.
