### PR TITLE
fix performance reporting

### DIFF
--- a/.jenkins/actions/run_standalone.sh
+++ b/.jenkins/actions/run_standalone.sh
@@ -38,8 +38,7 @@ if [ "${SAVE_CACHE}" != "true" -a "${DO_PROFILE}" != "true" ] ; then
     SAVE_TIMINGS="true"
 fi
 # check if we store the results of this run
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [[ "$BRANCH" != "master" ]]; then
+if [[ "$GIT_BRANCH" != "master" ]]; then
   SAVE_ARTIFACTS="false"
 fi
 


### PR DESCRIPTION


## Purpose

A recent commit stopped the copying of performance results to the location picked up by the performance plots. When jenkins runs, even on master, it checks out a commit and thus using git branch to get whether master is the name of the branch or not does work. jenkins provides GIT_BRANCH, which I think we want anyways, because it would prevent saving artifacts if run on master by hand

## Code changes:

- run_standalone jenkins action uses the jenkins GIT_BRANCH variable rather than scraping the branch using git branch
