### PR TITLE
Reducing Stencil Count in Remap Profile

### DIFF
--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -538,7 +538,7 @@ class RemapProfile:
         domain: Tuple[int, int, int] = (i_extent, j_extent, km)
         domain_extend: Tuple[int, int, int] = (i_extent, j_extent, km + 1)
 
-        self._set_initial_values_stencil = FrozenStencil(
+        self._set_initial_values = FrozenStencil(
             func=set_initial_vals,
             externals={"iv": iv, "kord": abs(kord)},
             origin=origin,
@@ -582,7 +582,7 @@ class RemapProfile:
             delp: The pressure difference between grid levels
             qmin: The minimum value the field can take in a cell
         """
-        self._set_initial_values_stencil(
+        self._set_initial_values(
             self._gam,
             self._q,
             delp,

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -106,7 +106,7 @@ def remap_constraint(
     return a4_1, a4_2, a4_3, a4_4
 
 
-def set_vals(
+def set_initial_vals(
     gam: FloatField,
     q: FloatField,
     delp: FloatField,
@@ -263,7 +263,7 @@ def apply_constraints_and_set_interpolation_coefficients(
             a4_4 = 3.0 * x0
             ext5 = abs(x0) > x1
             ext6 = abs(a4_4) > x1
-    
+
     # set_interpolation_coefficients
     # set_top_as_iv0
     with computation(PARALLEL):
@@ -528,8 +528,8 @@ class RemapProfile:
         domain: Tuple[int, int, int] = (i_extent, j_extent, km)
         domain_extend: Tuple[int, int, int] = (i_extent, j_extent, km + 1)
 
-        self._set_values_stencil = FrozenStencil(
-            func=set_vals,
+        self._set_initial_values_stencil = FrozenStencil(
+            func=set_initial_vals,
             externals={"iv": iv, "kord": abs(kord)},
             origin=origin,
             domain=domain_extend,
@@ -565,7 +565,7 @@ class RemapProfile:
             delp: The pressure difference between grid levels
             qmin: The minimum value the field can take in a cell
         """
-        self._set_values_stencil(
+        self._set_initial_values_stencil(
             self._gam,
             self._q,
             delp,


### PR DESCRIPTION
## Purpose

This PR merges stencils in remap_profile.py to improve performance and reduce stencil calls

## Code changes:

- remap_profile.py: `apply_constraints`, `set_top`, `set_inner`, and `set_bottom` are now one `set_interpolation_coefficients` stencil. `set_vals` has been renamed `set_initial_vals` for clarity.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
