### PR TITLE
remove tracers from initialization APIs

### DIFF
--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -171,8 +171,6 @@ if __name__ == "__main__":
             state["atmosphere_hybrid_a_coordinate"],
             state["atmosphere_hybrid_b_coordinate"],
             state["surface_geopotential"],
-            state["specific_humidity"].data,
-            state["graupel_mixing_ratio"].data,
         )
 
         # warm-up timestep.

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -256,8 +256,6 @@ class DynamicalCore:
         ak: fv3gfs.util.Quantity,
         bk: fv3gfs.util.Quantity,
         phis: fv3gfs.util.Quantity,
-        qvapor: fv3gfs.util.Quantity,
-        qgraupel: fv3gfs.util.Quantity,
     ):
         """
         Args:
@@ -295,7 +293,7 @@ class DynamicalCore:
         if not (not self.namelist.inline_q and DynamicalCore.NQ != 0):
             raise NotImplementedError("tracer_2d not implemented, turn on z_tracer")
         self._adjust_tracer_mixing_ratio = AdjustNegativeTracerMixingRatio(
-            self.grid, self.namelist, qvapor, qgraupel
+            self.grid, self.namelist
         )
 
     def step_dynamics(
@@ -474,8 +472,6 @@ def fv_dynamics(
         state["atmosphere_hybrid_a_coordinate"],
         state["atmosphere_hybrid_b_coordinate"],
         state["surface_geopotential"],
-        state["specific_humidity"].data,
-        state["graupel_mixing_ratio"].data,
     )
     dycore.step_dynamics(
         state,

--- a/fv3core/stencils/neg_adj3.py
+++ b/fv3core/stencils/neg_adj3.py
@@ -301,11 +301,9 @@ class AdjustNegativeTracerMixingRatio:
         self,
         grid,
         namelist,
-        qvapor,
-        qgraupel,
     ):
 
-        shape_ij = qgraupel.shape[0:2]
+        shape_ij = grid.domain_shape_full(add=(1, 1, 0))[:2]
         self._sum1 = utils.make_storage_from_shape(shape_ij, origin=(0, 0))
         self._sum2 = utils.make_storage_from_shape(shape_ij, origin=(0, 0))
         if namelist.check_negative:

--- a/tests/translate/translate_neg_adj3.py
+++ b/tests/translate/translate_neg_adj3.py
@@ -36,9 +36,7 @@ class TranslateNeg_Adj3(TranslateFortranData2Py):
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
-        compute_fn = AdjustNegativeTracerMixingRatio(
-            self.grid, spec.namelist, inputs["qvapor"], inputs["qgraupel"]
-        )
+        compute_fn = AdjustNegativeTracerMixingRatio(self.grid, spec.namelist)
         compute_fn(
             inputs["qvapor"],
             inputs["qliquid"],


### PR DESCRIPTION
## Purpose

A previous PR #440 added specific humidity and graupel mixing ratios to init routine arguments in order to retrieve the 2D domain shape. This PR removes those from these APIs and uses the grid to retrieve that information instead, since the data in those arrays is not necessary for initialization.

## Code changes:

- removed specific humidity and graupel mixing ratios from initialization APIs

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)