### PR TITLE
FillNegativeTracerValues (Fillz) freezes the stencil at init time

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN chmod +x /entrypoint.sh && \
 ARG ENV_CUDA_PATH=""
 ENV CUDA_PATH=${ENV_CUDA_PATH}
 ENV IN_DOCKER=True
-
+ENTRYPOINT [ "/entrypoint.sh" ]
 
 FROM fv3core AS fv3core_wrapper
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN chmod +x /entrypoint.sh && \
 ARG ENV_CUDA_PATH=""
 ENV CUDA_PATH=${ENV_CUDA_PATH}
 ENV IN_DOCKER=True
-ENTRYPOINT [ "/entrypoint.sh" ]
+
 
 FROM fv3core AS fv3core_wrapper
 

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -70,11 +70,4 @@ class MapNTracer:
             self._list_of_remap_objects[i](tracers[q], pe1, pe2, self._qs)
 
         if self._fill_negative_tracers is True:
-            self._fillz(
-                dp2,
-                tracers
-                # self._list_of_remap_objects[0].i_extent,
-                # self._list_of_remap_objects[0].j_extent,
-                # self._nk,
-                # self._nq,
-            )
+            self._fillz(dp2, tracers)

--- a/fv3core/stencils/mapn_tracer.py
+++ b/fv3core/stencils/mapn_tracer.py
@@ -37,7 +37,12 @@ class MapNTracer:
 
         if namelist.fill:
             self._fill_negative_tracers = True
-            self._fillz = FillNegativeTracerValues()
+            self._fillz = FillNegativeTracerValues(
+                self._list_of_remap_objects[0].i_extent,
+                self._list_of_remap_objects[0].j_extent,
+                self._nk,
+                self._nq,
+            )
         else:
             self._fill_negative_tracers = False
 
@@ -67,9 +72,9 @@ class MapNTracer:
         if self._fill_negative_tracers is True:
             self._fillz(
                 dp2,
-                tracers,
-                self._list_of_remap_objects[0].i_extent,
-                self._list_of_remap_objects[0].j_extent,
-                self._nk,
-                self._nq,
+                tracers
+                # self._list_of_remap_objects[0].i_extent,
+                # self._list_of_remap_objects[0].j_extent,
+                # self._nk,
+                # self._nq,
             )

--- a/tests/translate/translate_fillz.py
+++ b/tests/translate/translate_fillz.py
@@ -8,7 +8,6 @@ from fv3core.testing import TranslateFortranData2Py, pad_field_in_j
 class TranslateFillz(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        self.compute_func = fillz.FillNegativeTracerValues()
         self.in_vars["data_vars"] = {
             "dp2": {"istart": grid.is_, "iend": grid.ie, "axis": 1},
             "q2tracers": {"istart": grid.is_, "iend": grid.ie, "axis": 1},
@@ -56,7 +55,10 @@ class TranslateFillz(TranslateFortranData2Py):
                 inputs["tracers"][name] = self.make_storage_data(
                     pad_field_in_j(value, self.grid.njd)
                 )
-        self.compute_func(**inputs)
+        run_fillz = fillz.FillNegativeTracerValues(
+            inputs.pop("im"), inputs.pop("jm"), inputs.pop("km"), inputs.pop("nq")
+        )
+        run_fillz(**inputs)
         ds = self.grid.default_domain_dict()
         ds.update(self.out_vars["q2tracers"])
         tracers = np.zeros((self.grid.nic, self.grid.npz, len(inputs["tracers"])))


### PR DESCRIPTION
## Purpose

We eventually want all stencils to be compiled and specified in init, and remove gtstencil. This puts the freezing of fix_tracer in init time rather than the first timestep. 

## Code changes:

- stencils/fillz.py and its test and what calls it (mapn_tracer) are updated 


## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
