### PR TITLE
remove re-use of xt temporary when computing bl and br

### DIFF
--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -169,7 +169,7 @@ def compute_al(q: FloatField, dxa: FloatFieldIJ):
 
 
 @gtscript.function
-def xt_bl_br_edges(q, dxa, al, dm):
+def bl_br_edges(bl, br, q, dxa, al, dm):
     from __externals__ import i_end, i_start
 
     with horizontal(region[i_start - 1, :]):
@@ -181,7 +181,7 @@ def xt_bl_br_edges(q, dxa, al, dm):
         xt_br = yppm.s15 * q + yppm.s11 * q[1, 0, 0] - yppm.s14 * dm[1, 0, 0]
 
     with horizontal(region[i_start + 1, :]):
-        xt_bl = yppm.s15 * q[-1, 0, 0] + yppm.s11 * q - yppm.s14 * dm + q
+        xt_bl = yppm.s15 * q[-1, 0, 0] + yppm.s11 * q - yppm.s14 * dm
         xt_br = al[1, 0, 0]
 
     with horizontal(region[i_end - 1, :]):
@@ -196,7 +196,13 @@ def xt_bl_br_edges(q, dxa, al, dm):
         xt_bl = xt_dxa_edge_1(q, dxa)
         xt_br = yppm.s11 * (q[1, 0, 0] - q) - yppm.s14 * dm[1, 0, 0] + q
 
-    return xt_bl, xt_br
+    with horizontal(
+        region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]
+    ):
+        bl = xt_bl - q
+        br = xt_br - q
+
+    return bl, br
 
 
 @gtscript.function
@@ -209,13 +215,11 @@ def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
     external_assert(iord == 8)
 
     bl, br = blbr_iord8(q, al, dm)
-    xt_bl, xt_br = xt_bl_br_edges(q, dxa, al, dm)
+    bl, br = bl_br_edges(bl, br, q, dxa, al, dm)
 
     with horizontal(
         region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]
     ):
-        bl = xt_bl - q
-        br = xt_br - q
         bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     return bl, br

--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -132,80 +132,6 @@ def xt_dxa_edge_1(q, dxa):
 
 
 @gtscript.function
-def west_edge_iord8plus_0(
-    q: FloatField,
-    dxa: FloatFieldIJ,
-    dm: FloatField,
-):
-    bl = yppm.s14 * dm[-1, 0, 0] + yppm.s11 * (q[-1, 0, 0] - q)
-    xt = xt_dxa_edge_0(q, dxa)
-    br = xt - q
-    return bl, br
-
-
-@gtscript.function
-def west_edge_iord8plus_1(
-    q: FloatField,
-    dxa: FloatFieldIJ,
-    dm: FloatField,
-):
-    xt = xt_dxa_edge_1(q, dxa)
-    bl = xt - q
-    xt = yppm.s15 * q + yppm.s11 * q[1, 0, 0] - yppm.s14 * dm[1, 0, 0]
-    br = xt - q
-    return bl, br
-
-
-@gtscript.function
-def west_edge_iord8plus_2(
-    q: FloatField,
-    dm: FloatField,
-    al: FloatField,
-):
-    xt = yppm.s15 * q[-1, 0, 0] + yppm.s11 * q - yppm.s14 * dm
-    bl = xt - q
-    br = al[1, 0, 0] - q
-    return bl, br
-
-
-@gtscript.function
-def east_edge_iord8plus_0(
-    q: FloatField,
-    dm: FloatField,
-    al: FloatField,
-):
-    bl = al - q
-    xt = yppm.s15 * q[1, 0, 0] + yppm.s11 * q + yppm.s14 * dm
-    br = xt - q
-    return bl, br
-
-
-@gtscript.function
-def east_edge_iord8plus_1(
-    q: FloatField,
-    dxa: FloatFieldIJ,
-    dm: FloatField,
-):
-    xt = yppm.s15 * q + yppm.s11 * q[-1, 0, 0] + yppm.s14 * dm[-1, 0, 0]
-    bl = xt - q
-    xt = xt_dxa_edge_0(q, dxa)
-    br = xt - q
-    return bl, br
-
-
-@gtscript.function
-def east_edge_iord8plus_2(
-    q: FloatField,
-    dxa: FloatFieldIJ,
-    dm: FloatField,
-):
-    xt = xt_dxa_edge_1(q, dxa)
-    bl = xt - q
-    br = yppm.s11 * (q[1, 0, 0] - q) - yppm.s14 * dm[1, 0, 0]
-    return bl, br
-
-
-@gtscript.function
 def compute_al(q: FloatField, dxa: FloatFieldIJ):
     """
     Interpolate q at interface.
@@ -254,26 +180,34 @@ def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
     bl, br = blbr_iord8(q, al, dm)
 
     with horizontal(region[i_start - 1, :]):
-        bl, br = west_edge_iord8plus_0(q, dxa, dm)
+        xt_bl = yppm.s14 * dm[-1, 0, 0] + yppm.s11 * (q[-1, 0, 0] - q) + q
+        xt_br = xt_dxa_edge_0(q, dxa)
 
     with horizontal(region[i_start, :]):
-        bl, br = west_edge_iord8plus_1(q, dxa, dm)
+        xt_bl = xt_dxa_edge_1(q, dxa)
+        xt_br = yppm.s15 * q + yppm.s11 * q[1, 0, 0] - yppm.s14 * dm[1, 0, 0]
 
     with horizontal(region[i_start + 1, :]):
-        bl, br = west_edge_iord8plus_2(q, dm, al)
+        xt_bl = yppm.s15 * q[-1, 0, 0] + yppm.s11 * q - yppm.s14 * dm + q
+        xt_br = al[1, 0, 0]
 
     with horizontal(region[i_end - 1, :]):
-        bl, br = east_edge_iord8plus_0(q, dm, al)
+        xt_bl = al
+        xt_br = yppm.s15 * q[1, 0, 0] + yppm.s11 * q + yppm.s14 * dm
 
     with horizontal(region[i_end, :]):
-        bl, br = east_edge_iord8plus_1(q, dxa, dm)
+        xt_bl = yppm.s15 * q + yppm.s11 * q[-1, 0, 0] + yppm.s14 * dm[-1, 0, 0]
+        xt_br = xt_dxa_edge_0(q, dxa)
 
     with horizontal(region[i_end + 1, :]):
-        bl, br = east_edge_iord8plus_2(q, dxa, dm)
+        xt_bl = xt_dxa_edge_1(q, dxa)
+        xt_br = yppm.s11 * (q[1, 0, 0] - q) - yppm.s14 * dm[1, 0, 0] + q
 
     with horizontal(
         region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]
     ):
+        bl = xt_bl - q
+        br = xt_br - q
         bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     return bl, br

--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -259,26 +259,25 @@ def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
 
     with horizontal(region[i_start - 1, :]):
         bl, br = west_edge_iord8plus_0(q, dxa, dm)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_start, :]):
         bl, br = west_edge_iord8plus_1(q, dxa, dm)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_start + 1, :]):
         bl, br = west_edge_iord8plus_2(q, dm, al)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_end - 1, :]):
         bl, br = east_edge_iord8plus_0(q, dm, al)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_end, :]):
         bl, br = east_edge_iord8plus_1(q, dxa, dm)
-        bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[i_end + 1, :]):
         bl, br = east_edge_iord8plus_2(q, dxa, dm)
+
+    with horizontal(
+        region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]
+    ):
         bl, br = yppm.pert_ppm_standard_constraint_fcn(q, bl, br)
 
     return bl, br

--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -169,15 +169,8 @@ def compute_al(q: FloatField, dxa: FloatFieldIJ):
 
 
 @gtscript.function
-def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
-    from __externals__ import i_end, i_start, iord
-
-    dm = dm_iord8plus(q)
-    al = al_iord8plus(q, dm)
-
-    external_assert(iord == 8)
-
-    bl, br = blbr_iord8(q, al, dm)
+def xt_bl_br_edges(q, dxa, al, dm):
+    from __externals__ import i_end, i_start
 
     with horizontal(region[i_start - 1, :]):
         xt_bl = yppm.s14 * dm[-1, 0, 0] + yppm.s11 * (q[-1, 0, 0] - q) + q
@@ -202,6 +195,21 @@ def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
     with horizontal(region[i_end + 1, :]):
         xt_bl = xt_dxa_edge_1(q, dxa)
         xt_br = yppm.s11 * (q[1, 0, 0] - q) - yppm.s14 * dm[1, 0, 0] + q
+
+    return xt_bl, xt_br
+
+
+@gtscript.function
+def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
+    from __externals__ import i_end, i_start, iord
+
+    dm = dm_iord8plus(q)
+    al = al_iord8plus(q, dm)
+
+    external_assert(iord == 8)
+
+    bl, br = blbr_iord8(q, al, dm)
+    xt_bl, xt_br = xt_bl_br_edges(q, dxa, al, dm)
 
     with horizontal(
         region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]

--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -112,8 +112,6 @@ def xt_dxa_edge_0(q, dxa):
     from __externals__ import xt_minmax
 
     xt = xt_dxa_edge_0_base(q, dxa)
-    minq = 0.0
-    maxq = 0.0
     if __INLINED(xt_minmax):
         minq = min(min(min(q[-1, 0, 0], q), q[1, 0, 0]), q[2, 0, 0])
         maxq = max(max(max(q[-1, 0, 0], q), q[1, 0, 0]), q[2, 0, 0])
@@ -126,8 +124,6 @@ def xt_dxa_edge_1(q, dxa):
     from __externals__ import xt_minmax
 
     xt = xt_dxa_edge_1_base(q, dxa)
-    minq = 0.0
-    maxq = 0.0
     if __INLINED(xt_minmax):
         minq = min(min(min(q[-2, 0, 0], q[-1, 0, 0]), q), q[1, 0, 0])
         maxq = max(max(max(q[-2, 0, 0], q[-1, 0, 0]), q), q[1, 0, 0])

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -94,7 +94,6 @@ def _compute_stencil(
         ):
             bl = 0.0
             br = 0.0
-        # }
 
         flux = _get_flux(u, courant, rdx, bl, br)
 

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -11,7 +11,7 @@ from gt4py.gtscript import (
 
 import fv3core._config as spec
 from fv3core.decorators import StencilWrapper
-from fv3core.stencils import xppm
+from fv3core.stencils import xppm, yppm
 from fv3core.utils.grid import axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
@@ -77,13 +77,10 @@ def _compute_stencil(
             external_assert(iord == 8)
 
             bl, br = xppm.blbr_iord8(u, al, dm)
-            xt_bl, xt_br = xppm.xt_bl_br_edges(u, dxa, al, dm)
+            bl, br = xppm.bl_br_edges(bl, br, u, dxa, al, dm)
 
-            with horizontal(
-                region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]
-            ):
-                bl = xt_bl - u
-                br = xt_br - u
+            with horizontal(region[i_start + 1, :], region[i_end - 1, :]):
+                bl, br = yppm.pert_ppm_standard_constraint_fcn(u, bl, br)
 
         # Zero corners
         with horizontal(

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -11,7 +11,7 @@ from gt4py.gtscript import (
 
 import fv3core._config as spec
 from fv3core.decorators import FrozenStencil
-from fv3core.stencils import xppm, yppm
+from fv3core.stencils import xppm
 from fv3core.utils.grid import axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
@@ -70,55 +70,31 @@ def _compute_stencil(
             bl = al[0, 0, 0] - u[0, 0, 0]
             br = al[1, 0, 0] - u[0, 0, 0]
 
-            # Zero corners
-            with horizontal(
-                region[i_start - 1 : i_start + 1, j_start],
-                region[i_start - 1 : i_start + 1, j_end + 1],
-                region[i_end : i_end + 2, j_start],
-                region[i_end : i_end + 2, j_end + 1],
-            ):
-                bl = 0.0
-                br = 0.0
-
         else:
             dm = xppm.dm_iord8plus(u)
             al = xppm.al_iord8plus(u, dm)
 
             external_assert(iord == 8)
-            # {
+
             bl, br = xppm.blbr_iord8(u, al, dm)
-            # }
-            # {
-            with horizontal(region[i_start - 1, :]):
-                bl, br = xppm.west_edge_iord8plus_0(u, dxa, dm)
+            xt_bl, xt_br = xppm.xt_bl_br_edges(u, dxa, al, dm)
 
-            with horizontal(region[i_start, :]):
-                bl, br = xppm.west_edge_iord8plus_1(u, dxa, dm)
-
-            with horizontal(region[i_start + 1, :]):
-                bl, br = xppm.west_edge_iord8plus_2(u, dm, al)
-                bl, br = yppm.pert_ppm_standard_constraint_fcn(u, bl, br)
-
-            with horizontal(region[i_end - 1, :]):
-                bl, br = xppm.east_edge_iord8plus_0(u, dm, al)
-                bl, br = yppm.pert_ppm_standard_constraint_fcn(u, bl, br)
-
-            with horizontal(region[i_end, :]):
-                bl, br = xppm.east_edge_iord8plus_1(u, dxa, dm)
-
-            with horizontal(region[i_end + 1, :]):
-                bl, br = xppm.east_edge_iord8plus_2(u, dxa, dm)
-
-            # Zero corners
             with horizontal(
-                region[i_start - 1 : i_start + 1, j_start],
-                region[i_start - 1 : i_start + 1, j_end + 1],
-                region[i_end : i_end + 2, j_start],
-                region[i_end : i_end + 2, j_end + 1],
+                region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]
             ):
-                bl = 0.0
-                br = 0.0
-            # }
+                bl = xt_bl - u
+                br = xt_br - u
+
+        # Zero corners
+        with horizontal(
+            region[i_start - 1 : i_start + 1, j_start],
+            region[i_start - 1 : i_start + 1, j_end + 1],
+            region[i_end : i_end + 2, j_start],
+            region[i_end : i_end + 2, j_end + 1],
+        ):
+            bl = 0.0
+            br = 0.0
+        # }
 
         flux = _get_flux(u, courant, rdx, bl, br)
 

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -205,9 +205,6 @@ def north_edge_jord8plus_2(q: FloatField, dya: FloatFieldIJ, dm: FloatField):
 def pert_ppm_positive_definite_constraint_fcn(
     a0: FloatField, al: FloatField, ar: FloatField
 ):
-    da1 = 0.0
-    a4 = 0.0
-    fmin = 0.0
     if a0 <= 0.0:
         al = 0.0
         ar = 0.0
@@ -238,9 +235,6 @@ def pert_ppm_positive_definite_constraint(
 
 @gtscript.function
 def pert_ppm_standard_constraint_fcn(a0: FloatField, al: FloatField, ar: FloatField):
-    da1 = 0.0
-    da2 = 0.0
-    a6da = 0.0
     if al * ar < 0.0:
         da1 = al - ar
         da2 = da1 ** 2

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -152,56 +152,6 @@ def xt_dya_edge_1(q, dya):
 
 
 @gtscript.function
-def south_edge_jord8plus_0(q: FloatField, dya: FloatFieldIJ, dm: FloatField):
-    bl = s14 * dm[0, -1, 0] + s11 * (q[0, -1, 0] - q)
-    xt = xt_dya_edge_0(q, dya)
-    br = xt - q
-    return bl, br
-
-
-@gtscript.function
-def south_edge_jord8plus_1(q: FloatField, dya: FloatFieldIJ, dm: FloatField):
-    xt = xt_dya_edge_1(q, dya)
-    bl = xt - q
-    xt = s15 * q + s11 * q[0, 1, 0] - s14 * dm[0, 1, 0]
-    br = xt - q
-    return bl, br
-
-
-@gtscript.function
-def south_edge_jord8plus_2(q: FloatField, dm: FloatField, al: FloatField):
-    xt = s15 * q[0, -1, 0] + s11 * q - s14 * dm
-    bl = xt - q
-    br = al[0, 1, 0] - q
-    return bl, br
-
-
-@gtscript.function
-def north_edge_jord8plus_0(q: FloatField, dm: FloatField, al: FloatField):
-    bl = al - q
-    xt = s15 * q[0, 1, 0] + s11 * q + s14 * dm
-    br = xt - q
-    return bl, br
-
-
-@gtscript.function
-def north_edge_jord8plus_1(q: FloatField, dya: FloatFieldIJ, dm: FloatField):
-    xt = s15 * q + s11 * q[0, -1, 0] + s14 * dm[0, -1, 0]
-    bl = xt - q
-    xt = xt_dya_edge_0(q, dya)
-    br = xt - q
-    return bl, br
-
-
-@gtscript.function
-def north_edge_jord8plus_2(q: FloatField, dya: FloatFieldIJ, dm: FloatField):
-    xt = xt_dya_edge_1(q, dya)
-    bl = xt - q
-    br = s11 * (q[0, 1, 0] - q) - s14 * dm[0, 1, 0]
-    return bl, br
-
-
-@gtscript.function
 def pert_ppm_positive_definite_constraint_fcn(
     a0: FloatField, al: FloatField, ar: FloatField
 ):
@@ -299,9 +249,6 @@ def compute_al(q: FloatField, dya: FloatFieldIJ):
 def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
     from __externals__ import j_end, j_start, jord
 
-    bl = 0.0
-    br = 0.0
-
     dm = dm_jord8plus(q)
     al = al_jord8plus(q, dm)
 
@@ -310,26 +257,34 @@ def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
     bl, br = blbr_jord8(q, al, dm)
 
     with horizontal(region[:, j_start - 1]):
-        bl, br = south_edge_jord8plus_0(q, dya, dm)
+        xt_bl = s14 * dm[0, -1, 0] + s11 * (q[0, -1, 0] - q) + q
+        xt_br = xt_dya_edge_0(q, dya)
 
     with horizontal(region[:, j_start]):
-        bl, br = south_edge_jord8plus_1(q, dya, dm)
+        xt_bl = xt_dya_edge_1(q, dya)
+        xt_br = s15 * q + s11 * q[0, 1, 0] - s14 * dm[0, 1, 0]
 
     with horizontal(region[:, j_start + 1]):
-        bl, br = south_edge_jord8plus_2(q, dm, al)
+        xt_bl = s15 * q[0, -1, 0] + s11 * q - s14 * dm
+        xt_br = al[0, 1, 0]
 
     with horizontal(region[:, j_end - 1]):
-        bl, br = north_edge_jord8plus_0(q, dm, al)
+        xt_bl = al
+        xt_br = s15 * q[0, 1, 0] + s11 * q + s14 * dm
 
     with horizontal(region[:, j_end]):
-        bl, br = north_edge_jord8plus_1(q, dya, dm)
+        xt_bl = s15 * q + s11 * q[0, -1, 0] + s14 * dm[0, -1, 0]
+        xt_br = xt_dya_edge_0(q, dya)
 
     with horizontal(region[:, j_end + 1]):
-        bl, br = north_edge_jord8plus_2(q, dya, dm)
+        xt_bl = xt_dya_edge_1(q, dya)
+        xt_br = s11 * (q[0, 1, 0] - q) - s14 * dm[0, 1, 0] + q
 
     with horizontal(
         region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]
     ):
+        bl = xt_bl - q
+        br = xt_br - q
         bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     return bl, br

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -246,7 +246,7 @@ def compute_al(q: FloatField, dya: FloatFieldIJ):
 
 
 @gtscript.function
-def xt_bl_br_edges(q, dya, al, dm):
+def bl_br_edges(bl, br, q, dya, al, dm):
     from __externals__ import j_end, j_start
 
     with horizontal(region[:, j_start - 1]):
@@ -273,12 +273,21 @@ def xt_bl_br_edges(q, dya, al, dm):
         xt_bl = xt_dya_edge_1(q, dya)
         xt_br = s11 * (q[0, 1, 0] - q) - s14 * dm[0, 1, 0] + q
 
-    return xt_bl, xt_br
+    with horizontal(
+        region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]
+    ):
+        bl = xt_bl - q
+        br = xt_br - q
+
+    return bl, br
 
 
 @gtscript.function
 def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
     from __externals__ import j_end, j_start, jord
+
+    bl = 0.0
+    br = 0.0
 
     dm = dm_jord8plus(q)
     al = al_jord8plus(q, dm)
@@ -286,13 +295,11 @@ def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
     external_assert(jord == 8)
 
     bl, br = blbr_jord8(q, al, dm)
-    xt_bl, xt_br = xt_bl_br_edges(q, dya, al, dm)
+    bl, br = bl_br_edges(bl, br, q, dya, al, dm)
 
     with horizontal(
         region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]
     ):
-        bl = xt_bl - q
-        br = xt_br - q
         bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     return bl, br

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -317,26 +317,25 @@ def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
 
     with horizontal(region[:, j_start - 1]):
         bl, br = south_edge_jord8plus_0(q, dya, dm)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_start]):
         bl, br = south_edge_jord8plus_1(q, dya, dm)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_start + 1]):
         bl, br = south_edge_jord8plus_2(q, dm, al)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_end - 1]):
         bl, br = north_edge_jord8plus_0(q, dm, al)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_end]):
         bl, br = north_edge_jord8plus_1(q, dya, dm)
-        bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     with horizontal(region[:, j_end + 1]):
         bl, br = north_edge_jord8plus_2(q, dya, dm)
+
+    with horizontal(
+        region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]
+    ):
         bl, br = pert_ppm_standard_constraint_fcn(q, bl, br)
 
     return bl, br

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -246,15 +246,8 @@ def compute_al(q: FloatField, dya: FloatFieldIJ):
 
 
 @gtscript.function
-def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
-    from __externals__ import j_end, j_start, jord
-
-    dm = dm_jord8plus(q)
-    al = al_jord8plus(q, dm)
-
-    external_assert(jord == 8)
-
-    bl, br = blbr_jord8(q, al, dm)
+def xt_bl_br_edges(q, dya, al, dm):
+    from __externals__ import j_end, j_start
 
     with horizontal(region[:, j_start - 1]):
         xt_bl = s14 * dm[0, -1, 0] + s11 * (q[0, -1, 0] - q) + q
@@ -279,6 +272,21 @@ def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
     with horizontal(region[:, j_end + 1]):
         xt_bl = xt_dya_edge_1(q, dya)
         xt_br = s11 * (q[0, 1, 0] - q) - s14 * dm[0, 1, 0] + q
+
+    return xt_bl, xt_br
+
+
+@gtscript.function
+def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
+    from __externals__ import j_end, j_start, jord
+
+    dm = dm_jord8plus(q)
+    al = al_jord8plus(q, dm)
+
+    external_assert(jord == 8)
+
+    bl, br = blbr_jord8(q, al, dm)
+    xt_bl, xt_br = xt_bl_br_edges(q, dya, al, dm)
 
     with horizontal(
         region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -86,25 +86,15 @@ def _compute_stencil(
             bl, br = yppm.blbr_jord8(v, al, dm)
             # }
             # {
-            with horizontal(region[:, j_start - 1]):
-                bl, br = yppm.south_edge_jord8plus_0(v, dy, dm)
+            xt_bl, xt_br = yppm.xt_bl_br_edges(v, dya, al, dm)
 
-            with horizontal(region[:, j_start]):
-                bl, br = yppm.south_edge_jord8plus_1(v, dy, dm)
-
-            with horizontal(region[:, j_start + 1]):
-                bl, br = yppm.south_edge_jord8plus_2(v, dm, al)
+            with horizontal(
+                region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]
+            ):
+                bl = xt_bl - v
+                br = xt_br - v
+            with horizontal(region[:, j_start + 1], region[:, j_end - 1]):
                 bl, br = yppm.pert_ppm_standard_constraint_fcn(v, bl, br)
-
-            with horizontal(region[:, j_end - 1]):
-                bl, br = yppm.north_edge_jord8plus_0(v, dm, al)
-                bl, br = yppm.pert_ppm_standard_constraint_fcn(v, bl, br)
-
-            with horizontal(region[:, j_end]):
-                bl, br = yppm.north_edge_jord8plus_1(v, dy, dm)
-
-            with horizontal(region[:, j_end + 1]):
-                bl, br = yppm.north_edge_jord8plus_2(v, dy, dm)
 
             # Zero corners
             with horizontal(

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -74,14 +74,8 @@ def _compute_stencil(
             external_assert(jord == 8)
 
             bl, br = yppm.blbr_jord8(v, al, dm)
+            bl, br = yppm.bl_br_edges(bl, br, v, dya, al, dm)
 
-            xt_bl, xt_br = yppm.xt_bl_br_edges(v, dya, al, dm)
-
-            with horizontal(
-                region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]
-            ):
-                bl = xt_bl - v
-                br = xt_br - v
             with horizontal(region[:, j_start + 1], region[:, j_end - 1]):
                 bl, br = yppm.pert_ppm_standard_constraint_fcn(v, bl, br)
 

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -67,25 +67,14 @@ def _compute_stencil(
             bl = al[0, 0, 0] - v[0, 0, 0]
             br = al[0, 1, 0] - v[0, 0, 0]
 
-            # Zero corners
-            with horizontal(
-                region[i_start, j_start - 1 : j_start + 1],
-                region[i_start, j_end : j_end + 2],
-                region[i_end + 1, j_start - 1 : j_start + 1],
-                region[i_end + 1, j_end : j_end + 2],
-            ):
-                bl = 0.0
-                br = 0.0
-
         else:
             dm = yppm.dm_jord8plus(v)
             al = yppm.al_jord8plus(v, dm)
 
             external_assert(jord == 8)
-            # {
+
             bl, br = yppm.blbr_jord8(v, al, dm)
-            # }
-            # {
+
             xt_bl, xt_br = yppm.xt_bl_br_edges(v, dya, al, dm)
 
             with horizontal(
@@ -96,16 +85,15 @@ def _compute_stencil(
             with horizontal(region[:, j_start + 1], region[:, j_end - 1]):
                 bl, br = yppm.pert_ppm_standard_constraint_fcn(v, bl, br)
 
-            # Zero corners
-            with horizontal(
-                region[i_start, j_start - 1 : j_start + 1],
-                region[i_start, j_end : j_end + 2],
-                region[i_end + 1, j_start - 1 : j_start + 1],
-                region[i_end + 1, j_end : j_end + 2],
-            ):
-                bl = 0.0
-                br = 0.0
-            # }
+        # Zero corners
+        with horizontal(
+            region[i_start, j_start - 1 : j_start + 1],
+            region[i_start, j_end : j_end + 2],
+            region[i_end + 1, j_start - 1 : j_start + 1],
+            region[i_end + 1, j_end : j_end + 2],
+        ):
+            bl = 0.0
+            br = 0.0
 
         flux = _get_flux(v, courant, rdy, bl, br)
 


### PR DESCRIPTION
## Purpose

This PR further speeds up xppm and yppm, and propagates their optimizations to xtp_u and ytp_v.

## Code changes:

- Optimized code in xppm, yppm, xtp_u, and ytp_v by removing re-use of xt temporary for bl and br, and performing the "subtract q" step of computing bl and br in parallel across edge regions.

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
