### PR TITLE
Riem solver3 is an object

### DIFF
--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -8,7 +8,7 @@ from gt4py.gtscript import (
     interval,
     region,
 )
-
+from fv3core.stencils.riem_solver3 import RiemannSolver3
 import fv3core._config as spec
 import fv3core.stencils.basic_operations as basic
 import fv3core.stencils.c_sw as c_sw
@@ -527,15 +527,14 @@ class AcousticDynamics:
                     state.wsd,
                     dt,
                 )
-
-                riem_solver3.compute(
+                riem_solver3 = utils.cached_stencil_class(RiemannSolver3)(spec.namelist, cache_key="riem_solver3")
+                riem_solver3(
                     remap_step,
                     dt,
-                    akap,
                     state.cappa,
                     state.ptop,
                     self._zs,
-                    state.w,
+                    state.wsd,
                     state.delz,
                     state.q_con,
                     state.delp,
@@ -546,7 +545,7 @@ class AcousticDynamics:
                     state.pk3,
                     state.pk,
                     state.peln,
-                    state.wsd,
+                    state.w,
                 )
 
                 if self.do_halo_exchange:

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -8,7 +8,7 @@ from gt4py.gtscript import (
     interval,
     region,
 )
-from fv3core.stencils.riem_solver3 import RiemannSolver3
+
 import fv3core._config as spec
 import fv3core.stencils.basic_operations as basic
 import fv3core.stencils.c_sw as c_sw
@@ -18,7 +18,6 @@ import fv3core.stencils.nh_p_grad as nh_p_grad
 import fv3core.stencils.pe_halo as pe_halo
 import fv3core.stencils.pk3_halo as pk3_halo
 import fv3core.stencils.ray_fast as ray_fast
-import fv3core.stencils.riem_solver3 as riem_solver3
 import fv3core.stencils.riem_solver_c as riem_solver_c
 import fv3core.stencils.temperature_adjust as temperature_adjust
 import fv3core.stencils.updatedzc as updatedzc
@@ -30,6 +29,7 @@ import fv3gfs.util
 import fv3gfs.util as fv3util
 from fv3core.decorators import StencilWrapper
 from fv3core.stencils.basic_operations import copy_stencil
+from fv3core.stencils.riem_solver3 import RiemannSolver3
 from fv3core.utils.grid import axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
@@ -527,7 +527,9 @@ class AcousticDynamics:
                     state.wsd,
                     dt,
                 )
-                riem_solver3 = utils.cached_stencil_class(RiemannSolver3)(spec.namelist, cache_key="riem_solver3")
+                riem_solver3 = utils.cached_stencil_class(RiemannSolver3)(
+                    spec.namelist, cache_key="riem_solver3"
+                )
                 riem_solver3(
                     remap_step,
                     dt,

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -260,6 +260,7 @@ class AcousticDynamics:
             self._update_height_on_d_grid = updatedzd.UpdateDeltaZOnDGrid(
                 self.grid, self._dp_ref, d_sw.get_column_namelist(), d_sw.k_bounds()
             )
+            self._riem_solver3 = RiemannSolver3(spec.namelist)
 
         self._set_gz = StencilWrapper(
             set_gz,
@@ -527,10 +528,7 @@ class AcousticDynamics:
                     state.wsd,
                     dt,
                 )
-                riem_solver3 = utils.cached_stencil_class(RiemannSolver3)(
-                    spec.namelist, cache_key="riem_solver3"
-                )
-                riem_solver3(
+                self._riem_solver3(
                     remap_step,
                     dt,
                     state.cappa,

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -112,7 +112,7 @@ class RiemannSolver3:
         grid = spec.grid
         self._sim1_solve = Sim1Solver(
             namelist,
-            spec.grid,
+            grid,
             grid.is_,
             grid.ie,
             grid.js,

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -17,9 +17,8 @@ import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.sim1_solver import Sim1Solver
 from fv3core.utils.typing import FloatField, FloatFieldIJ
+from fv3core.decorators import StencilWrapper
 
-
-@gtstencil()
 def precompute(
     delp: FloatField,
     cappa: FloatField,
@@ -32,16 +31,12 @@ def precompute(
     pem: FloatField,
     peln: FloatField,
     pk3: FloatField,
-    peg: FloatField,
-    pelng: FloatField,
     gm: FloatField,
     dz: FloatField,
     pm: FloatField,
     ptop: float,
     peln1: float,
     ptk: float,
-    rgrav: float,
-    akap: float,
 ):
     with computation(PARALLEL), interval(...):
         dm = delp
@@ -58,33 +53,20 @@ def precompute(
             # TODO consolidate with riem_solver_c, same functions, math functions
             pem = pem[0, 0, -1] + dm[0, 0, -1]
             peln = log(pem)
+            # Excluding contribution from condensates
+            # peln used during remap; pk3 used only for p_grad   
             peg = peg[0, 0, -1] + dm[0, 0, -1] * (1.0 - q_con[0, 0, -1])
             pelng = log(peg)
-            pk3 = exp(akap * peln)
+            # interface pk is using constant akap 
+            pk3 = exp(constants.KAPPA * peln)
     with computation(PARALLEL), interval(...):
         gm = 1.0 / (1.0 - cp3)
-        dm = dm * rgrav
+        dm = dm * constants.RGRAV
     with computation(PARALLEL), interval(0, -1):
         pm = (peg[0, 0, 1] - peg) / (pelng[0, 0, 1] - pelng)
         dz = zh[0, 0, 1] - zh
 
 
-@gtstencil()
-def last_call_copy(
-    peln_run: FloatField,
-    peln: FloatField,
-    pk3: FloatField,
-    pk: FloatField,
-    pem: FloatField,
-    pe: FloatField,
-):
-    with computation(PARALLEL), interval(...):
-        peln = peln_run
-        pk = pk3
-        pe = pem
-
-
-@gtstencil()
 def finalize(
     zs: FloatFieldIJ,
     dz: FloatField,
@@ -118,102 +100,119 @@ def finalize(
         with interval(0, -1):
             zh = zh[0, 0, 1] - dz
 
+class RiemannSolver3:
+    """
+    Fortran subroutine Riem_Solver3
+    """
+    def __init__(self, namelist):
+        grid = spec.grid
+        self._sim1_solve = Sim1Solver(namelist,
+                                      spec.grid,
+                                      grid.is_,
+                                      grid.ie,
+                                      grid.js,
+                                      grid.je,
+                                      )
 
-def compute(
-    last_call: bool,
-    dt: float,
-    akap: float,
-    cappa: FloatField,
-    ptop: float,
-    zs: FloatFieldIJ,
-    w: FloatField,
-    delz: FloatField,
-    q_con: FloatField,
-    delp: FloatField,
-    pt: FloatField,
-    zh: FloatField,
-    pe: FloatField,
-    ppe: FloatField,
-    pk3: FloatField,
-    pk: FloatField,
-    peln: FloatField,
-    wsd: FloatFieldIJ,
-):
-    grid = spec.grid
-    rgrav = 1.0 / constants.GRAV
-    km = grid.npz - 1
-    peln1 = math.log(ptop)
-    ptk = math.exp(akap * peln1)
-    shape = w.shape
-    domain = (grid.nic, grid.njc, km + 2)
-    riemorigin = (grid.is_, grid.js, 0)
+        km = grid.npz - 1
+        riemorigin = (grid.is_, grid.js, 0)
+        domain = (grid.nic, grid.njc, km + 2)
+        shape = grid.domain_shape_full(add=(1, 1, 1))
+        self._tmp_dm = utils.make_storage_from_shape(shape, riemorigin)
+        self._tmp_cp3 = utils.make_storage_from_shape(shape, riemorigin)
+        self._tmp_pe_init = utils.make_storage_from_shape(shape, riemorigin)
+        self._tmp_pm = utils.make_storage_from_shape(shape, riemorigin)
+        self._tmp_pem = utils.make_storage_from_shape(shape, riemorigin)
+        self._tmp_peln_run = utils.make_storage_from_shape(shape, riemorigin)
+        self._tmp_gm = utils.make_storage_from_shape(shape, riemorigin)
+        self._precompute_stencil = StencilWrapper(
+            precompute,
+            origin=riemorigin,
+            domain=domain,
+        )
+        self._finalize_stencil = StencilWrapper(
+            finalize,
+	    origin=riemorigin,
+            domain=domain,
+        )
 
-    dm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_dm")
-    cp3 = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem3_cp3")
-    pe_init = utils.make_storage_from_shape(
-        shape, riemorigin, cache_key="riem3_pe_init"
-    )
-    pm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_pm")
-    pem = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_pem")
-    peln_run = utils.make_storage_from_shape(
-        shape, riemorigin, cache_key="riem_solver3_peln_run"
-    )
-    peg = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_peg")
-    pelng = utils.make_storage_from_shape(
-        shape, riemorigin, cache_key="riem_solver3_pelng"
-    )
-    gm = utils.make_storage_from_shape(shape, riemorigin, cache_key="riem_solver3_gm")
+    def __call__(self, 
+        last_call: bool,
+        dt: float,
+        cappa: FloatField,
+        ptop: float,
+        zs: FloatFieldIJ,
+        wsd: FloatField,
+        delz: FloatField,
+        q_con: FloatField,
+        delp: FloatField,
+        pt: FloatField,
+        zh: FloatField,
+        pe: FloatField,
+        ppe: FloatField,
+        pk3: FloatField,
+        pk: FloatField,
+        peln: FloatField,
+        w: FloatFieldIJ,
+    ):
+        """
+        Riemann solver for after D-grid winds advected and model heights updated,                                                                                                                    that accounts for vertically propagating sound waves by solving the nonhydrostatic terms                                                                                                     for vertical velocity (w) and non-hydrostatic pressure perturbation.                                                                                                                 
 
-    precompute(
-        delp,
-        cappa,
-        pe,
-        pe_init,
-        cp3,
-        dm,
-        zh,
-        q_con,
-        pem,
-        peln_run,
-        pk3,
-        peg,
-        pelng,
-        gm,
-        delz,
-        pm,
-        ptop,
-        peln1,
-        ptk,
-        rgrav,
-        akap,
-        origin=riemorigin,
-        domain=domain,
-    )
+        Args:                                                                                                                                                                                           last_call: boolean, is this the last acoustic timestep of an acoustic loop (in)
+           dt: acoustic timestep in seconds (in)
+           cappa: (in)
+           ptop: pressure at top of atmosphere (in)
+           zs: surface geopotential height(in)
+           wsd: vertical velocity of the lowest level (to keep it at the surface) (in)
+           delz: vertical delta of atmospheric layer in meters (in)
+           q_con: total condensate mixing ratio (in)
+           delp: vertical delta in pressure (in)
+           pt: potential temperature (in)
+           zh: geopotential heigh (inout)
+           pe: full hydrostatic pressure(inout),
+           ppe: non-hydrostatic pressure perturbation (inout)
+           pk3: interface pressure raised to power of kappa using constant kappa (inout)
+           pk: interface pressure raised to power of kappa, updated in last acoustic timestep(inout)
+           peln: logarithm of interface pressure(inout)
+           w: vertical velocity (inout)     
 
-    sim1_solve = utils.cached_stencil_class(Sim1Solver)(
-        spec.namelist,
-        spec.grid,
-        grid.is_,
-        grid.ie,
-        grid.js,
-        grid.je,
-        cache_key="riem_solver3_sim1solver",
-    )
-    sim1_solve(dt, gm, cp3, pe, dm, pm, pem, w, delz, pt, wsd)
+        """
 
-    finalize(
-        zs,
-        delz,
-        zh,
-        peln_run,
-        peln,
-        pk3,
-        pk,
-        pem,
-        pe,
-        ppe,
-        pe_init,
-        last_call,
-        origin=riemorigin,
-        domain=domain,
-    )
+        peln1 = math.log(ptop)
+        ptk = math.exp(constants.KAPPA * peln1)
+        self._precompute_stencil(
+            delp,
+            cappa,
+            pe,
+            self._tmp_pe_init,
+            self._tmp_cp3,
+            self._tmp_dm,
+            zh,
+            q_con,
+            self._tmp_pem,
+            self._tmp_peln_run,
+            pk3,
+            self._tmp_gm,
+            delz,
+            self._tmp_pm,
+            ptop,
+            peln1,
+            ptk,
+        )
+
+        self._sim1_solve(dt, self._tmp_gm, self._tmp_cp3, pe, self._tmp_dm, self._tmp_pm, self._tmp_pem, w, delz, pt, wsd)
+
+        self._finalize_stencil(
+            zs,
+            delz,
+            zh,
+            self._tmp_peln_run,
+            peln,
+            pk3,
+            pk,
+            self._tmp_pem,
+            pe,
+            ppe,
+            self._tmp_pe_init,
+            last_call
+        )

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -118,10 +118,8 @@ class RiemannSolver3:
             grid.js,
             grid.je,
         )
-
-        km = grid.npz - 1
-        riemorigin = (grid.is_, grid.js, 0)
-        domain = (grid.nic, grid.njc, km + 2)
+        riemorigin = grid.compute_origin()
+        domain = grid.domain_shape_compute(add=(0, 0, 1))
         shape = grid.domain_shape_full(add=(1, 1, 1))
         self._tmp_dm = utils.make_storage_from_shape(shape, riemorigin)
         self._tmp_cp3 = utils.make_storage_from_shape(shape, riemorigin)

--- a/fv3core/stencils/sim1_solver.py
+++ b/fv3core/stencils/sim1_solver.py
@@ -143,6 +143,24 @@ class Sim1Solver:
         ptr: FloatField,
         wsr: FloatFieldIJ,
     ):
+        """
+        Semi-Implicit Method solver -- solves a vertically tridiagonal
+        system for sound waves to compute nonhydrostatic terms for
+         vertical velocity and pressure perturbations
+        Args:
+          dt: timstep in seconds of solver (in),
+          gm: ?? 1 / (1 - cappa)(in),
+          cp3: cappa (in),
+          pe: full hydrostatic pressure (inout),
+          dm: delta in pressure / g (in),
+          pm: ?? ratio of change in layer pressure without condensates(in),
+          pem: recomputed pressure using ptop and delp(in),
+          w: vertical velocity (inout),
+          dz: vertical delta of atmospheric layer in meters (in),
+          ptr: potential temperature (in),
+          wsr: vertical velocity of the lowest level(in),
+
+        """
         t1g = 2.0 * dt * dt
         rdt = 1.0 / dt
         self._compute_sim1_solve(

--- a/fv3core/stencils/sim1_solver.py
+++ b/fv3core/stencils/sim1_solver.py
@@ -123,9 +123,7 @@ class Sim1Solver:
         self._pfac = namelist.p_fac
         nic = iend - istart + 1
         njc = jend - jstart + 1
-        self._origin = (istart, jstart, 0)
-        self._domain = (nic, njc, grid.npz + 1)
-        self._compute_sim1_solve = StencilWrapper(func=sim1_solver, externals={})
+        self._compute_sim1_solve = StencilWrapper(func=sim1_solver,  origin=(istart, jstart, 0), domain=(nic, njc, grid.npz + 1))
 
     def __call__(
         self,
@@ -158,6 +156,4 @@ class Sim1Solver:
             t1g,
             rdt,
             self._pfac,
-            origin=self._origin,
-            domain=self._domain,
         )

--- a/fv3core/stencils/sim1_solver.py
+++ b/fv3core/stencils/sim1_solver.py
@@ -123,7 +123,11 @@ class Sim1Solver:
         self._pfac = namelist.p_fac
         nic = iend - istart + 1
         njc = jend - jstart + 1
-        self._compute_sim1_solve = StencilWrapper(func=sim1_solver,  origin=(istart, jstart, 0), domain=(nic, njc, grid.npz + 1))
+        self._compute_sim1_solve = StencilWrapper(
+            func=sim1_solver,
+            origin=(istart, jstart, 0),
+            domain=(nic, njc, grid.npz + 1),
+        )
 
     def __call__(
         self,

--- a/fv3core/utils/global_constants.py
+++ b/fv3core/utils/global_constants.py
@@ -6,7 +6,7 @@ RDGAS = 287.05  # Gas constant for dry air [J/kg/deg] # 287.04
 RVGAS = 461.50  # Gas constant for water vapor [J/kg/deg]
 HLV = 2.5e6  # Latent heat of evaporation [J/kg]
 HLF = 3.3358e5  # Latent heat of fusion [J/kg]  # 3.34e5
-
+RGRAV = 1.0 / GRAV
 # CP_AIR: Specific heat capacity of dry air at
 # constant pressure [J/kg/deg] # RDGAS / KAPPA
 CP_AIR = 1004.6

--- a/tests/translate/translate_riem_solver3.py
+++ b/tests/translate/translate_riem_solver3.py
@@ -1,11 +1,11 @@
-import fv3core.stencils.riem_solver3 as riem_solver3
+from fv3core.stencils.riem_solver3 import RiemannSolver3
 from fv3core.testing import TranslateFortranData2Py
-
+import fv3core._config as spec
 
 class TranslateRiem_Solver3(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = riem_solver3.compute
+        self.compute_func = RiemannSolver3(spec.namelist)
         self.in_vars["data_vars"] = {
             "cappa": {},
             "zs": {},
@@ -22,7 +22,7 @@ class TranslateRiem_Solver3(TranslateFortranData2Py):
             "peln": {"istart": grid.is_, "jstart": grid.js, "kaxis": 1},
             "wsd": {"istart": grid.is_, "jstart": grid.js},
         }
-        self.in_vars["parameters"] = ["dt", "akap", "ptop", "last_call"]
+        self.in_vars["parameters"] = ["dt", "ptop", "last_call"]
         self.out_vars = {
             "zh": {"kend": grid.npz},
             "w": {},

--- a/tests/translate/translate_riem_solver3.py
+++ b/tests/translate/translate_riem_solver3.py
@@ -1,6 +1,7 @@
+import fv3core._config as spec
 from fv3core.stencils.riem_solver3 import RiemannSolver3
 from fv3core.testing import TranslateFortranData2Py
-import fv3core._config as spec
+
 
 class TranslateRiem_Solver3(TranslateFortranData2Py):
     def __init__(self, grid):


### PR DESCRIPTION
## Purpose

Use our OOP conventions to make the riemann solver3 a class. 

## Code changes:

- stencils/riem_solver3, the test code that calls it 
- removed temporaries in riem_solver3 that were not needed
- dyn_core uses a cached stencil class initialization to call it
- the sim1_solver class sets the fixed origin in class initialization rather than runtime


## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate

