### PR TITLE
OOPify sim1_solver used in riem_solver_X

### DIFF
--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -12,10 +12,10 @@ from gt4py.gtscript import (
 )
 
 import fv3core._config as spec
-import fv3core.stencils.sim1_solver as sim1_solver
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
+from fv3core.stencils.sim1_solver import Sim1Solver
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -190,23 +190,16 @@ def compute(
         domain=domain,
     )
 
-    sim1_solver.solve(
+    sim1_solve = utils.cached_stencil_class(Sim1Solver)(
+        spec.namelist,
+        spec.grid,
         grid.is_,
         grid.ie,
         grid.js,
         grid.je,
-        dt,
-        gm,
-        cp3,
-        pe,
-        dm,
-        pm,
-        pem,
-        w,
-        delz,
-        pt,
-        wsd,
+        cache_key="riem_solver3_sim1solver",
     )
+    sim1_solve(dt, gm, cp3, pe, dm, pm, pem, w, delz, pt, wsd)
 
     finalize(
         zs,

--- a/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/stencils/riem_solver_c.py
@@ -3,10 +3,10 @@ import typing
 from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval, log
 
 import fv3core._config as spec
-import fv3core.stencils.sim1_solver as sim1_solver
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
+from fv3core.stencils.sim1_solver import Sim1Solver
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -130,5 +130,16 @@ def compute(
         origin=riemorigin,
         domain=domain,
     )
-    sim1_solver.solve(is1, ie1, js1, je1, dt2, gm, cp3, pe, dm, pm, pem, w, dz, ptc, ws)
+
+    sim1_solve = utils.cached_stencil_class(Sim1Solver)(
+        spec.namelist,
+        spec.grid,
+        is1,
+        ie1,
+        js1,
+        je1,
+        cache_key="riem_solver_c_sim1solver",
+    )
+    sim1_solve(dt2, gm, cp3, pe, dm, pm, pem, w, dz, ptc, ws)
+
     finalize(pe, pem, hs, dz, pef, gz, ptop, origin=riemorigin, domain=domain)


### PR DESCRIPTION
## Purpose

OOPify the sim1_solver
Called within `riem_solver3` and `riem_solver_c`

ToDo: Figure out a better docstring

## Code changes:

Cached stencil trick in caller that are not yet object themselves

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
