### PR TITLE
fix bug introduced in 54 rank sequential tests

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -267,7 +267,7 @@ def get_non_frozen_stencil(func, externals) -> Callable[..., None]:
         else:
             origin_key = origin
             origin_tuple = origin
-        key: Hashable = (origin_key, domain, stencil_config)
+        key: Hashable = (origin_key, domain, stencil_config, spec.grid.rank)
         if key not in stencil_dict:
             axis_offsets = fv3core.utils.grid.axis_offsets(
                 spec.grid, origin=origin_tuple, domain=domain

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -267,6 +267,9 @@ def get_non_frozen_stencil(func, externals) -> Callable[..., None]:
         else:
             origin_key = origin
             origin_tuple = origin
+        # rank is needed in the key for regression testing
+        # for > 6 ranks, where each rank may or may not be
+        # on a tile edge
         key: Hashable = (origin_key, domain, stencil_config, spec.grid.rank)
         if key not in stencil_dict:
             axis_offsets = fv3core.utils.grid.axis_offsets(

--- a/tests/translate/translate_fillz.py
+++ b/tests/translate/translate_fillz.py
@@ -49,12 +49,12 @@ class TranslateFillz(TranslateFortranData2Py):
         for name, value in tuple(inputs.items()):
             if hasattr(value, "shape") and len(value.shape) > 1 and value.shape[1] == 1:
                 inputs[name] = self.make_storage_data(
-                    pad_field_in_j(value, self.grid.npy)
+                    pad_field_in_j(value, self.grid.njd)
                 )
         for name, value in tuple(inputs["tracers"].items()):
             if hasattr(value, "shape") and len(value.shape) > 1 and value.shape[1] == 1:
                 inputs["tracers"][name] = self.make_storage_data(
-                    pad_field_in_j(value, self.grid.npy)
+                    pad_field_in_j(value, self.grid.njd)
                 )
         self.compute_func(**inputs)
         ds = self.grid.default_domain_dict()

--- a/tests/translate/translate_map_scalar_2d.py
+++ b/tests/translate/translate_map_scalar_2d.py
@@ -29,7 +29,7 @@ class TranslateMapScalar_2d(TranslateFortranData2Py):
         self.is_ = grid.is_
         self.ie = grid.ie
         self.write_vars = ["qs"]
-        self.nj = grid.npy
+        self.nj = grid.njd
         self.nk = grid.npz
 
     def compute(self, inputs):

--- a/tests/translate/translate_mapn_tracer_2d.py
+++ b/tests/translate/translate_mapn_tracer_2d.py
@@ -33,13 +33,13 @@ class TranslateMapN_Tracer_2d(TranslateFortranData2Py):
         inputs["j2"] = inputs["j_2d"]
         del inputs["j_2d"]
         inputs["pe1"] = self.make_storage_data(
-            pad_field_in_j(inputs["pe1"], self.grid.npy)
+            pad_field_in_j(inputs["pe1"], self.grid.njd)
         )
         inputs["pe2"] = self.make_storage_data(
-            pad_field_in_j(inputs["pe2"], self.grid.npy)
+            pad_field_in_j(inputs["pe2"], self.grid.njd)
         )
         inputs["dp2"] = self.make_storage_data(
-            pad_field_in_j(inputs["dp2"], self.grid.npy)
+            pad_field_in_j(inputs["dp2"], self.grid.njd)
         )
         inputs["kord"] = abs(spec.namelist.kord_tr)
         self.compute_func(**inputs)

--- a/tests/translate/translate_moistcvpluspkz_2d.py
+++ b/tests/translate/translate_moistcvpluspkz_2d.py
@@ -60,7 +60,7 @@ class TranslateMoistCVPlusPkz_2d(TranslateFortranData2Py):
         for name, value in inputs.items():
             if hasattr(value, "shape") and len(value.shape) > 1 and value.shape[1] == 1:
                 inputs[name] = self.make_storage_data(
-                    pad_field_in_j(value, self.grid.npy)
+                    pad_field_in_j(value, self.grid.njd)
                 )
         self.compute_func(**inputs)
         j = inputs["j_2d"]

--- a/tests/translate/translate_moistcvpluspt_2d.py
+++ b/tests/translate/translate_moistcvpluspt_2d.py
@@ -54,7 +54,7 @@ class TranslateMoistCVPlusPt_2d(TranslateFortranData2Py):
         for name, value in inputs.items():
             if hasattr(value, "shape") and len(value.shape) > 1 and value.shape[1] == 1:
                 inputs[name] = self.make_storage_data(
-                    pad_field_in_j(value, self.grid.npy)
+                    pad_field_in_j(value, self.grid.njd)
                 )
         self.compute_func(**inputs)
         for var in ["gz", "cvm"]:


### PR DESCRIPTION
## Purpose

Fix the issues caught on the daily cron that caused failures in c54ranks. One issue was using grid.npy, which is tile global, instead of grid.njd, the local array range. The other was caching the non frozen stencils, when running the sequential tests, the cache survives the move to a new rank (used to be cleared, but that was removed in a recent PR). With 54 ranks, this changes the stencil whether or not a cell is on a tile edge. So, added the rank to the hash key as a short-term solution, knowing eventually everything will be a FrozenStencil and we don't need a cache of non-frozen ones. 

## Code changes:

- change occurrences of grid.npy to grid.njd in translate classes j slicing
- update fv3core/decorators to use the rank as part of the non-frzone stencil cache hash



## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
