### PR TITLE
Add files with few or no mypy errors to checking, fix minor errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,14 +22,8 @@ repos:
         (?x)^(
         fv3core/utils/grid.py |
         fv3core/utils/gt4py_utils.py |
-        fv3core/stencils/fillz.py |
-        fv3core/stencils/moist_cv.py |
-        fv3core/stencils/corners.py |
         fv3core/stencils/rayleigh_super.py |
-        fv3core/stencils/map_single.py |
-        fv3core/stencils/remap_profile.py |
         fv3core/stencils/fv_subgridz.py |
-        fv3core/testing/parallel_translate.py
         )$
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/fv3core/stencils/fillz.py
+++ b/fv3core/stencils/fillz.py
@@ -1,3 +1,4 @@
+import typing
 from typing import Any, Dict
 
 from gt4py.gtscript import FORWARD, PARALLEL, computation, interval
@@ -8,6 +9,7 @@ from fv3core.decorators import StencilWrapper
 from fv3core.utils.typing import FloatField, FloatFieldIJ, IntFieldIJ
 
 
+@typing.no_type_check
 def fix_tracer(
     q: FloatField,
     dp: FloatField,

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -593,9 +593,9 @@ class RemapProfile:
         """
         i_extent: int = i2 - i1 + 1
         j_extent: int = j2 - j1 + 1
-        orig: Tuple[int] = (i1, j1, 0)
-        dom: Tuple[int] = (i_extent, j_extent, self._km)
-        dom_extend: Tuple[int] = (i_extent, j_extent, self._km + 1)
+        origin: Tuple[int, int, int] = (i1, j1, 0)
+        domain: Tuple[int, int, int] = (i_extent, j_extent, self._km)
+        domain_extend: Tuple[int, int, int] = (i_extent, j_extent, self._km + 1)
 
         self._set_values_stencil(
             self._gam,
@@ -607,8 +607,8 @@ class RemapProfile:
             a4_4,
             self._q_bot,
             qs,
-            origin=orig,
-            domain=dom_extend,
+            origin=origin,
+            domain=domain_extend,
         )
 
         if abs(self._kord) <= 16:
@@ -622,8 +622,8 @@ class RemapProfile:
                 self._ext5,
                 self._ext6,
                 self._extm,
-                origin=orig,
-                domain=dom,
+                origin=origin,
+                domain=domain,
             )
 
             self._set_top_stencil(
@@ -632,7 +632,7 @@ class RemapProfile:
                 a4_3,
                 a4_4,
                 self._extm,
-                origin=orig,
+                origin=origin,
                 domain=(i_extent, j_extent, 2),
             )
 

--- a/fv3core/testing/parallel_translate.py
+++ b/fv3core/testing/parallel_translate.py
@@ -1,7 +1,8 @@
 import copy
 from types import SimpleNamespace
-from typing import List
+from typing import Any, Dict, List
 
+import numpy as np
 import pytest
 
 import fv3core
@@ -16,8 +17,8 @@ class ParallelTranslate:
     max_error = TranslateFortranData2Py.max_error
     near_zero = TranslateFortranData2Py.near_zero
     python_regression = False
-    inputs = {}
-    outputs = {}
+    inputs: Dict[str, Any] = {}
+    outputs: Dict[str, Any] = {}
 
     def __init__(self, rank_grids):
         if not hasattr(rank_grids, "__getitem__"):
@@ -35,7 +36,7 @@ class ParallelTranslate:
         self._rank_grids = rank_grids
         self.ignore_near_zero_errors = {}
 
-    def state_list_from_inputs_list(self, inputs_list: List[list]) -> list:
+    def state_list_from_inputs_list(self, inputs_list: List[dict]) -> list:
         state_list = []
         for inputs in inputs_list:
             state_list.append(self.state_from_inputs(inputs))
@@ -76,7 +77,7 @@ class ParallelTranslate:
         return input_data
 
     def outputs_from_state(self, state: dict):
-        return_dict = {}
+        return_dict: Dict[str, np.ndarray] = {}
         if len(self.outputs) == 0:
             return return_dict
         for name, properties in self.outputs.items():


### PR DESCRIPTION
## Purpose

This PR adds more files to mypy validation. Files with very few errors were fixed and added, alongside files with no errors.

The four remaining excluded files are utils/grid.py, utils/gt4py_utils.py, stencils/rayleigh_super.py, and stencils/fv_subgridz.py.

## Code changes:

- Fixed remaining mypy errors in fillz, remap_profile and parallel_translate. Removed these alongside moist_cv, corners, and map_single from mypy ignore list.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
