### PR TITLE
sim1_solver no longer copies wsr up k

### DIFF
--- a/fv3core/stencils/sim1_solver.py
+++ b/fv3core/stencils/sim1_solver.py
@@ -24,14 +24,6 @@ def sim1_solver(
     rdt: float,
     p_fac: float,
 ):
-    # TODO: We only want to bottom level of wsr, so this could be removed once
-    # wsr_top is a 2d field.
-    with computation(FORWARD):
-        with interval(0, 1):
-            wsr_top = wsr
-        with interval(1, None):
-            wsr_top = wsr_top[0, 0, -1]
-
     with computation(PARALLEL), interval(0, -1):
         pe = exp(gm * log(-dm / dz * constants.RDGAS * ptr)) - pm
         w1 = w
@@ -86,9 +78,7 @@ def sim1_solver(
             p1 = t1g * gm / dz * (pem[0, 0, 1] + pp[0, 0, 1])
             gam = aa / bet[0, 0, -1]
             bet = dm - (aa + p1 + aa * gam)
-            w = (
-                dm * w1 + dt * (pp[0, 0, 1] - pp) - p1 * wsr_top - aa * w[0, 0, -1]
-            ) / bet
+            w = (dm * w1 + dt * (pp[0, 0, 1] - pp) - p1 * wsr - aa * w[0, 0, -1]) / bet
     with computation(BACKWARD), interval(0, -2):
         w = w - gam[0, 0, 1] * w[0, 0, 1]
     with computation(FORWARD):

--- a/fv3core/stencils/sim1_solver.py
+++ b/fv3core/stencils/sim1_solver.py
@@ -78,7 +78,9 @@ def sim1_solver(
             p1 = t1g * gm / dz * (pem[0, 0, 1] + pp[0, 0, 1])
             gam = aa / bet[0, 0, -1]
             bet = dm - (aa + p1 + aa * gam)
-            w = (dm * w1 + dt * (pp[0, 0, 1] - pp) - p1 * wsr - aa * w[0, 0, -1]) / bet
+            w = (
+                dm * w1 + dt * (pp[0, 0, 1] - pp) - p1 * wsr[0, 0] - aa * w[0, 0, -1]
+            ) / bet
     with computation(BACKWARD), interval(0, -2):
         w = w - gam[0, 0, 1] * w[0, 0, 1]
     with computation(FORWARD):


### PR DESCRIPTION
## Purpose

Since wsr is a 2d field, it no longer needs to be copied in the vertical to be used. 

## Code changes:

- small change to sim1_solver 

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
