### PR TITLE
calls to xppm/yppm use fixed origins

### DIFF
--- a/fv3core/stencils/fvtp2d.py
+++ b/fv3core/stencils/fvtp2d.py
@@ -105,10 +105,18 @@ class FiniteVolumeTransport:
             origin=self.grid.compute_origin(),
             domain=self.grid.domain_shape_compute(add=(1, 1, 1)),
         )
-        self.x_piecewise_parabolic_inner = XPiecewiseParabolic(namelist, ord_inner)
-        self.y_piecewise_parabolic_inner = YPiecewiseParabolic(namelist, ord_inner)
-        self.x_piecewise_parabolic_outer = XPiecewiseParabolic(namelist, ord_outer)
-        self.y_piecewise_parabolic_outer = YPiecewiseParabolic(namelist, ord_outer)
+        self.x_piecewise_parabolic_inner = XPiecewiseParabolic(
+            namelist, ord_inner, self.grid.jsd, self.grid.jed
+        )
+        self.y_piecewise_parabolic_inner = YPiecewiseParabolic(
+            namelist, ord_inner, self.grid.isd, self.grid.ied
+        )
+        self.x_piecewise_parabolic_outer = XPiecewiseParabolic(
+            namelist, ord_outer, self.grid.js, self.grid.je
+        )
+        self.y_piecewise_parabolic_outer = YPiecewiseParabolic(
+            namelist, ord_outer, self.grid.is_, self.grid.ie
+        )
 
     def __call__(
         self,
@@ -146,7 +154,7 @@ class FiniteVolumeTransport:
         corners.copy_corners_y_stencil(
             q, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1))
         )
-        self.y_piecewise_parabolic_inner(q, cry, self._tmp_fy2, grid.isd, grid.ied)
+        self.y_piecewise_parabolic_inner(q, cry, self._tmp_fy2)
         self.stencil_q_i(
             q,
             grid.area,
@@ -154,11 +162,11 @@ class FiniteVolumeTransport:
             self._tmp_fy2,
             self._tmp_q_i,
         )
-        self.x_piecewise_parabolic_outer(self._tmp_q_i, crx, fx, grid.js, grid.je)
+        self.x_piecewise_parabolic_outer(self._tmp_q_i, crx, fx)
         corners.copy_corners_x_stencil(
             q, origin=grid.full_origin(), domain=grid.domain_shape_full(add=(0, 0, 1))
         )
-        self.x_piecewise_parabolic_inner(q, crx, self._tmp_fx2, grid.jsd, grid.jed)
+        self.x_piecewise_parabolic_inner(q, crx, self._tmp_fx2)
         self.stencil_q_j(
             q,
             grid.area,
@@ -166,7 +174,7 @@ class FiniteVolumeTransport:
             self._tmp_fx2,
             self._tmp_q_j,
         )
-        self.y_piecewise_parabolic_outer(self._tmp_q_j, cry, fy, grid.is_, grid.ie)
+        self.y_piecewise_parabolic_outer(self._tmp_q_j, cry, fy)
         if mfx is not None and mfy is not None:
             self.stencil_transport_flux(
                 fx,

--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -244,15 +244,12 @@ class XPiecewiseParabolic:
     Fortran name is xppm
     """
 
-    def __init__(self, namelist, iord):
+    def __init__(self, namelist, iord, jfirst, jlast):
         grid = spec.grid
         origin = grid.compute_origin()
         domain = grid.domain_shape_compute(add=(1, 1, 1))
         ax_offsets = axis_offsets(spec.grid, origin, domain)
         assert namelist.grid_type < 3
-        self._npz = grid.npz
-        self._is_ = grid.is_
-        self._nic = grid.nic
         self._dxa = grid.dxa
         self._compute_flux_stencil = StencilWrapper(
             func=compute_x_flux,
@@ -262,11 +259,11 @@ class XPiecewiseParabolic:
                 "xt_minmax": True,
                 **ax_offsets,
             },
+            origin=(grid.is_, jfirst, 0),
+            domain=(grid.nic + 1, jlast - jfirst + 1, grid.npz + 1),
         )
 
-    def __call__(
-        self, q: FloatField, c: FloatField, xflux: FloatField, jfirst: int, jlast: int
-    ):
+    def __call__(self, q: FloatField, c: FloatField, xflux: FloatField):
         """
         Compute x-flux using the PPM method.
 
@@ -278,12 +275,4 @@ class XPiecewiseParabolic:
             jlast: Final index of the J-dir compute domain
         """
 
-        nj = jlast - jfirst + 1
-        self._compute_flux_stencil(
-            q,
-            c,
-            self._dxa,
-            xflux,
-            origin=(self._is_, jfirst, 0),
-            domain=(self._nic + 1, nj, self._npz + 1),
-        )
+        self._compute_flux_stencil(q, c, self._dxa, xflux)

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -343,7 +343,7 @@ class YPiecewiseParabolic:
     Fortran name is yppm
     """
 
-    def __init__(self, namelist, jord):
+    def __init__(self, namelist, jord, ifirst, ilast):
         grid = spec.grid
         origin = grid.compute_origin()
         domain = grid.domain_shape_compute(add=(1, 1, 1))
@@ -354,9 +354,6 @@ class YPiecewiseParabolic:
                 f"Unimplemented hord value, {jord}. "
                 "Currently only support hord={5, 6, 7, 8}"
             )
-        self._npz = grid.npz
-        self._js = grid.js
-        self._njc = grid.njc
         self._dya = grid.dya
         self._compute_flux_stencil = StencilWrapper(
             func=compute_y_flux,
@@ -366,11 +363,11 @@ class YPiecewiseParabolic:
                 "xt_minmax": True,
                 **ax_offsets,
             },
+            origin=(ifirst, grid.js, 0),
+            domain=(ilast - ifirst + 1, grid.njc + 1, grid.npz + 1),
         )
 
-    def __call__(
-        self, q: FloatField, c: FloatField, flux: FloatField, ifirst: int, ilast: int
-    ):
+    def __call__(self, q: FloatField, c: FloatField, flux: FloatField):
         """
         Compute y-flux using the PPM method.
 
@@ -382,12 +379,4 @@ class YPiecewiseParabolic:
             ilast: Final index of the I-dir compute domain
         """
 
-        ni = ilast - ifirst + 1
-        self._compute_flux_stencil(
-            q,
-            c,
-            self._dya,
-            flux,
-            origin=(ifirst, self._js, 0),
-            domain=(ni, self._njc + 1, self._npz + 1),
-        )
+        self._compute_flux_stencil(q, c, self._dya, flux)

--- a/tests/translate/translate_xppm.py
+++ b/tests/translate/translate_xppm.py
@@ -24,8 +24,8 @@ class TranslateXPPM(TranslateFortranData2Py):
     def jvars(self, inputs):
         inputs["jfirst"] += TranslateGrid.fpy_model_index_offset
         inputs["jlast"] += TranslateGrid.fpy_model_index_offset
-        inputs["jfirst"] = int(self.grid.global_to_local_y(inputs["jfirst"]))
-        inputs["jlast"] = int(self.grid.global_to_local_y(inputs["jlast"]))
+        inputs["jfirst"] = self.grid.global_to_local_y(inputs["jfirst"])
+        inputs["jlast"] = self.grid.global_to_local_y(inputs["jlast"])
 
     def process_inputs(self, inputs):
         self.jvars(inputs)

--- a/tests/translate/translate_xppm.py
+++ b/tests/translate/translate_xppm.py
@@ -24,8 +24,8 @@ class TranslateXPPM(TranslateFortranData2Py):
     def jvars(self, inputs):
         inputs["jfirst"] += TranslateGrid.fpy_model_index_offset
         inputs["jlast"] += TranslateGrid.fpy_model_index_offset
-        inputs["jfirst"] = self.grid.global_to_local_y(inputs["jfirst"])
-        inputs["jlast"] = self.grid.global_to_local_y(inputs["jlast"])
+        inputs["jfirst"] = int(self.grid.global_to_local_y(inputs["jfirst"]))
+        inputs["jlast"] = int(self.grid.global_to_local_y(inputs["jlast"]))
 
     def process_inputs(self, inputs):
         self.jvars(inputs)
@@ -34,9 +34,10 @@ class TranslateXPPM(TranslateFortranData2Py):
     def compute(self, inputs):
         self.process_inputs(inputs)
         inputs["xflux"] = utils.make_storage_from_shape(inputs["q"].shape)
-        self.compute_func = xppm.XPiecewiseParabolic(spec.namelist, int(inputs["iord"]))
-        del inputs["iord"]
-        self.compute_func(**inputs)
+        self.compute_func = xppm.XPiecewiseParabolic(
+            spec.namelist, int(inputs["iord"]), inputs["jfirst"], inputs["jlast"]
+        )
+        self.compute_func(inputs["q"], inputs["c"], inputs["xflux"])
         return self.slice_output(inputs)
 
 

--- a/tests/translate/translate_yppm.py
+++ b/tests/translate/translate_yppm.py
@@ -34,9 +34,10 @@ class TranslateYPPM(TranslateFortranData2Py):
 
     def compute(self, inputs):
         self.process_inputs(inputs)
-        self.compute_func = yppm.YPiecewiseParabolic(spec.namelist, int(inputs["jord"]))
-        del inputs["jord"]
-        self.compute_func(**inputs)
+        self.compute_func = yppm.YPiecewiseParabolic(
+            spec.namelist, int(inputs["jord"]), inputs["ifirst"], inputs["ilast"]
+        )
+        self.compute_func(inputs["q"], inputs["c"], inputs["flux"])
         return self.slice_output(inputs)
 
 


### PR DESCRIPTION


## Purpose

To move more python overhead to the initialization of model objects, moving the runtime specification of origin and domain for XPPM and YPPM to the init phase, since the different variations we have line up with the different inner and outer objects we use anyways. 

## Code changes:

- xppm/yppm call methods now only call a fixed origin stencil
- fvtp2d initializes these objects with the origin/domain bounds needed
- translate code is updated 

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
