### PR TITLE
Object Orientation of remapping_part2

### DIFF
--- a/fv3core/stencils/basic_operations.py
+++ b/fv3core/stencils/basic_operations.py
@@ -82,7 +82,6 @@ def adjustmentfactor_stencil(adjustment: FloatFieldIJ, q_out: FloatField):
         q_out[0, 0, 0] = q_out * adjustment
 
 
-#@gtstencil
 def adjust_divide_stencil(adjustment: FloatField, q_out: FloatField):
     with computation(PARALLEL), interval(...):
         q_out[0, 0, 0] = q_out / adjustment

--- a/fv3core/stencils/basic_operations.py
+++ b/fv3core/stencils/basic_operations.py
@@ -82,7 +82,7 @@ def adjustmentfactor_stencil(adjustment: FloatFieldIJ, q_out: FloatField):
         q_out[0, 0, 0] = q_out * adjustment
 
 
-@gtstencil
+#@gtstencil
 def adjust_divide_stencil(adjustment: FloatField, q_out: FloatField):
     with computation(PARALLEL), interval(...):
         q_out[0, 0, 0] = q_out / adjustment

--- a/fv3core/stencils/moist_cv.py
+++ b/fv3core/stencils/moist_cv.py
@@ -177,7 +177,6 @@ def last_pt(
     return (pt + dtmp * pkz) / ((1.0 + zvir * qv) * (1.0 - gz))
 
 
-#@gtstencil
 def moist_pt_last_step(
     qvapor: FloatField,
     qliquid: FloatField,

--- a/fv3core/stencils/moist_cv.py
+++ b/fv3core/stencils/moist_cv.py
@@ -177,7 +177,7 @@ def last_pt(
     return (pt + dtmp * pkz) / ((1.0 + zvir * qv) * (1.0 - gz))
 
 
-@gtstencil
+#@gtstencil
 def moist_pt_last_step(
     qvapor: FloatField,
     qliquid: FloatField,
@@ -343,7 +343,11 @@ def compute_last_step(
     gz: FloatField,
 ):
     grid = spec.grid
-    moist_pt_last_step(
+
+    # Temporary Fix for calling moist_pt_last_step for verification tests
+    last_step = gtstencil(moist_pt_last_step)
+
+    last_step(
         qvapor,
         qliquid,
         qrain,

--- a/fv3core/stencils/remapping.py
+++ b/fv3core/stencils/remapping.py
@@ -55,7 +55,9 @@ def compute(
         pt.shape, grid.compute_origin(), cache_key="remapping_cvm"
     )
 
-    remap_part2_compute = remap_part2.Remapping_Part2()
+    remap_part2_compute = utils.cached_stencil_class(remap_part2.Remapping_Part2)(
+        pfull=pfull, cache_key="remapping_part2"
+    )
 
     remap_part1.compute(
         tracers,

--- a/fv3core/stencils/remapping.py
+++ b/fv3core/stencils/remapping.py
@@ -3,7 +3,7 @@ from typing import Dict
 import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.stencils.remapping_part1 import VerticalRemapping1
-from fv3core.stencils.remapping_part2 import Remapping_Part2
+from fv3core.stencils.remapping_part2 import VerticalRemapping2
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
 
@@ -59,7 +59,7 @@ def compute(
         namelist, nq, cache_key="remapping_part_1"
     )
 
-    remapping_part_2 = utils.cached_stencil_class(Remapping_Part2)(
+    remapping_part_2 = utils.cached_stencil_class(VerticalRemapping2)(
         pfull=pfull, cache_key="remapping_part2"
     )
 

--- a/fv3core/stencils/remapping.py
+++ b/fv3core/stencils/remapping.py
@@ -55,6 +55,8 @@ def compute(
         pt.shape, grid.compute_origin(), cache_key="remapping_cvm"
     )
 
+    remap_part2_compute = remap_part2.Remapping_Part2()
+
     remap_part1.compute(
         tracers,
         pt,
@@ -84,7 +86,7 @@ def compute(
         zvir,
         nq,
     )
-    remap_part2.compute(
+    remap_part2_compute(
         tracers["qvapor"],
         tracers["qliquid"],
         tracers["qice"],

--- a/fv3core/stencils/remapping_part2.py
+++ b/fv3core/stencils/remapping_part2.py
@@ -9,7 +9,6 @@ from fv3core.stencils.saturation_adjustment import SatAdjust3d
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
 
-@gtstencil
 def copy_from_below(a: FloatField, b: FloatField):
     with computation(PARALLEL), interval(1, None):
         b = a[0, 0, -1]

--- a/fv3core/stencils/remapping_part2.py
+++ b/fv3core/stencils/remapping_part2.py
@@ -5,7 +5,7 @@ import fv3core.stencils.basic_operations as basic
 import fv3core.stencils.moist_cv as moist_cv
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
-from fv3core.decorators import gtstencil
+from fv3core.decorators import FrozenStencil, gtstencil
 from fv3core.stencils.saturation_adjustment import SatAdjust3d
 from fv3core.utils.typing import FloatField, FloatFieldIJ, FloatFieldK
 
@@ -27,7 +27,7 @@ def init_phis(hs: FloatField, delz: FloatField, phis: FloatField, te_2d: FloatFi
             phis = phis[0, 0, 1] - constants.GRAV * delz
 
 
-@gtstencil
+#@gtstencil
 def sum_te(te: FloatField, te0_2d: FloatField):
     with computation(FORWARD):
         with interval(0, None):
@@ -149,3 +149,164 @@ def compute(
         basic.adjust_divide_stencil(
             pkz, pt, origin=grid.compute_origin(), domain=grid.domain_shape_compute()
         )
+
+class Remapping_Part2:
+    def __init__(self):
+        self.grid = spec.grid
+        self.namelist = spec.namelist
+        self._saturation_adjustment = utils.cached_stencil_class(SatAdjust3d)(
+            cache_key="satadjust3d"
+        )
+        self._copy_from_below_stencil = FrozenStencil(copy_from_below,
+                                                      origin=self.grid.compute_origin(),
+                                                      domain=self.grid.domain_shape_compute())
+
+        self._moist_cv_last_step_stencil = FrozenStencil(moist_cv.moist_pt_last_step,
+                                                         origin=(self.grid.is_, self.grid.js, 0),
+                                                         domain=(self.grid.nic, self.grid.njc, self.grid.npz + 1))
+
+        self._basic_adjust_divide_stencil = FrozenStencil(basic.adjust_divide_stencil,
+                                                          origin=self.grid.compute_origin(),
+                                                          domain=self.grid.domain_shape_compute())
+
+        self.do_sat_adjust = self.namelist.do_sat_adj
+
+        # TODO : When remapping becomes an object, these stencils can be declared in __init__
+        #        when (I think) pFull can be passed into __init__
+        #self._saturation_adjustment_stencil = FrozenStencil(SatAdjust3d,...)
+        #self._sum_te_stencil = FrozenStencil(sum_te,...)
+
+        # TODO : When state.pt from fv_dynamics can be passed into __init__, these storages can be
+        #        declared in __init__
+        # phis = utils.make_storage_from_shape(
+        #     pt.shape, grid.compute_origin(), cache_key="remapping_part2_phis"
+        # )
+        # te_2d = utils.make_storage_from_shape(
+        #     pt.shape[0:2], grid.compute_origin(), cache_key="remapping_part2_te_2d"
+        # )
+        # zsum1 = utils.make_storage_from_shape(
+        #     pt.shape[0:2], grid.compute_origin(), cache_key="remapping_part2_zsum1"
+        # )
+
+    def __call__(self,
+                 qvapor: FloatField,
+                 qliquid: FloatField,
+                 qice: FloatField,
+                 qrain: FloatField,
+                 qsnow: FloatField,
+                 qgraupel: FloatField,
+                 qcld: FloatField,
+                 pt: FloatField,
+                 delp: FloatField,
+                 delz: FloatField,
+                 peln: FloatField,
+                 u: FloatField,
+                 v: FloatField,
+                 w: FloatField,
+                 ua: FloatField,
+                 cappa: FloatField,
+                 q_con: FloatField,
+                 gz: FloatField,
+                 pkz: FloatField,
+                 pk: FloatField,
+                 pe: FloatField,
+                 hs: FloatFieldIJ,
+                 te0_2d: FloatFieldIJ,
+                 te: FloatField,
+                 cvm: FloatField,
+                 pfull: FloatFieldK,
+                 ptop: float,
+                 akap: float,
+                 r_vir: float,
+                 last_step: bool,
+                 pdt: float,
+                 mdt: float,
+                 consv: float,
+                 do_adiabatic_init: bool,
+    ):
+        saturation_adjustment = utils.cached_stencil_class(SatAdjust3d)(
+            cache_key="satadjust3d"
+        )
+
+
+        self._copy_from_below_stencil(ua, pe)
+        dtmp = 0.0
+        phis = utils.make_storage_from_shape(
+            pt.shape, self.grid.compute_origin(), cache_key="remapping_part2_phis"
+        )
+        te_2d = utils.make_storage_from_shape(
+            pt.shape[0:2], self.grid.compute_origin(), cache_key="remapping_part2_te_2d"
+        )
+        zsum1 = utils.make_storage_from_shape(
+            pt.shape[0:2], self.grid.compute_origin(), cache_key="remapping_part2_zsum1"
+        )
+        if self.do_sat_adjust:
+            fast_mp_consv = not do_adiabatic_init and consv > constants.CONSV_MIN
+            # TODO pfull is a 1d var
+            kmp = self.grid.npz - 1
+            for k in range(pfull.shape[0]):
+                if pfull[k] > 10.0e2:
+                    kmp = k
+                    break
+        if last_step and not do_adiabatic_init:
+            if consv > constants.CONSV_MIN:
+                raise NotImplementedError(
+                    "We do not support consv_te > 0.001 "
+                    "because that would trigger an allReduce"
+                )
+            elif consv < -constants.CONSV_MIN:
+                raise Exception(
+                    "Unimplemented/untested case consv("
+                    + str(consv)
+                    + ")  < -CONSV_MIN("
+                    + str(-constants.CONSV_MIN)
+                    + ")"
+                )
+
+        if self.do_sat_adjust:
+
+            kmp_origin = (self.grid.is_, self.grid.js, kmp)
+            kmp_domain = (self.grid.nic, self.grid.njc, self.grid.npz - kmp)
+            saturation_adjustment(
+                te,
+                qvapor,
+                qliquid,
+                qice,
+                qrain,
+                qsnow,
+                qgraupel,
+                qcld,
+                hs,
+                peln,
+                delp,
+                delz,
+                q_con,
+                pt,
+                pkz,
+                cappa,
+                r_vir,
+                mdt,
+                fast_mp_consv,
+                last_step,
+                akap,
+                kmp,
+            )
+            if fast_mp_consv:
+                sum_te(te, te0_2d, origin=kmp_origin, domain=kmp_domain)
+        if last_step:
+            self._moist_cv_last_step_stencil(
+                qvapor,
+                qliquid,
+                qrain,
+                qsnow,
+                qice,
+                qgraupel,
+                gz,
+                pt,
+                pkz,
+                dtmp,
+                r_vir,
+            )
+        else:
+            self._basic_adjust_divide_stencil(pkz, pt, origin=self.grid.compute_origin(), domain=self.grid.domain_shape_compute()
+            )

--- a/fv3core/stencils/saturation_adjustment.py
+++ b/fv3core/stencils/saturation_adjustment.py
@@ -5,7 +5,7 @@ from gt4py.gtscript import FORWARD, PARALLEL, computation, exp, floor, interval,
 
 import fv3core._config as spec
 import fv3core.utils.global_constants as constants
-from fv3core.decorators import gtstencil
+from fv3core.decorators import FrozenStencil, gtstencil
 from fv3core.stencils.basic_operations import dim
 from fv3core.stencils.moist_cv import compute_pkz_func
 from fv3core.utils.typing import FloatField, FloatFieldIJ
@@ -898,10 +898,11 @@ def satadjust(
 
 
 class SatAdjust3d:
-    def __init__(self):
+    def __init__(self, kmp):
         self.grid = spec.grid
         self.namelist = spec.namelist
-        self._satadjust_stencil = gtstencil(
+
+        self._satadjust_stencil = FrozenStencil(
             func=satadjust,
             externals={
                 "hydrostatic": self.namelist.hydrostatic,
@@ -922,6 +923,8 @@ class SatAdjust3d:
                 "icloud_f": self.namelist.icloud_f,
                 "cld_min": self.namelist.cld_min,
             },
+            origin=(self.grid.is_, self.grid.js, kmp),
+            domain=(self.grid.nic, self.grid.njc, (self.grid.npz - kmp)),
         )
 
     def __call__(
@@ -1012,6 +1015,4 @@ class SatAdjust3d:
             fac_v2l,
             fac_l2v,
             last_step,
-            origin=(self.grid.is_, self.grid.js, kmp),
-            domain=(self.grid.nic, self.grid.njc, (self.grid.npz - kmp)),
         )

--- a/tests/translate/translate_remapping_part2.py
+++ b/tests/translate/translate_remapping_part2.py
@@ -5,7 +5,7 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateRemapping_Part2(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = remap_part2.compute
+        self.compute_func = remap_part2.Remapping_Part2()
         self.in_vars["data_vars"] = {
             "qvapor": {},
             "qliquid": {},

--- a/tests/translate/translate_remapping_part2.py
+++ b/tests/translate/translate_remapping_part2.py
@@ -5,7 +5,6 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateRemapping_Part2(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = remap_part2.Remapping_Part2()
         self.in_vars["data_vars"] = {
             "qvapor": {},
             "qliquid": {},
@@ -100,3 +99,8 @@ class TranslateRemapping_Part2(TranslateFortranData2Py):
             self.out_vars[k] = self.in_vars["data_vars"][k]
         self.max_error = 2e-14
         self.write_vars = ["gz", "cvm"]
+
+    def compute_from_storage(self, inputs):
+        remapping_pt2_obj = remap_part2.Remapping_Part2(inputs["pfull"])
+        remapping_pt2_obj(**inputs)
+        return inputs

--- a/tests/translate/translate_remapping_part2.py
+++ b/tests/translate/translate_remapping_part2.py
@@ -1,4 +1,4 @@
-import fv3core.stencils.remapping_part2 as remap_part2
+from fv3core.stencils.remapping_part2 import VerticalRemapping2
 from fv3core.testing import TranslateFortranData2Py
 
 
@@ -101,6 +101,6 @@ class TranslateRemapping_Part2(TranslateFortranData2Py):
         self.write_vars = ["gz", "cvm"]
 
     def compute_from_storage(self, inputs):
-        remapping_pt2_obj = remap_part2.Remapping_Part2(inputs["pfull"])
+        remapping_pt2_obj = VerticalRemapping2(inputs["pfull"])
         remapping_pt2_obj(**inputs)
         return inputs

--- a/tests/translate/translate_satadjust3d.py
+++ b/tests/translate/translate_satadjust3d.py
@@ -5,7 +5,6 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateSatAdjust3d(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = SatAdjust3d()
         cvar = {"axis": 0, "kstart": 3}
         self.in_vars["data_vars"] = {
             "te": {},
@@ -55,8 +54,8 @@ class TranslateSatAdjust3d(TranslateFortranData2Py):
             "cappa": {},
         }
 
-    def compute(self, inputs):
-        self.make_storage_data_input_vars(inputs)
+    def compute_from_storage(self, inputs):
         inputs["kmp"] -= 1
-        self.compute_func(**inputs)
-        return self.slice_output(inputs)
+        satadjust3d_obj = SatAdjust3d(inputs["kmp"])
+        satadjust3d_obj(**inputs)
+        return inputs


### PR DESCRIPTION
## Purpose

Creating an object for remapping_part2 and adjusting other files as necessary.

## Code changes:

`fv3core/stencils/basic_operations.py` : Removed gtstencil decorator

`fv3core/stencils/moist_cv.py` : Removed gtstencil decorator and adjusted call to `moist_pt_last_step`

`fv3core/stencils/remapping.py` : Changed to use object initialization of remapping_part2

`fv3core/stencils/remapping_part2.py` : Created `__init__` and `__call__` for `Remapping_Part2` object

`tests/translate/translate_remapping_part2.py` : Changed to use object initialization of remapping_part2