### PR TITLE
make pfull init time

### DIFF
--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -231,6 +231,7 @@ class AcousticDynamics:
         namelist,
         ak: FloatFieldK,
         bk: FloatFieldK,
+        pfull: FloatFieldK,
         phis: FloatFieldIJ,
     ):
         """
@@ -248,6 +249,7 @@ class AcousticDynamics:
         assert not self.namelist.use_logp, "use_logp=True is not implemented"
         self.grid = spec.grid
         self.do_halo_exchange = global_config.get_do_halo_exchange()
+        self._pfull = pfull
         self._nk_heat_dissipation = get_nk_heat_dissipation(namelist, self.grid)
         self.nonhydrostatic_pressure_gradient = (
             nh_p_grad.NonHydrostaticPressureGradient()
@@ -346,7 +348,7 @@ class AcousticDynamics:
     def __call__(self, state):
         # u, v, w, delz, delp, pt, pe, pk, phis, wsd, omga, ua, va, uc, vc, mfxd,
         # mfyd, cxd, cyd, pkz, peln, q_con, ak, bk, diss_estd, cappa, mdt, n_split,
-        # akap, ptop, pfull, n_map, comm):
+        # akap, ptop, n_map, comm):
         end_step = state.n_map == self.namelist.k_split
         akap = constants.KAPPA
         dt = state.mdt / self.namelist.n_split
@@ -639,7 +641,7 @@ class AcousticDynamics:
                     state.v,
                     state.w,
                     self._dp_ref,
-                    state.pfull,
+                    self._pfull,
                     dt,
                     state.ptop,
                     state.ks,

--- a/tests/translate/translate_cubedtolatlon.py
+++ b/tests/translate/translate_cubedtolatlon.py
@@ -1,7 +1,7 @@
+import fv3core._config as spec
 import fv3gfs.util as fv3util
 from fv3core.stencils.c2l_ord import CubedToLatLon
 from fv3core.testing import ParallelTranslate2Py
-import fv3core._config as spec
 
 
 class TranslateCubedToLatLon(ParallelTranslate2Py):

--- a/tests/translate/translate_dyncore.py
+++ b/tests/translate/translate_dyncore.py
@@ -117,12 +117,12 @@ class TranslateDynCore(ParallelTranslate2PyState):
         self.max_error = 2e-6
 
     def compute_parallel(self, inputs, communicator):
-
         self._base.compute_func = dyn_core.AcousticDynamics(
             communicator,
             spec.namelist,
             inputs["ak"],
             inputs["bk"],
+            inputs["pfull"],
             inputs["phis"],
         )
         return super().compute_parallel(inputs, communicator)


### PR DESCRIPTION
## Purpose

Remapping computes a k origin of kmp using pfull in the runtime. This could be resolved by pushing the pfull comparison as a runtime if condition inside of stencils, but this will not look great. pfull actually only depends on things known at the init time of the FVDynamics objects that don't change, so it also can be computed in init. Then when we make remapping an object, we can make the computation of kmp also init time, and use FrozenStencil for stencils that use kmp as an origin. 

## Code changes:

- Updated fv_dynamics and dyn_core to use init time pfull. 

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).

