### PR TITLE
add an assertion to prevent a stencil from being double decorated

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -123,6 +123,10 @@ class FrozenStencil:
 
         self._argument_names = tuple(inspect.getfullargspec(func).args)
 
+        assert (
+            len(self._argument_names) > 0
+        ), "A stencil with no arguments? You may be double decorating"
+
         self._field_origins: Dict[str, Tuple[int, ...]] = compute_field_origins(
             self.stencil_object.field_info, self.origin
         )


### PR DESCRIPTION
## Purpose

To prevent a likely mistake that only gets caught in the standalone as we refactor. If we accidentally try to decorate a stencil that has already been decorated (e.g. forgot to remove @gtstencil before the definition). This assertion should also just make sense to have, a stencil with no arguments doesn't make any sense. 

## Code changes:

- added an assertion to FrozenStencil

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
