### PR TITLE
Remove uneeded dirs from caches before saving

### DIFF
--- a/.jenkins/actions/run_standalone.sh
+++ b/.jenkins/actions/run_standalone.sh
@@ -100,8 +100,11 @@ fi
 
 # store cache artifacts (and remove caches afterwards)
 if [ "${SAVE_CACHE}" == "true" ] ; then
-    mkdir -p ${CACHE_DIR}
+    echo "Pruning cache to make sure no __pycache__ and *_pyext_BUILD dirs are present"
+    find .gt_cache* -type d -name \*_pyext_BUILD -exec \rm -rf {} \;
+    find .gt_cache* -type d -name __pycache__ -exec \rm -rf {} \;
     echo "Copying GT4Py cache directories to ${CACHE_DIR}"
+    mkdir -p ${CACHE_DIR}
     cp ${ROOT_DIR}/GT4PY_VERSION.txt ${CACHE_DIR}
     rm -rf ${CACHE_DIR}/.gt_cache*
     cp -rp .gt_cache* ${CACHE_DIR}/


### PR DESCRIPTION
## Purpose

We continually run out of inodes. This PR reduces the number of files and directories (inodes) significantly (down to ~10%) by removing uneeded artifacts of Python (`__pycache__` directory) and GT4Py compilation (`*_pyext_BUILD` directory)

## Code changes:

- Only changes in `.jenkins/actions/run_standalone`

## Notes:

- This is a temporary solution. The better solution is introduce a common decorator to all stencils and make sure we pass the `clean=True` flag when compiling stencils.
- This PR is really hard to test. I suggest merging this in the evening after work hours and then try it.