### PR TITLE
Increase number of timesteps for benchmarking & profiling

### DIFF
--- a/.jenkins/actions/run_standalone.sh
+++ b/.jenkins/actions/run_standalone.sh
@@ -41,7 +41,7 @@ SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 ROOT_DIR="$(dirname "$(dirname "$SCRIPTPATH")")"
 DATA_VERSION=`grep 'FORTRAN_SERIALIZED_DATA_VERSION *=' ${ROOT_DIR}/Makefile | cut -d '=' -f 2`
-TIMESTEPS=6
+TIMESTEPS=60
 RANKS=6
 BENCHMARK_DIR=${ROOT_DIR}/examples/standalone/benchmarks
 DATA_DIR="/project/s1053/fv3core_serialized_test_data/${DATA_VERSION}/${experiment}"


### PR DESCRIPTION
## Purpose

Increase number of timesteps that we run for the benchmarks. This should have no side-effects since it only affects the performance benchmarking and profiling (cache building is not affected). The performance metrics are already pretty stable, so increasing further will mainly show us whether the system is stable and can sustain a significant number of timesteps without a lot of jitter.