### PR TITLE
remapping_part1 is an object

### DIFF
--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -364,6 +364,7 @@ class DynamicalCore:
                 # pnats = Atm(mytile)%flagstruct%pnats
                 # here we hard-coded it because 8 is the only supported value,
                 # refactor this later!
+
                 # do_omega = self.namelist.hydrostatic and last_step
                 # TODO: Determine a better way to do this, polymorphic fields perhaps?
                 # issue is that set_val in map_single expects a 3D field for the

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -364,8 +364,6 @@ class DynamicalCore:
                 # pnats = Atm(mytile)%flagstruct%pnats
                 # here we hard-coded it because 8 is the only supported value,
                 # refactor this later!
-                kord_tracer = [self.namelist.kord_tr] * DynamicalCore.NQ
-                kord_tracer[6] = 9
                 # do_omega = self.namelist.hydrostatic and last_step
                 # TODO: Determine a better way to do this, polymorphic fields perhaps?
                 # issue is that set_val in map_single expects a 3D field for the
@@ -407,7 +405,6 @@ class DynamicalCore:
                         state.consv_te,
                         state.bdt / state.k_split,
                         state.bdt,
-                        kord_tracer,
                         state.do_adiabatic_init,
                         DynamicalCore.NQ,
                     )

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -22,9 +22,7 @@ class MapNTracer:
         self._j1 = j1
         self._j2 = j2
         self._qs = utils.make_storage_from_shape(
-            (grid.npx, grid.npy, self._nk + 1),
-            origin=(0, 0, 0),
-            cache_key="mapn_tracer_qs",
+            (grid.npx, grid.npy, self._nk + 1), origin=(0, 0, 0)
         )
 
         self._map_single = MapSingle(kord, 0, i1, i2, j1, j2)

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -12,11 +12,13 @@ class MapNTracer:
     Fortran code is mapn_tracer, test class is MapN_Tracer_2d
     """
 
-    def __init__(self, kord: int, i1: int, i2: int, j1: int, j2: int):
+    def __init__(self, kord: int, nq: int, i1: int, i2: int, j1: int, j2: int):
         grid = spec.grid
+        namelist = spec.namelist
         self._origin = (i1, j1, 0)
         self._domain = ()
         self._nk = grid.npz
+        self._nq = nq
         self._i1 = i1
         self._i2 = i2
         self._j1 = j1
@@ -25,9 +27,15 @@ class MapNTracer:
             (grid.npx, grid.npy, self._nk + 1), origin=(0, 0, 0)
         )
 
-        self._map_single = MapSingle(kord, 0, i1, i2, j1, j2)
+        kord_tracer = [kord] * self._nq
+        kord_tracer[5] = 9  # qcld
 
-        if spec.namelist.fill:
+        self._list_of_remap_objects = [
+            MapSingle(kord_tracer[i], 0, i1, i2, j1, j2)
+            for i in range(len(kord_tracer))
+        ]
+
+        if namelist.fill:
             self._fill_negative_tracers = True
             self._fillz = FillNegativeTracerValues()
         else:
@@ -39,7 +47,6 @@ class MapNTracer:
         pe2: FloatField,
         dp2: FloatField,
         tracers: Dict[str, "FloatField"],
-        nq: int,
         q_min: float,
     ):
         """
@@ -54,15 +61,15 @@ class MapNTracer:
             jfirst: Starting index of the J-dir compute domain
             jlast: Final index of the J-dir compute domain
         """
-        for q in utils.tracer_variables[0:nq]:
-            self._map_single(tracers[q], pe1, pe2, self._qs)
+        for i, q in enumerate(utils.tracer_variables[0 : self._nq]):
+            self._list_of_remap_objects[i](tracers[q], pe1, pe2, self._qs)
 
         if self._fill_negative_tracers is True:
             self._fillz(
                 dp2,
                 tracers,
-                self._map_single.i_extent,
-                self._map_single.j_extent,
+                self._list_of_remap_objects[0].i_extent,
+                self._list_of_remap_objects[0].j_extent,
                 self._nk,
-                nq,
+                self._nq,
             )

--- a/fv3core/stencils/remapping.py
+++ b/fv3core/stencils/remapping.py
@@ -1,9 +1,9 @@
-from typing import Dict, List
+from typing import Dict
 
 import fv3core._config as spec
-import fv3core.stencils.remapping_part1 as remap_part1
 import fv3core.stencils.remapping_part2 as remap_part2
 import fv3core.utils.gt4py_utils as utils
+from fv3core.stencils.remapping_part1 import VerticalRemapping1
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
 
@@ -39,7 +39,6 @@ def compute(
     consv_te: float,
     mdt: float,
     bdt: float,
-    kord_tracer: List[int],
     do_adiabatic_init: bool,
     nq: int,
 ):
@@ -55,7 +54,11 @@ def compute(
         pt.shape, grid.compute_origin(), cache_key="remapping_cvm"
     )
 
-    remap_part1.compute(
+    remapping_part_1 = utils.cached_stencil_class(VerticalRemapping1)(
+        cache_key="remapping_part_1"
+    )
+
+    remapping_part_1(
         tracers,
         pt,
         delp,

--- a/fv3core/stencils/remapping.py
+++ b/fv3core/stencils/remapping.py
@@ -47,6 +47,7 @@ def compute(
     coordinate levels.
     """
     grid = spec.grid
+    namelist = spec.namelist
     gz: FloatField = utils.make_storage_from_shape(
         pt.shape, grid.compute_origin(), cache_key="remapping_gz"
     )
@@ -55,7 +56,7 @@ def compute(
     )
 
     remapping_part_1 = utils.cached_stencil_class(VerticalRemapping1)(
-        cache_key="remapping_part_1"
+        namelist, nq, cache_key="remapping_part_1"
     )
 
     remapping_part_1(
@@ -83,9 +84,6 @@ def compute(
         gz,
         cvm,
         ptop,
-        akap,
-        zvir,
-        nq,
     )
     remap_part2.compute(
         tracers["qvapor"],

--- a/fv3core/stencils/remapping_part1.py
+++ b/fv3core/stencils/remapping_part1.py
@@ -1,11 +1,20 @@
 from typing import Any, Dict
 
-from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, log
+from gt4py.gtscript import (
+    __INLINED,
+    BACKWARD,
+    FORWARD,
+    PARALLEL,
+    computation,
+    exp,
+    interval,
+    log,
+)
 
 import fv3core._config as spec
 import fv3core.stencils.moist_cv as moist_cv
 import fv3core.utils.gt4py_utils as utils
-from fv3core.decorators import gtstencil
+from fv3core.decorators import FrozenStencil, gtstencil
 from fv3core.stencils.map_single import MapSingle
 from fv3core.stencils.mapn_tracer import MapNTracer
 from fv3core.stencils.moist_cv import moist_pt_func
@@ -15,7 +24,6 @@ from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 CONSV_MIN = 0.001
 
 
-@gtstencil
 def init_pe(pe: FloatField, pe1: FloatField, pe2: FloatField, ptop: float):
     with computation(PARALLEL):
         with interval(0, 1):
@@ -26,7 +34,6 @@ def init_pe(pe: FloatField, pe1: FloatField, pe2: FloatField, ptop: float):
         pe1 = pe
 
 
-@gtstencil
 def undo_delz_adjust_and_copy_peln(
     delp: FloatField,
     delz: FloatField,
@@ -41,7 +48,6 @@ def undo_delz_adjust_and_copy_peln(
         peln = pn2
 
 
-@gtstencil
 def moist_cv_pt_pressure(
     qvapor: FloatField,
     qliquid: FloatField,
@@ -65,13 +71,12 @@ def moist_cv_pt_pressure(
     pn2: FloatField,
     peln: FloatField,
     r_vir: float,
-    hydrostatic: bool,
 ):
-    from __externals__ import namelist
+    from __externals__ import hydrostatic, kord_tm
 
     # moist_cv.moist_pt
     with computation(PARALLEL), interval(0, -1):
-        if namelist.kord_tm < 0:
+        if __INLINED(kord_tm < 0):
             cvm, gz, q_con, cappa, pt = moist_pt_func(
                 qvapor,
                 qliquid,
@@ -89,7 +94,7 @@ def moist_cv_pt_pressure(
                 r_vir,
             )
         # delz_adjust
-        if not hydrostatic:
+        if __INLINED(not hydrostatic):
             delz = -delz / delp
     # pressure_updates
     with computation(FORWARD):
@@ -109,14 +114,12 @@ def moist_cv_pt_pressure(
         delp = dp2
 
 
-@gtstencil
 def copy_j_adjacent(pe2: FloatField):
     with computation(PARALLEL), interval(...):
         pe2_0 = pe2[0, -1, 0]
         pe2 = pe2_0
 
 
-@gtstencil
 def pn2_pk_delp(
     dp2: FloatField,
     delp: FloatField,
@@ -131,7 +134,6 @@ def pn2_pk_delp(
         pk = exp(akap * pn2)
 
 
-@gtstencil
 def pressures_mapu(
     pe: FloatField,
     pe1: FloatField,
@@ -176,201 +178,211 @@ def pressures_mapv(
             pe3 = ak + bkh * (pe_bottom[-1, 0, 0] + pe_bottom)
 
 
-@gtstencil
 def update_ua(pe2: FloatField, ua: FloatField):
     with computation(PARALLEL), interval(0, -1):
         ua = pe2[0, 0, 1]
 
 
-def compute(
-    tracers: Dict[str, Any],
-    pt: FloatField,
-    delp: FloatField,
-    delz: FloatField,
-    peln: FloatField,
-    u: FloatField,
-    v: FloatField,
-    w: FloatField,
-    ua: FloatField,
-    cappa: FloatField,
-    q_con: FloatField,
-    pkz: FloatField,
-    pk: FloatField,
-    pe: FloatField,
-    hs: FloatFieldIJ,
-    te: FloatField,
-    ps: FloatFieldIJ,
-    wsd: FloatField,
-    omga: FloatField,
-    ak: FloatFieldK,
-    bk: FloatFieldK,
-    gz: FloatField,
-    cvm: FloatField,
-    ptop: float,
-    akap: float,
-    r_vir: float,
-    nq: int,
-):
-    if spec.namelist.kord_tm >= 0:
-        raise Exception("map ppm, untested mode where kord_tm >= 0")
+class VerticalRemapping1:
+    def __init__(self):
+        """
+        Test is Remapping_Part1
+        Fortran code is the first section of lagrangian_to_eulerian in fv_mapz.F90
+        """
+        if spec.namelist.kord_tm >= 0:
+            raise Exception("map ppm, untested mode where kord_tm >= 0")
 
-    hydrostatic = spec.namelist.hydrostatic
-    if hydrostatic:
-        raise Exception("Hydrostatic is not implemented")
+        hydrostatic = spec.namelist.hydrostatic
+        if hydrostatic:
+            raise Exception("Hydrostatic is not implemented")
 
-    grid = spec.grid
-    t_min = 184.0
+        grid = spec.grid
+        shape_kplus = grid.domain_shape_full(add=(0, 0, 1))
+        self._t_min = 184.0
 
-    # do_omega = hydrostatic and last_step # TODO pull into inputs
-    domain_jextra = (grid.nic, grid.njc + 1, grid.npz + 1)
+        # do_omega = hydrostatic and last_step # TODO pull into inputs
+        self._domain_jextra = (grid.nic, grid.njc + 1, grid.npz + 1)
 
-    pe1 = utils.make_storage_from_shape(
-        pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe1"
-    )
+        self._pe1 = utils.make_storage_from_shape(shape_kplus, grid.compute_origin())
 
-    pe2 = utils.make_storage_from_shape(
-        pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe2"
-    )
-    dp2 = utils.make_storage_from_shape(
-        pe.shape, grid.compute_origin(), cache_key="remapping_part1_dp2"
-    )
-    pn2 = utils.make_storage_from_shape(
-        pe.shape, grid.compute_origin(), cache_key="remapping_part1_pn2"
-    )
-    pe0 = utils.make_storage_from_shape(
-        pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe0"
-    )
-    pe3 = utils.make_storage_from_shape(
-        pe.shape, grid.compute_origin(), cache_key="remapping_part1_pe3"
-    )
+        self._pe2 = utils.make_storage_from_shape(shape_kplus, grid.compute_origin())
+        self._dp2 = utils.make_storage_from_shape(shape_kplus, grid.compute_origin())
+        self._pn2 = utils.make_storage_from_shape(shape_kplus, grid.compute_origin())
+        self._pe0 = utils.make_storage_from_shape(shape_kplus, grid.compute_origin())
+        self._pe3 = utils.make_storage_from_shape(shape_kplus, grid.compute_origin())
 
-    init_pe(pe, pe1, pe2, ptop, origin=grid.compute_origin(), domain=domain_jextra)
+        self._init_pe = FrozenStencil(
+            init_pe, origin=grid.compute_origin(), domain=self._domain_jextra
+        )
 
-    moist_cv_pt_pressure(
-        tracers["qvapor"],
-        tracers["qliquid"],
-        tracers["qrain"],
-        tracers["qsnow"],
-        tracers["qice"],
-        tracers["qgraupel"],
-        q_con,
-        gz,
-        cvm,
-        pt,
-        cappa,
-        delp,
-        delz,
-        pe,
-        pe2,
-        ak,
-        bk,
-        dp2,
-        ps,
-        pn2,
-        peln,
-        r_vir,
-        hydrostatic,
-        origin=grid.compute_origin(),
-        domain=grid.domain_shape_compute(add=(0, 0, 1)),
-    )
+        self._moist_cv_pt_pressure = FrozenStencil(
+            moist_cv_pt_pressure,
+            externals={"kord_tm": spec.namelist.kord_tm, "hydrostatic": hydrostatic},
+            origin=grid.compute_origin(),
+            domain=grid.domain_shape_compute(add=(0, 0, 1)),
+        )
 
-    # TODO: Fix silly hack due to pe2 being 2d, so pe[:, je+1, 1:npz] should be
-    # the same as it was for pe[:, je, 1:npz] (unchanged)
-    copy_j_adjacent(
-        pe2, origin=(grid.is_, grid.je + 1, 1), domain=(grid.nic, 1, grid.npz - 1)
-    )
-    pn2_pk_delp(
-        dp2,
-        delp,
-        pe2,
-        pn2,
-        pk,
-        akap,
-        origin=grid.compute_origin(),
-        domain=grid.domain_shape_compute(),
-    )
+        self._copy_j_adjacent = FrozenStencil(
+            copy_j_adjacent,
+            origin=(grid.is_, grid.je + 1, 1),
+            domain=(grid.nic, 1, grid.npz - 1),
+        )
 
-    kord_tm = abs(spec.namelist.kord_tm)
-    map_single = utils.cached_stencil_class(MapSingle)(
-        kord_tm, 1, grid.is_, grid.ie, grid.js, grid.je, cache_key="remap1-single1"
-    )
-    map_single(
-        pt,
-        peln,
-        pn2,
-        gz,
-        qmin=t_min,
-    )
+        self._pn2_pk_delp = FrozenStencil(
+            pn2_pk_delp,
+            origin=grid.compute_origin(),
+            domain=grid.domain_shape_compute(),
+        )
 
-    # TODO if nq > 5:
-    mapn_tracer = utils.cached_stencil_class(MapNTracer)(
-        abs(spec.namelist.kord_tr),
-        grid.is_,
-        grid.ie,
-        grid.js,
-        grid.je,
-        cache_key="remap1-tracers",
-    )
-    mapn_tracer(pe1, pe2, dp2, tracers, nq, 0.0)
-    # TODO else if nq > 0:
-    # TODO map1_q2, fillz
-    kord_wz = spec.namelist.kord_wz
-    map_single = utils.cached_stencil_class(MapSingle)(
-        kord_wz, -2, grid.is_, grid.ie, grid.js, grid.je, cache_key="remap1-single2"
-    )
-    map_single(w, pe1, pe2, wsd)
-    map_single = utils.cached_stencil_class(MapSingle)(
-        kord_wz, 1, grid.is_, grid.ie, grid.js, grid.je, cache_key="remap1-single3"
-    )
-    map_single(delz, pe1, pe2, gz)
+        kord_tm = abs(spec.namelist.kord_tm)
+        self._map_single_pt = MapSingle(kord_tm, 1, grid.is_, grid.ie, grid.js, grid.je)
 
-    undo_delz_adjust_and_copy_peln(
-        delp,
-        delz,
-        peln,
-        pe0,
-        pn2,
-        origin=grid.compute_origin(),
-        domain=(grid.nic, grid.njc, grid.npz + 1),
-    )
-    # if do_omega:  # NOTE untested
-    #    pe3 = copy(omga, origin=(grid.is_, grid.js, 1))
+        self._mapn_tracer = MapNTracer(
+            abs(spec.namelist.kord_tr), grid.is_, grid.ie, grid.js, grid.je
+        )
 
-    moist_cv.compute_pkz(
-        tracers["qvapor"],
-        tracers["qliquid"],
-        tracers["qice"],
-        tracers["qrain"],
-        tracers["qsnow"],
-        tracers["qgraupel"],
-        q_con,
-        gz,
-        cvm,
-        pkz,
-        pt,
-        cappa,
-        delp,
-        delz,
-        r_vir,
-    )
-    # if do_omega:
-    # dp2 update, if larger than pe0 and smaller than one level up, update omega
-    # and exit
+        kord_wz = spec.namelist.kord_wz
+        self._map_single_w = MapSingle(kord_wz, -2, grid.is_, grid.ie, grid.js, grid.je)
+        self._map_single_delz = MapSingle(
+            kord_wz, 1, grid.is_, grid.ie, grid.js, grid.je
+        )
 
-    pressures_mapu(
-        pe, pe1, ak, bk, pe0, pe3, origin=grid.compute_origin(), domain=domain_jextra
-    )
-    kord_mt = spec.namelist.kord_mt
-    map_single = utils.cached_stencil_class(MapSingle)(
-        kord_mt, -1, grid.is_, grid.ie, grid.js, grid.je + 1, cache_key="remap1-single4"
-    )
-    map_single(u, pe0, pe3, gz)
-    domain_iextra = (grid.nic + 1, grid.njc, grid.npz + 1)
-    pressures_mapv(
-        pe, ak, bk, pe0, pe3, origin=grid.compute_origin(), domain=domain_iextra
-    )
-    map_single = utils.cached_stencil_class(MapSingle)(
-        kord_mt, -1, grid.is_, grid.ie + 1, grid.js, grid.je, cache_key="remap1-single5"
-    )
-    map_single(v, pe0, pe3, gz)
-    update_ua(pe2, ua, origin=grid.compute_origin(), domain=domain_jextra)
+        self._undo_delz_adjust_and_copy_peln = FrozenStencil(
+            undo_delz_adjust_and_copy_peln,
+            origin=grid.compute_origin(),
+            domain=(grid.nic, grid.njc, grid.npz + 1),
+        )
+
+        self._pressures_mapu = FrozenStencil(
+            pressures_mapu, origin=grid.compute_origin(), domain=self._domain_jextra
+        )
+
+        kord_mt = spec.namelist.kord_mt
+        self._map_single_u = MapSingle(
+            kord_mt, -1, grid.is_, grid.ie, grid.js, grid.je + 1
+        )
+
+        domain_iextra = (grid.nic + 1, grid.njc, grid.npz + 1)
+        self._pressures_mapv = FrozenStencil(
+            pressures_mapv, origin=grid.compute_origin(), domain=domain_iextra
+        )
+
+        self._map_single_v = MapSingle(
+            kord_mt, -1, grid.is_, grid.ie + 1, grid.js, grid.je
+        )
+
+        self._update_ua = FrozenStencil(
+            update_ua, origin=grid.compute_origin(), domain=self._domain_jextra
+        )
+
+    def __call__(
+        self,
+        tracers: Dict[str, Any],
+        pt: FloatField,
+        delp: FloatField,
+        delz: FloatField,
+        peln: FloatField,
+        u: FloatField,
+        v: FloatField,
+        w: FloatField,
+        ua: FloatField,
+        cappa: FloatField,
+        q_con: FloatField,
+        pkz: FloatField,
+        pk: FloatField,
+        pe: FloatField,
+        hs: FloatFieldIJ,
+        te: FloatField,
+        ps: FloatFieldIJ,
+        wsd: FloatField,
+        omga: FloatField,
+        ak: FloatFieldK,
+        bk: FloatFieldK,
+        gz: FloatField,
+        cvm: FloatField,
+        ptop: float,
+        akap: float,
+        r_vir: float,
+        nq: int,
+    ):
+        # TODO: Many of these could be passed at runtime
+        """
+        Remaps tracers, winds, pt, and delz from the deformed Lagrangian grid
+        to the Eulerian grid.
+        """
+
+        self._init_pe(pe, self._pe1, self._pe2, ptop)
+
+        self._moist_cv_pt_pressure(
+            tracers["qvapor"],
+            tracers["qliquid"],
+            tracers["qrain"],
+            tracers["qsnow"],
+            tracers["qice"],
+            tracers["qgraupel"],
+            q_con,
+            gz,
+            cvm,
+            pt,
+            cappa,
+            delp,
+            delz,
+            pe,
+            self._pe2,
+            ak,
+            bk,
+            self._dp2,
+            ps,
+            self._pn2,
+            peln,
+            r_vir,
+        )
+
+        # TODO: Fix silly hack due to pe2 being 2d, so pe[:, je+1, 1:npz] should be
+        # the same as it was for pe[:, je, 1:npz] (unchanged)
+        self._copy_j_adjacent(self._pe2)
+
+        self._pn2_pk_delp(self._dp2, delp, self._pe2, self._pn2, pk, akap)
+
+        self._map_single_pt(pt, peln, self._pn2, gz, qmin=self._t_min)
+
+        # TODO if nq > 5:
+        self._mapn_tracer(self._pe1, self._pe2, self._dp2, tracers, nq, 0.0)
+        # TODO else if nq > 0:
+        # TODO map1_q2, fillz
+
+        self._map_single_w(w, self._pe1, self._pe2, wsd)
+        self._map_single_delz(delz, self._pe1, self._pe2, gz)
+
+        self._undo_delz_adjust_and_copy_peln(delp, delz, peln, self._pe0, self._pn2)
+        # if do_omega:  # NOTE untested
+        #    pe3 = copy(omga, origin=(grid.is_, grid.js, 1))
+
+        moist_cv.compute_pkz(
+            tracers["qvapor"],
+            tracers["qliquid"],
+            tracers["qice"],
+            tracers["qrain"],
+            tracers["qsnow"],
+            tracers["qgraupel"],
+            q_con,
+            gz,
+            cvm,
+            pkz,
+            pt,
+            cappa,
+            delp,
+            delz,
+            r_vir,
+        )
+        # if do_omega:
+        # dp2 update, if larger than pe0 and smaller than one level up, update omega
+        # and exit
+
+        self._pressures_mapu(pe, self._pe1, ak, bk, self._pe0, self._pe3)
+        self._map_single_u(u, self._pe0, self._pe3, gz)
+
+        self._pressures_mapv(pe, ak, bk, self._pe0, self._pe3)
+        self._map_single_v(v, self._pe0, self._pe3, gz)
+
+        self._update_ua(self._pe2, ua)

--- a/tests/translate/translate_mapn_tracer_2d.py
+++ b/tests/translate/translate_mapn_tracer_2d.py
@@ -43,6 +43,7 @@ class TranslateMapN_Tracer_2d(TranslateFortranData2Py):
         inputs["kord"] = abs(spec.namelist.kord_tr)
         self.compute_func = MapN_Tracer.MapNTracer(
             inputs.pop("kord"),
+            inputs.pop("nq"),
             inputs.pop("i1"),
             inputs.pop("i2"),
             inputs.pop("j1"),

--- a/tests/translate/translate_remapping.py
+++ b/tests/translate/translate_remapping.py
@@ -74,7 +74,6 @@ class TranslateRemapping(TranslateFortranData2Py):
             "consv_te",
             "mdt",
             "bdt",
-            "kord_tracer",
             "do_adiabatic_init",
             "nq",
         ]

--- a/tests/translate/translate_remapping_part1.py
+++ b/tests/translate/translate_remapping_part1.py
@@ -5,7 +5,7 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateRemapping_Part1(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = remap_part1.compute
+        self.compute_func = remap_part1.VerticalRemapping1()
         self.in_vars["data_vars"] = {
             "tracers": {"serialname": "qtracers"},
             "w": {},

--- a/tests/translate/translate_remapping_part1.py
+++ b/tests/translate/translate_remapping_part1.py
@@ -1,3 +1,4 @@
+import fv3core._config as spec
 import fv3core.stencils.remapping_part1 as remap_part1
 from fv3core.testing import TranslateFortranData2Py
 
@@ -5,7 +6,6 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateRemapping_Part1(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = remap_part1.VerticalRemapping1()
         self.in_vars["data_vars"] = {
             "tracers": {"serialname": "qtracers"},
             "w": {},
@@ -92,3 +92,12 @@ class TranslateRemapping_Part1(TranslateFortranData2Py):
         self.max_error = 3e-9
         self.near_zero = 5e-18
         self.ignore_near_zero_errors = {"q_con": True, "qtracers": True}
+
+    def compute(self, inputs):
+        self.setup(inputs)
+        self.compute_func = remap_part1.VerticalRemapping1(
+            spec.namelist, inputs.pop("nq")
+        )
+        del inputs["akap"]
+        del inputs["r_vir"]
+        return self.slice_output(self.compute_from_storage(inputs))


### PR DESCRIPTION
## Purpose

This PR turns remapping_part1 into an object

## Code changes:

- remapping_part1.py: replaced compute function with VerticalRemapping1 class, moved `hydrostatic` handling to init
- remapping.py: removed kord_tracer from arguments as it wasn't used, updated call to remapping_part1
- fv_dynamics.py: removed kord_tracer code as it wasn't used
- mapn_tracer.py: removed cache_key from storage declaration
- translate_remapping_part1.py: changed to handle new object-structure
- translate_remapping.py: changed to handle new call arguments

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
