### PR TITLE
External profiler marking script

### DIFF
--- a/profiler/README.MD
+++ b/profiler/README.MD
@@ -1,0 +1,20 @@
+# External Profiler
+
+Add information for external profilers, by wrapping run into the `external_profiler.py` script.
+
+Usage: `python external_profiler.py <PYTHON SCRIPT>.py <ARGS>`
+
+## NVTX marking
+
+Adds semantic marking using `nvtx` for `nsys` profiler (via `cupy`).
+
+Configuration of the markings are inlined in code under the `functions_desc` list with:
+* `fn`: function name to hook int.
+* `file`: part of the source code file path, enough to form unique id with the `fn`.
+* `name`: display name on the profiler. `str` or `Callable` with `(frame, event, args)->str` signature.
+
+
+## Example usage on DAINT
+
+`example.profiling.standalone.daint.slurm` is an example slurm job file to run the above. To be launched from
+root director `fv3core` with a `sbatch` command.

--- a/profiler/example.profiling.standalone.daint.slurm
+++ b/profiler/example.profiling.standalone.daint.slurm
@@ -1,0 +1,37 @@
+#!/bin/bash
+#SBATCH --constraint=gpu
+#SBATCH --job-name=standalone
+#SBATCH --ntasks=6
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=12
+#SBATCH --output=run.daint.out
+#SBATCH --hint=nomultithread
+#SBATCH --time=00:08:00
+#SBATCH --gres=gpu:1
+#SBATCH --account=s1053
+#SBATCH --partition=debug
+
+########################################################
+
+# source an venv with cupy, mpi4py, fv3core installed
+# load corresponding cuda module to cupy version (10+)
+
+module load nvidia-nsight-systems/2021.1.1.66-6c5c5cb
+
+########################################################
+
+# To be launched from ./fv3core, will copy the results in ./profiling_results
+
+set -x
+export OMP_NUM_THREADS=12
+export CRAY_CUDA_PROXY=0
+export PYTHONOPTIMIZE=TRUE
+export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:$PYTHONPATH
+srun nsys profile --force-overwrite=true \
+  -o ./profiling_results/%h.%q{SLURM_NODEID}.%q{SLURM_PROCID}.qdstrm \
+  --trace=cuda,mpi,nvtx --mpi-impl=mpich \
+  --stats=true \
+  python ./profiler/external_profiler.py \
+  examples/standalone/runfile/dynamics.py /project/s1053/fv3core_serialized_test_data/7.2.5/c128_6ranks_baroclinic/ 2 gtcuda profiling 
+
+########################################################

--- a/profiler/external_profiler.py
+++ b/profiler/external_profiler.py
@@ -28,12 +28,12 @@ def get_static_name(frame, event, args) -> str:
     """Static naming"""
     if (
         frame.f_code.co_name == "__call__"
-        and frame.f_code.co_filename == "fv3core/stencils/dyn_core.py"
+        and "fv3core/stencils/dyn_core.py" in frame.f_code.co_filename
     ):
         return "Acoustic timestep"
     elif (
         frame.f_code.co_name == "compute"
-        and frame.f_code.co_filename == "fv3core/stencils/remapping.py"
+        and "fv3core/stencils/remapping.py" in frame.f_code.co_filename
     ):
         return "Remapping"
 
@@ -59,6 +59,11 @@ functions_desc = [
         "fn": "compute",
         "file": "fv3core/stencils/remapping.py",
         "name_fn": get_static_name,
+    },
+    {
+        "fn": "step_dynamics",
+        "file": "fv3core/stencils/fv_dynamics.py",
+        "name_fn": get_name_from_frame,
     },
     {"fn": "fv_dynamics", "file": None, "name_fn": get_name_from_frame},
 ]

--- a/profiler/external_profiler.py
+++ b/profiler/external_profiler.py
@@ -1,0 +1,90 @@
+"""Adding semantic marking to external profiler
+
+Works with nvtx (via cupy) for now.
+"""
+
+import sys
+
+try:
+    import cupy as cp
+except ModuleNotFoundError:
+    cp = None
+
+try:
+    from mpi4py import MPI
+except ModuleNotFoundError:
+    MPI = None
+
+
+def get_stencil_name(frame, event, args) -> str:
+    """Get the name of the stencil from within a call to StencilWrapper.__call__"""
+    name = getattr(
+        frame.f_locals["self"].func, "__name__", repr(frame.f_locals["self"].func)
+    )
+    return f"{name}.__call__"
+
+
+def get_static_name(frame, event, args) -> str:
+    """Static naming"""
+    if (
+        frame.f_code.co_name == "__call__"
+        and frame.f_code.co_filename == "fv3core/stencils/dyn_core.py"
+    ):
+        return "Acoustic timestep"
+    elif (
+        frame.f_code.co_name == "compute"
+        and frame.f_code.co_filename == "fv3core/stencils/remapping.py"
+    ):
+        return "Remapping"
+
+
+def get_name_from_frame(frame, event, args) -> str:
+    """Static name from frame object"""
+    return frame.f_code.co_name
+
+
+""" List of hook descriptors
+
+Each entry define a unique id (function name + filename[Optional]) and a function
+that gives back a str for the marker.
+"""
+functions_desc = [
+    {"fn": "__call__", "file": "fv3core/decorators.py", "name_fn": get_stencil_name},
+    {
+        "fn": "__call__",
+        "file": "fv3core/stencils/dyn_core.py",
+        "name_fn": get_static_name,
+    },
+    {
+        "fn": "compute",
+        "file": "fv3core/stencils/remapping.py",
+        "name_fn": get_static_name,
+    },
+    {"fn": "fv_dynamics", "file": None, "name_fn": get_name_from_frame},
+]
+
+
+def profile_hook(frame, event, args):
+    """Hook at each function call & exit to record a Mark"""
+    if event == "call":
+        for fn_desc in functions_desc:
+            if frame.f_code.co_name == fn_desc["fn"] and (
+                fn_desc["file"] is None or fn_desc["file"] in frame.f_code.co_filename
+            ):
+                name = fn_desc["name_fn"](frame, event, args)
+                cp.cuda.nvtx.RangePush(name)
+    elif event == "return":
+        for fn_desc in functions_desc:
+            if frame.f_code.co_name == fn_desc["fn"] and (
+                fn_desc["file"] is None or fn_desc["file"] in frame.f_code.co_filename
+            ):
+                cp.cuda.nvtx.RangePop()
+
+
+if __name__ == "__main__":
+    if cp is None:
+        raise RuntimeError("External profiling requires CUPY")
+    sys.setprofile(profile_hook)
+    filename = sys.argv[1]
+    sys.argv = sys.argv[1:]
+    exec(compile(open(filename, "rb").read(), filename, "exec"))


### PR DESCRIPTION
## Purpose

Add marking for external profiler, targeting nvidia `nsys`

## Code changes:

- `profiler/external_profiler.py` as a script to call before the python run to generate the marking during runtime using the `sys.setprofile` hook of Python
- Basic coverage for fv3core marking

## Requirements changes:

N/A

## Infrastructure changes:

N/A

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes

