### PR TITLE
OOPs Tracer Remapping

### DIFF
--- a/fv3core/stencils/map_single.py
+++ b/fv3core/stencils/map_single.py
@@ -126,6 +126,19 @@ class LagrangianContributions:
         q4_4: FloatField,
         dp1: FloatField,
     ):
+        """
+        Distributes a field from the deformed Lagrangian grid onto the remapped
+        Eulerian grid.
+
+        Args:
+            q1 (out): the field on the remapped grid
+            pe1 (in): Lagrangian pressure levels
+            pe2 (in): Eulerian pressure levels
+            q4_1, q4_2, q4_3, a4_4 (in): the interpolation coefficients that specify
+                the cubic subgrid distribution of q on the deformed grid.
+            dp1 (in): the pressure difference between the top and bottom of each
+                Lagrangian level
+        """
         eul_domain = (self.domain[0], self.domain[1], 1)
 
         # A stencil with a loop over k2:
@@ -206,8 +219,8 @@ class MapSingle:
         Args:
             q1 (out): Remapped field on Eulerian grid
             pe1 (in): Lagrangian pressure levels
-            pe2 (out): Eulerian pressure levels
-            qs (out): Field to be remapped on deformed grid
+            pe2 (in): Eulerian pressure levels
+            qs (in): Field to be remapped on deformed grid
             jfirst: Starting index of the J-dir compute domain
             jlast: Final index of the J-dir compute domain
         """

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -27,15 +27,11 @@ class MapNTracer:
             cache_key="mapn_tracer_qs",
         )
 
-        self._map_single = utils.cached_stencil_class(MapSingle)(
-            kord, 0, i1, i2, j1, j2, cache_key=f"mapntracer-single{j2}"
-        )
+        self._map_single = MapSingle(kord, 0, i1, i2, j1, j2)
 
         if spec.namelist.fill:
             self._fill_negative_tracers = True
-            self._fillz = utils.cached_stencil_class(FillNegativeTracerValues)(
-                cache_key="mapntracer-fillz"
-            )
+            self._fillz = FillNegativeTracerValues()
         else:
             self._fill_negative_tracers = False
 
@@ -55,7 +51,7 @@ class MapNTracer:
         Args:
             pe1 (in): Lagrangian pressure levels
             pe2 (out): Eulerian pressure levels
-            dp2 (in)
+            dp2 (in): Difference in pressure between Eulerian levels
             qs (out): Field to be remapped on deformed grid
             jfirst: Starting index of the J-dir compute domain
             jlast: Final index of the J-dir compute domain

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -7,31 +7,68 @@ from fv3core.stencils.map_single import MapSingle
 from fv3core.utils.typing import FloatField
 
 
-def compute(
-    pe1: FloatField,
-    pe2: FloatField,
-    dp2: FloatField,
-    tracers: Dict[str, "FloatField"],
-    nq: int,
-    q_min: float,
-    i1: int,
-    i2: int,
-    j1: int,
-    j2: int,
-    kord: int,
-):
-    qs = utils.make_storage_from_shape(
-        pe1.shape, origin=(0, 0, 0), cache_key="mapn_tracer_qs"
-    )
-    map_single = utils.cached_stencil_class(MapSingle)(
-        kord, 0, i1, i2, j1, j2, cache_key=f"mapntracer-single-j{j2}"
-    )
+class MapNTracer:
+    """
+    Fortran code is mapn_tracer, test class is MapN_Tracer_2d
+    """
 
-    for q in utils.tracer_variables[0:nq]:
-        map_single(tracers[q], pe1, pe2, qs)
-
-    if spec.namelist.fill:
-        fillz = utils.cached_stencil_class(FillNegativeTracerValues)(
-            cache_key="mapntracer-fillz"
+    def __init__(self, kord: int, i1: int, i2: int, j1: int, j2: int):
+        grid = spec.grid
+        self._origin = (i1, j1, 0)
+        self._domain = ()
+        self._nk = grid.npz
+        self._i1 = i1
+        self._i2 = i2
+        self._j1 = j1
+        self._j2 = j2
+        self._qs = utils.make_storage_from_shape(
+            (grid.npx, grid.npy, self._nk + 1),
+            origin=(0, 0, 0),
+            cache_key="mapn_tracer_qs",
         )
-        fillz(dp2, tracers, map_single.i_extent, map_single.j_extent, spec.grid.npz, nq)
+
+        self._map_single = utils.cached_stencil_class(MapSingle)(
+            kord, 0, i1, i2, j1, j2, cache_key=f"mapntracer-single{j2}"
+        )
+
+        if spec.namelist.fill:
+            self._fill_negative_tracers = True
+            self._fillz = utils.cached_stencil_class(FillNegativeTracerValues)(
+                cache_key="mapntracer-fillz"
+            )
+        else:
+            self._fill_negative_tracers = False
+
+    def __call__(
+        self,
+        pe1: FloatField,
+        pe2: FloatField,
+        dp2: FloatField,
+        tracers: Dict[str, "FloatField"],
+        nq: int,
+        q_min: float,
+    ):
+        """
+        Remaps the tracer species onto the Eulerian grid
+        and optionally fills negative values in the tracer fields
+
+        Args:
+            pe1 (in): Lagrangian pressure levels
+            pe2 (out): Eulerian pressure levels
+            dp2 (in)
+            qs (out): Field to be remapped on deformed grid
+            jfirst: Starting index of the J-dir compute domain
+            jlast: Final index of the J-dir compute domain
+        """
+        for q in utils.tracer_variables[0:nq]:
+            self._map_single(tracers[q], pe1, pe2, self._qs)
+
+        if self._fill_negative_tracers is True:
+            self._fillz(
+                dp2,
+                tracers,
+                self._map_single.i_extent,
+                self._map_single.j_extent,
+                self._nk,
+                nq,
+            )

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -303,7 +303,7 @@ def compute(
     )
 
     # TODO if nq > 5:
-    MapN_Tracer = utils.cached_stencil_class(MapNTracer)(
+    mapn_tracer = utils.cached_stencil_class(MapNTracer)(
         abs(spec.namelist.kord_tr),
         grid.is_,
         grid.ie,
@@ -311,7 +311,7 @@ def compute(
         grid.je,
         cache_key="remap1-tracers",
     )
-    MapN_Tracer(pe1, pe2, dp2, tracers, nq, 0.0)
+    mapn_tracer(pe1, pe2, dp2, tracers, nq, 0.0)
     # TODO else if nq > 0:
     # TODO map1_q2, fillz
     kord_wz = spec.namelist.kord_wz

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -3,11 +3,11 @@ from typing import Any, Dict
 from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, log
 
 import fv3core._config as spec
-import fv3core.stencils.mapn_tracer as mapn_tracer
 import fv3core.stencils.moist_cv as moist_cv
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import gtstencil
 from fv3core.stencils.map_single import MapSingle
+from fv3core.stencils.mapn_tracer import MapNTracer
 from fv3core.stencils.moist_cv import moist_pt_func
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
@@ -303,19 +303,15 @@ def compute(
     )
 
     # TODO if nq > 5:
-    mapn_tracer.compute(
-        pe1,
-        pe2,
-        dp2,
-        tracers,
-        nq,
-        0.0,
+    MapN_Tracer = utils.cached_stencil_class(MapNTracer)(
+        abs(spec.namelist.kord_tr),
         grid.is_,
         grid.ie,
         grid.js,
         grid.je,
-        abs(spec.namelist.kord_tr),
+        cache_key="remap1-tracers",
     )
+    MapN_Tracer(pe1, pe2, dp2, tracers, nq, 0.0)
     # TODO else if nq > 0:
     # TODO map1_q2, fillz
     kord_wz = spec.namelist.kord_wz

--- a/tests/translate/translate_cubedtolatlon.py
+++ b/tests/translate/translate_cubedtolatlon.py
@@ -1,7 +1,7 @@
+import fv3core._config as spec
 import fv3gfs.util as fv3util
 from fv3core.stencils.c2l_ord import CubedToLatLon
 from fv3core.testing import ParallelTranslate2Py
-import fv3core._config as spec
 
 
 class TranslateCubedToLatLon(ParallelTranslate2Py):

--- a/tests/translate/translate_mapn_tracer_2d.py
+++ b/tests/translate/translate_mapn_tracer_2d.py
@@ -6,7 +6,6 @@ from fv3core.testing import TranslateFortranData2Py, TranslateGrid, pad_field_in
 class TranslateMapN_Tracer_2d(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = MapN_Tracer.compute
         self.in_vars["data_vars"] = {
             "pe1": {"istart": grid.is_, "iend": grid.ie - 2, "axis": 1},
             "pe2": {"istart": grid.is_, "iend": grid.ie - 2, "axis": 1},
@@ -42,5 +41,12 @@ class TranslateMapN_Tracer_2d(TranslateFortranData2Py):
             pad_field_in_j(inputs["dp2"], self.grid.npy)
         )
         inputs["kord"] = abs(spec.namelist.kord_tr)
+        self.compute_func = MapN_Tracer.MapNTracer(
+            inputs.pop("kord"),
+            inputs.pop("i1"),
+            inputs.pop("i2"),
+            inputs.pop("j1"),
+            inputs.pop("j2"),
+        )
         self.compute_func(**inputs)
         return self.slice_output(inputs)


### PR DESCRIPTION
## Purpose

This PR oopifies mapn_tracer

## Code changes:

- mapn_tracer.py: created MapNTracer class to cache stencils and variables
- map_single.py: expanded docstrings
- remapping_part1.py: changed the call to mapn_tracer to use the new class
- translate_mapn_tracer_2d.py: changed the call to mapn_tracer to use the new class

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
