### PR TITLE
fvsubgridz is 3d and OOPed

### DIFF
--- a/examples/wrapped/runfiles/baroclinic_test.py
+++ b/examples/wrapped/runfiles/baroclinic_test.py
@@ -266,7 +266,7 @@ if __name__ == "__main__":
     v_tendency.metadata.gt4py_backend = fv3core.get_backend()
 
     n_tracers = 6
-
+    fvsubgridz = fv3core.FVSubgridZ(spec.namelist)
     # Step through time
     for i in range(wrapper.get_step_count()):
         print("STEP IS ", i)
@@ -296,7 +296,7 @@ if __name__ == "__main__":
         if spec.namelist.fv_sg_adj > 0:
             state["eastward_wind_tendency_due_to_physics"] = u_tendency
             state["northward_wind_tendency_due_to_physics"] = v_tendency
-            fv3core.fv_subgridz(state, n_tracers, dt_atmos)
+            fvsubgridz(state, dt_atmos)
 
         newstate = {}
         for name, quantity in state.items():

--- a/examples/wrapped/runfiles/fv3core_test.py
+++ b/examples/wrapped/runfiles/fv3core_test.py
@@ -256,7 +256,7 @@ if __name__ == "__main__":
     v_tendency.metadata.gt4py_backend = fv3core.get_backend()
 
     n_tracers = 6
-
+    fvsubgridz = fv3core.FVSubgridZ(spec.namelist)
     # Step through time
     for i in range(wrapper.get_step_count()):
         print("STEP IS ", i)
@@ -285,7 +285,7 @@ if __name__ == "__main__":
         if spec.namelist.fv_sg_adj > 0:
             state["eastward_wind_tendency_due_to_physics"] = u_tendency
             state["northward_wind_tendency_due_to_physics"] = v_tendency
-            fv3core.fv_subgridz(state, n_tracers, dt_atmos)
+            fvsubgridz(state, dt_atmos)
 
         newstate = {}
         for name, quantity in state.items():

--- a/fv3core/__init__.py
+++ b/fv3core/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa: F401
 from .stencils.fv_dynamics import DynamicalCore, fv_dynamics
-from .stencils.fv_subgridz import compute as fv_subgridz
+from .stencils.fv_subgridz import FVSubgridZ
 from .utils.global_config import (
     get_backend,
     get_rebuild,

--- a/fv3core/stencils/c2l_ord.py
+++ b/fv3core/stencils/c2l_ord.py
@@ -9,8 +9,6 @@ from fv3gfs.util import CubedSphereCommunicator
 from fv3gfs.util.quantity import Quantity
 
 
-sd = utils.sd
-
 C1 = 1.125
 C2 = -0.125
 

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -194,15 +194,28 @@ def KH_instability_adjustment_top(ri, ri_ref, delp, h0, q0):
         q0 = q0 + h0[0, 0, 1] / delp
     return q0
 
+
+@gtscript.function
+def KH_instability_adjustment_bottom2(mc, delp, h0, q0):
+    h0 = mc * (q0 - q0[0, 0, -1])
+    q0 = q0 - h0 / delp
+    return q0, h0
+
+@gtscript.function
+def KH_instability_adjustment_top2(delp, h0, q0):
+    return q0 + h0[0, 0, 1] / delp
+
+@gtscript.function
+def KH_instability_adjustment_bottom_te2(mc, delp, h0, q0, hd):
+    h0 = mc * (hd - hd[0, 0, -1])
+    q0 = q0 - h0 / delp
+    return q0, h0
+
 @gtscript.function
 def KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0, q0, hd):
     if ri < ri_ref:
         h0 = mc * (hd - hd[0, 0, -1])
         q0 = q0 - h0 / delp
-    else:
-        h0 = h0
-        q0 = q0
-
     return q0, h0
 
 
@@ -266,7 +279,11 @@ def m_loop(
             q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
             q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
             q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
-            u0, h0_u = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_u, u0)
+            if ri < ri_ref:
+                #h0_u = mc * (u0 - u0[0, 0, -1])
+                #u0 = u0 - h0_u / delp
+                u0, h0_u = KH_instability_adjustment_bottom2(mc, delp, h0_u, u0)
+            #u0, h0_u = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_u, u0)
             v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
             w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
             te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)
@@ -283,7 +300,10 @@ def m_loop(
             q0_cld = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_cld, q0_cld)
             if ri[0, 0, 1] < ri_ref[0, 0, 1]:
                 qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
-            u0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_u, u0)
+            #u0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_u, u0)
+            if ri[0, 0, 1] < ri_ref[0, 0, 1]:
+                u0 = u0 + h0_u[0, 0, 1] / delp
+                u0 = KH_instability_adjustment_top2(delp, h0_u, u0)
             v0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_v, v0)
             w0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_w, w0)
             te = KH_instability_adjustment_top(ri, ri_ref, delp, h0_te, te)
@@ -308,7 +328,10 @@ def m_loop(
             q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
             q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
             q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
-            u0, h0_u = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_u, u0)
+            if ri < ri_ref:
+                #h0_u = mc * (u0 - u0[0, 0, -1])
+                #u0 = u0 - h0_u / delp
+                u0, h0_u = KH_instability_adjustment_bottom2(mc, delp, h0_u, u0)
             v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
             w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
             te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -278,6 +278,9 @@ def m_loop(
             if ri[0, 0, 1] < ri_ref[0, 0, 1]:
                 qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
             u0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_u, u0)
+            v0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_v, v0)
+            w0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_w, w0)
+            te = KH_instability_adjustment_top(ri, ri_ref, delp, h0_te, te)
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,)
             #
             ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -280,33 +280,44 @@ def m_loop(
             q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
             q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
             if ri < ri_ref:
-                #h0_u = mc * (u0 - u0[0, 0, -1])
-                #u0 = u0 - h0_u / delp
-                u0, h0_u = KH_instability_adjustment_bottom2(mc, delp, h0_u, u0)
+                h0_u = mc * (u0 - u0[0, 0, -1])
+                u0 = u0 - h0_u / delp
+                #u0, h0_u = KH_instability_adjustment_bottom2(mc, delp, h0_u, u0)
             #u0, h0_u = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_u, u0)
             v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
             w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
             te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
         with interval(4, -1):
-            q0_vapor  = KH_instability_adjustment_top(ri, ri_ref, delp, h0_vapor,q0_vapor)
-            q0_liquid= KH_instability_adjustment_top(ri, ri_ref,  delp, h0_liquid, q0_liquid)
-            q0_rain = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_rain, q0_rain)
-            q0_ice = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_ice, q0_ice)
-            q0_snow = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_snow, q0_snow)
-            q0_graupel = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_graupel, q0_graupel)
-            q0_o3mr = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_o3mr, q0_o3mr)
-            q0_sgs_tke = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_o3mr, q0_sgs_tke)
-            q0_cld = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_cld, q0_cld)
             if ri[0, 0, 1] < ri_ref[0, 0, 1]:
+                q0_vapor = q0_vapor + h0_vapor[0, 0, 1] / delp
+                q0_liquid = q0_liquid + h0_liquid[0, 0, 1] / delp
+                q0_rain = q0_rain + h0_rain[0, 0, 1] / delp
+                q0_ice = q0_ice + h0_ice[0, 0, 1] / delp
+                q0_snow = q0_snow + h0_snow[0, 0, 1] / delp
+                q0_graupel = q0_graupel + h0_graupel[0, 0, 1] / delp
+                q0_o3mr = q0_o3mr + h0_o3mr[0, 0, 1] / delp
+                q0_sgs_tke = q0_sgs_tke + h0_sgs_tke[0, 0, 1] / delp
+            #q0_vapor  = KH_instability_adjustment_top(ri, ri_ref, delp, h0_vapor,q0_vapor)
+            #q0_liquid= KH_instability_adjustment_top(ri, ri_ref,  delp, h0_liquid, q0_liquid)
+            #q0_rain = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_rain, q0_rain)
+            #q0_ice = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_ice, q0_ice)
+            #q0_snow = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_snow, q0_snow)
+            #q0_graupel = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_graupel, q0_graupel)
+            #q0_o3mr = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_o3mr, q0_o3mr)
+            #q0_sgs_tke = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_sgs_tke, q0_sgs_tke)
+            #q0_cld = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_cld, q0_cld)
+            #if ri[0, 0, 1] < ri_ref[0, 0, 1]:
                 qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
             #u0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_u, u0)
-            if ri[0, 0, 1] < ri_ref[0, 0, 1]:
+            #if ri[0, 0, 1] < ri_ref[0, 0, 1]:
                 u0 = u0 + h0_u[0, 0, 1] / delp
-                u0 = KH_instability_adjustment_top2(delp, h0_u, u0)
-            v0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_v, v0)
-            w0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_w, w0)
-            te = KH_instability_adjustment_top(ri, ri_ref, delp, h0_te, te)
+                v0 = v0 + h0_v[0, 0, 1] / delp
+                w0 = w0 + h0_w[0, 0, 1] / delp
+                te = te + h0_te[0, 0, 1] / delp
+            #v0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_v, v0)
+            #w0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_w, w0)
+            #te = KH_instability_adjustment_top(ri, ri_ref, delp, h0_te, te)
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
             ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)
             # with computation(PARALLEL):
@@ -318,23 +329,44 @@ def m_loop(
             #        ri_ref = ri_ref_copy * 1.5
             #with computation(PARALLEL), interval(1, None):
             mc = compute_mass_flux(ri, ri_ref, delp, mc, ratio)
-        
-            q0_vapor, h0_vapor =KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_vapor, q0_vapor)
-            q0_liquid, h0_liquid = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_liquid, q0_liquid)
-            q0_rain, h0_rain = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_rain, q0_rain)
-            q0_ice, h0_ice = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_ice, q0_ice)
-            q0_snow, h0_snow = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_snow, q0_snow)
-            q0_graupel, h0_graupel = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_graupel, q0_graupel)
-            q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
-            q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
-            q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
             if ri < ri_ref:
-                #h0_u = mc * (u0 - u0[0, 0, -1])
-                #u0 = u0 - h0_u / delp
-                u0, h0_u = KH_instability_adjustment_bottom2(mc, delp, h0_u, u0)
-            v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
-            w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
-            te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)
+                h0_vapor = mc * (q0_vapor - q0_vapor[0, 0, -1])
+                q0_vapor = q0_vapor - h0_vapor / delp
+                h0_liquid = mc * (q0_liquid - q0_liquid[0, 0, -1])
+                q0_liquid = q0_liquid - h0_liquid / delp
+                h0_rain = mc * (q0_rain - q0_rain[0, 0, -1])
+                q0_rain = q0_rain - h0_rain / delp
+                h0_ice = mc * (q0_ice - q0_ice[0, 0, -1])
+                q0_ice = q0_ice - h0_ice / delp
+                h0_snow = mc * (q0_snow - q0_snow[0, 0, -1])
+                q0_snow = q0_snow - h0_snow / delp
+                h0_graupel = mc * (q0_graupel - q0_graupel[0, 0, -1])
+                q0_graupel = q0_graupel - h0_graupel / delp
+                h0_o3mr = mc * (q0_o3mr - q0_o3mr[0, 0, -1])
+                q0_o3mr = q0_o3mr - h0_o3mr / delp
+                h0_sgs_tke = mc * (q0_sgs_tke - q0_sgs_tke[0, 0, -1])
+                q0_sgs_tke = q0_sgs_tke - h0_sgs_tke / delp
+            #q0_vapor, h0_vapor =KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_vapor, q0_vapor)
+            #q0_liquid, h0_liquid = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_liquid, q0_liquid)
+            #q0_rain, h0_rain = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_rain, q0_rain)
+            #q0_ice, h0_ice = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_ice, q0_ice)
+            #q0_snow, h0_snow = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_snow, q0_snow)
+            #q0_graupel, h0_graupel = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_graupel, q0_graupel)
+            #q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
+            #q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
+            #q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
+            #if ri < ri_ref:
+                h0_u = mc * (u0 - u0[0, 0, -1])
+                u0 = u0 - h0_u / delp
+                h0_v = mc * (v0 - v0[0, 0, -1])
+                v0 = v0 - h0_v / delp
+                h0_w = mc * (w0 - w0[0, 0, -1])
+                w0 = w0 - h0_w / delp
+                h0_te = mc * (hd - hd[0, 0, -1])
+                te = te - h0_te / delp
+            #v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
+            #w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
+            #te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)
            
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te, hd)
         #with interval(3, 4)
@@ -708,23 +740,27 @@ def compute(state, nq, dt):
             domain=kbot_domain,
         )
         if n ==	0:
+            i = 10
+            j = 11
             print(t_min)
-            for	z in range(40,50):
+            for	z in range(43,50):
                 print('---')
-                print(z, 'ri',  ri[10, 11,z], ri_ref[10, 11, z])
-                print(z, 't0',  t0[10, 11,z])
-                print(z, 'qv',  q0["qvapor"][10, 11,z])
-                print(z, 'qt',  qcon[10, 11,z])
-                print(z, 'u0',  u0[10, 11,z])
-                print(z, 'v0',  v0[10, 11,z])
-                print(z, 'mc', mc[10,11,z])
-                print(z, 'cv', cvm[10,11,z])
-                print(z, 'cp', cpm[10,11,z])
-                print(z, 'hd', hd[10,11,z])
-                print(z, 'te', te[10,11,z])
-                print(z, 'w0', w0[10,11,z])
+                print(z, 'ri',  ri[i, j,z], ri_ref[i, j, z])
+                print(z, 't0',  t0[i, j,z])
+                print(z, 'qv',  q0["qvapor"][i, j,z])
+                print(z, 'qt',  qcon[i, j,z])
+                print(z, 'u0',  u0[i, j,z])
+                print(z, 'v0',  v0[i, j,z])
+                print(z, 'mc', mc[i, j,z])
+                print(z, 'cv', cvm[i, j,z])
+                print(z, 'cp', cpm[i, j,z])
+                print(z, 'hd', hd[i, j,z])
+                print(z, 'te', te[i, j,z])
+                print(z, 'w0', w0[i, j,z])
+                for k, v in q0.items():
+                    print(z, k, v[i, j,z])
             #for z in range(ri.shape[2]):
-            #    print('pm at ',z,  pm[10, 11,z])
+            #    print('pm at ',z,  pm[i, j,z])
         #if k == 1:
         #    ri_ref *= 4.0
         #if k == 2:

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -238,6 +238,13 @@ def m_loop(
 ):
     with computation(PARALLEL), interval(...):
         h0_vapor = 0.0
+        h0_liquid = 0.0
+        h0_rain = 0.0
+        h0_ice = 0.0
+        h0_snow = 0.0
+        h0_graupel = 0.0
+        h0_o3mr = 0.0
+        h0_cld = 0.0
         h0_u = 0.0
         h0_v = 0.0
         h0_w = 0.0
@@ -247,6 +254,13 @@ def m_loop(
             ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)
             mc = compute_mass_flux(ri, ri_ref, delp, ratio)
             q0_vapor, h0_vapor = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_vapor, q0_vapor)
+            q0_liquid, h0_liquid = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_liquid, q0_liquid)
+            q0_rain, h0_rain = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_rain, q0_rain)
+            q0_ice, h0_ice = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_ice, q0_ice)
+            q0_snow, h0_snow = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_snow, q0_snow)
+            q0_graupel, h0_graupel = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_graupel, q0_graupel)
+            q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
+            q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
             u0, h0_u = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_u, u0)
             v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
             w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
@@ -254,6 +268,13 @@ def m_loop(
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,)
         with interval(4, -1):
             q0_vapor  = KH_instability_adjustment_top(ri, ri_ref, delp, h0_vapor,q0_vapor)
+            q0_liquid= KH_instability_adjustment_top(ri, ri_ref,  delp, h0_liquid, q0_liquid)
+            q0_rain = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_rain, q0_rain)
+            q0_ice = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_ice, q0_ice)
+            q0_snow = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_snow, q0_snow)
+            q0_graupel = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_graupel, q0_graupel)
+            q0_o3mr = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_o3mr, q0_o3mr)
+            q0_cld = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_cld, q0_cld)
             if ri[0, 0, 1] < ri_ref[0, 0, 1]:
                 qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
             u0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_u, u0)

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -270,23 +270,45 @@ def m_loop(
         with interval(-1, None):
             ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)
             mc = compute_mass_flux(ri, ri_ref, delp, mc, ratio)
-            q0_vapor, h0_vapor = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_vapor, q0_vapor)
-            q0_liquid, h0_liquid = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_liquid, q0_liquid)
-            q0_rain, h0_rain = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_rain, q0_rain)
-            q0_ice, h0_ice = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_ice, q0_ice)
-            q0_snow, h0_snow = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_snow, q0_snow)
-            q0_graupel, h0_graupel = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_graupel, q0_graupel)
-            q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
-            q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
-            q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
+            #q0_vapor, h0_vapor = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_vapor, q0_vapor)
+            #q0_liquid, h0_liquid = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_liquid, q0_liquid)
+            #q0_rain, h0_rain = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_rain, q0_rain)
+            #q0_ice, h0_ice = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_ice, q0_ice)
+            #q0_snow, h0_snow = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_snow, q0_snow)
+            #q0_graupel, h0_graupel = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_graupel, q0_graupel)
+            #q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
+            #q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
+            #q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
             if ri < ri_ref:
+                h0_vapor = mc * (q0_vapor - q0_vapor[0, 0, -1])
+                q0_vapor = q0_vapor - h0_vapor / delp
+                h0_liquid = mc * (q0_liquid - q0_liquid[0, 0, -1])
+                q0_liquid = q0_liquid - h0_liquid / delp
+                h0_rain = mc * (q0_rain - q0_rain[0, 0, -1])
+                q0_rain = q0_rain - h0_rain / delp
+                h0_ice = mc * (q0_ice - q0_ice[0, 0, -1])
+                q0_ice = q0_ice - h0_ice / delp
+                h0_snow = mc * (q0_snow - q0_snow[0, 0, -1])
+                q0_snow = q0_snow - h0_snow / delp
+                h0_graupel = mc * (q0_graupel - q0_graupel[0, 0, -1])
+                q0_graupel = q0_graupel - h0_graupel / delp
+                h0_o3mr = mc * (q0_o3mr - q0_o3mr[0, 0, -1])
+                q0_o3mr = q0_o3mr - h0_o3mr / delp
+                h0_sgs_tke = mc * (q0_sgs_tke - q0_sgs_tke[0, 0, -1])
+                q0_sgs_tke = q0_sgs_tke - h0_sgs_tke / delp
                 h0_u = mc * (u0 - u0[0, 0, -1])
                 u0 = u0 - h0_u / delp
+                h0_v = mc * (v0 - v0[0, 0, -1])
+                v0 = v0 - h0_v / delp
+                h0_w = mc * (w0 - w0[0, 0, -1])
+                w0 = w0 - h0_w / delp
+                h0_te = mc * (hd - hd[0, 0, -1])
+                te = te - h0_te / delp
                 #u0, h0_u = KH_instability_adjustment_bottom2(mc, delp, h0_u, u0)
             #u0, h0_u = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_u, u0)
-            v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
-            w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
-            te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)
+            #v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
+            #w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
+            #te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
         with interval(4, -1):
             if ri[0, 0, 1] < ri_ref[0, 0, 1]:
@@ -741,7 +763,7 @@ def compute(state, nq, dt):
         )
         if n ==	0:
             i = 10
-            j = 11
+            j = 12
             print(t_min)
             for	z in range(43,50):
                 print('---')

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -470,7 +470,25 @@ def m_loop(
                 te = adjust_down(delp, h0_te, te)
         
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te, hd)
+        with interval(0, 1):
+            if ri[0, 0, 1] < ri_ref[0, 0, 1]:
+                q0_vapor = adjust_up(delp, h0_vapor, q0_vapor)
+                q0_liquid = adjust_up(delp, h0_liquid, q0_liquid)
+                q0_rain = adjust_up(delp, h0_rain, q0_rain)
+                q0_ice = adjust_up(delp, h0_ice, q0_ice)
+                q0_snow = adjust_up(delp, h0_snow, q0_snow)
+                q0_graupel = adjust_up(delp, h0_graupel, q0_graupel)
+                q0_o3mr = adjust_up(delp, h0_o3mr, q0_o3mr)
+                q0_sgs_tke = adjust_up(delp, h0_sgs_tke, q0_sgs_tke)
+                q0_cld = adjust_up(delp, h0_cld, q0_cld)
+                qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
+                u0 = adjust_up(delp, h0_u, u0)
+                v0 = adjust_up(delp, h0_v, v0)
+                w0 = adjust_up(delp, h0_w, w0)
+                te = adjust_up(delp, h0_te, te)
 
+            cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
+            
 @gtscript.function
 def readjust_by_frac(a0, a, fra):
     return a + (a0 - a) * fra

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -200,10 +200,17 @@ def KH_instability_adjustment_bottom2(mc, delp, h0, q0):
     h0 = mc * (q0 - q0[0, 0, -1])
     q0 = q0 - h0 / delp
     return q0, h0
+@gtscript.function
+def kh_adjustment(mc, q0):
+    return mc * (q0 - q0[0, 0, -1])
 
 @gtscript.function
-def KH_instability_adjustment_top2(delp, h0, q0):
-    return q0 + h0[0, 0, 1] / delp
+def adjust_down(delp, h0, q0):
+    return  q0 - h0 / delp
+
+@gtscript.function
+def adjust_up(delp, h0, q0):
+    return  q0 + h0[0, 0, 1] / delp
 
 @gtscript.function
 def KH_instability_adjustment_bottom_te2(mc, delp, h0, q0, hd):
@@ -270,79 +277,55 @@ def m_loop(
         with interval(-1, None):
             ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)
             mc = compute_mass_flux(ri, ri_ref, delp, mc, ratio)
-            #q0_vapor, h0_vapor = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_vapor, q0_vapor)
-            #q0_liquid, h0_liquid = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_liquid, q0_liquid)
-            #q0_rain, h0_rain = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_rain, q0_rain)
-            #q0_ice, h0_ice = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_ice, q0_ice)
-            #q0_snow, h0_snow = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_snow, q0_snow)
-            #q0_graupel, h0_graupel = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_graupel, q0_graupel)
-            #q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
-            #q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
-            #q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
             if ri < ri_ref:
-                h0_vapor = mc * (q0_vapor - q0_vapor[0, 0, -1])
-                q0_vapor = q0_vapor - h0_vapor / delp
-                h0_liquid = mc * (q0_liquid - q0_liquid[0, 0, -1])
-                q0_liquid = q0_liquid - h0_liquid / delp
-                h0_rain = mc * (q0_rain - q0_rain[0, 0, -1])
-                q0_rain = q0_rain - h0_rain / delp
-                h0_ice = mc * (q0_ice - q0_ice[0, 0, -1])
-                q0_ice = q0_ice - h0_ice / delp
-                h0_snow = mc * (q0_snow - q0_snow[0, 0, -1])
-                q0_snow = q0_snow - h0_snow / delp
-                h0_graupel = mc * (q0_graupel - q0_graupel[0, 0, -1])
-                q0_graupel = q0_graupel - h0_graupel / delp
-                h0_o3mr = mc * (q0_o3mr - q0_o3mr[0, 0, -1])
-                q0_o3mr = q0_o3mr - h0_o3mr / delp
-                h0_sgs_tke = mc * (q0_sgs_tke - q0_sgs_tke[0, 0, -1])
-                q0_sgs_tke = q0_sgs_tke - h0_sgs_tke / delp
-                h0_cld = mc * (q0_cld - q0_cld[0, 0, -1])
-                q0_cld = q0_cld - h0_cld / delp
-                h0_u = mc * (u0 - u0[0, 0, -1])
-                u0 = u0 - h0_u / delp
-                h0_v = mc * (v0 - v0[0, 0, -1])
-                v0 = v0 - h0_v / delp
-                h0_w = mc * (w0 - w0[0, 0, -1])
-                w0 = w0 - h0_w / delp
-                h0_te = mc * (hd - hd[0, 0, -1])
-                te = te - h0_te / delp
-                #u0, h0_u = KH_instability_adjustment_bottom2(mc, delp, h0_u, u0)
-            #u0, h0_u = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_u, u0)
-            #v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
-            #w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
-            #te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)
+                # TODO: loop over tracers not hardcoded
+                # Note combining into functions breaks
+                # validation
+                h0_vapor = kh_adjustment(mc, q0_vapor)
+                q0_vapor = adjust_down(delp, h0_vapor, q0_vapor)
+                h0_liquid = kh_adjustment(mc, q0_liquid)
+                q0_liquid = adjust_down(delp, h0_liquid, q0_liquid)
+                h0_rain = kh_adjustment(mc, q0_rain)
+                q0_rain = adjust_down(delp, h0_rain, q0_rain)
+                h0_ice = kh_adjustment(mc, q0_ice)
+                q0_ice = adjust_down(delp, h0_ice, q0_ice)
+                h0_snow = kh_adjustment(mc, q0_snow)
+                q0_snow = adjust_down(delp, h0_snow, q0_snow)
+                h0_graupel = kh_adjustment(mc, q0_graupel)
+                q0_graupel = adjust_down(delp, h0_graupel, q0_graupel)
+                h0_o3mr = kh_adjustment(mc, q0_o3mr)
+                q0_o3mr = adjust_down(delp, h0_o3mr, q0_o3mr)
+                h0_sgs_tke = kh_adjustment(mc, q0_sgs_tke)
+                q0_sgs_tke = adjust_down(delp, h0_sgs_tke, q0_sgs_tke)
+                h0_cld = kh_adjustment(mc, q0_cld)
+                q0_cld = adjust_down(delp, h0_cld, q0_cld)
+                h0_u = kh_adjustment(mc, u0)
+                u0 = adjust_down(delp, h0_u, u0)
+                h0_v = kh_adjustment(mc, v0)
+                v0 = adjust_down(delp, h0_v, v0)
+                h0_w = kh_adjustment(mc, w0)
+                w0 = adjust_down(delp, h0_w, w0)
+                h0_te = kh_adjustment(mc, hd)
+                te = adjust_down(delp, h0_te, te)
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
         with interval(4, -1):
             if ri[0, 0, 1] < ri_ref[0, 0, 1]:
-                q0_vapor = q0_vapor + h0_vapor[0, 0, 1] / delp
-                q0_liquid = q0_liquid + h0_liquid[0, 0, 1] / delp
-                q0_rain = q0_rain + h0_rain[0, 0, 1] / delp
-                q0_ice = q0_ice + h0_ice[0, 0, 1] / delp
-                q0_snow = q0_snow + h0_snow[0, 0, 1] / delp
-                q0_graupel = q0_graupel + h0_graupel[0, 0, 1] / delp
-                q0_o3mr = q0_o3mr + h0_o3mr[0, 0, 1] / delp
-                q0_sgs_tke = q0_sgs_tke + h0_sgs_tke[0, 0, 1] / delp
-                q0_cld = q0_cld + h0_cld[0, 0, 1] / delp
-            #q0_vapor  = KH_instability_adjustment_top(ri, ri_ref, delp, h0_vapor,q0_vapor)
-            #q0_liquid= KH_instability_adjustment_top(ri, ri_ref,  delp, h0_liquid, q0_liquid)
-            #q0_rain = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_rain, q0_rain)
-            #q0_ice = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_ice, q0_ice)
-            #q0_snow = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_snow, q0_snow)
-            #q0_graupel = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_graupel, q0_graupel)
-            #q0_o3mr = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_o3mr, q0_o3mr)
-            #q0_sgs_tke = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_sgs_tke, q0_sgs_tke)
-            #q0_cld = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_cld, q0_cld)
-            #if ri[0, 0, 1] < ri_ref[0, 0, 1]:
+                q0_vapor = adjust_up(delp, h0_vapor, q0_vapor)
+                q0_liquid = adjust_up(delp, h0_liquid, q0_liquid)
+                q0_rain = adjust_up(delp, h0_rain, q0_rain)
+                q0_ice = adjust_up(delp, h0_ice, q0_ice)
+                q0_snow = adjust_up(delp, h0_snow, q0_snow)
+                q0_graupel = adjust_up(delp, h0_graupel, q0_graupel)
+                q0_o3mr = adjust_up(delp, h0_o3mr, q0_o3mr)
+                q0_sgs_tke = adjust_up(delp, h0_sgs_tke, q0_sgs_tke)
+                q0_cld = adjust_up(delp, h0_cld, q0_cld)
+                # recompute qcon
                 qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
-            #u0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_u, u0)
-            #if ri[0, 0, 1] < ri_ref[0, 0, 1]:
-                u0 = u0 + h0_u[0, 0, 1] / delp
-                v0 = v0 + h0_v[0, 0, 1] / delp
-                w0 = w0 + h0_w[0, 0, 1] / delp
-                te = te + h0_te[0, 0, 1] / delp
-            #v0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_v, v0)
-            #w0 = KH_instability_adjustment_top(ri, ri_ref, delp, h0_w, w0)
-            #te = KH_instability_adjustment_top(ri, ri_ref, delp, h0_te, te)
+                u0 = adjust_up(delp, h0_u, u0)
+                v0 = adjust_up(delp, h0_v, v0)
+                w0 = adjust_up(delp, h0_w, w0)
+                te = adjust_up(delp, h0_te, te)
+
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
             ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)
             # with computation(PARALLEL):
@@ -355,48 +338,191 @@ def m_loop(
             #with computation(PARALLEL), interval(1, None):
             mc = compute_mass_flux(ri, ri_ref, delp, mc, ratio)
             if ri < ri_ref:
-                h0_vapor = mc * (q0_vapor - q0_vapor[0, 0, -1])
-                q0_vapor = q0_vapor - h0_vapor / delp
-                h0_liquid = mc * (q0_liquid - q0_liquid[0, 0, -1])
-                q0_liquid = q0_liquid - h0_liquid / delp
-                h0_rain = mc * (q0_rain - q0_rain[0, 0, -1])
-                q0_rain = q0_rain - h0_rain / delp
-                h0_ice = mc * (q0_ice - q0_ice[0, 0, -1])
-                q0_ice = q0_ice - h0_ice / delp
-                h0_snow = mc * (q0_snow - q0_snow[0, 0, -1])
-                q0_snow = q0_snow - h0_snow / delp
-                h0_graupel = mc * (q0_graupel - q0_graupel[0, 0, -1])
-                q0_graupel = q0_graupel - h0_graupel / delp
-                h0_o3mr = mc * (q0_o3mr - q0_o3mr[0, 0, -1])
-                q0_o3mr = q0_o3mr - h0_o3mr / delp
-                h0_sgs_tke = mc * (q0_sgs_tke - q0_sgs_tke[0, 0, -1])
-                q0_sgs_tke = q0_sgs_tke - h0_sgs_tke / delp
-                h0_cld = mc * (q0_cld - q0_cld[0, 0, -1])
-                q0_cld = q0_cld - h0_cld / delp
-            #q0_vapor, h0_vapor =KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_vapor, q0_vapor)
-            #q0_liquid, h0_liquid = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_liquid, q0_liquid)
-            #q0_rain, h0_rain = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_rain, q0_rain)
-            #q0_ice, h0_ice = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_ice, q0_ice)
-            #q0_snow, h0_snow = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_snow, q0_snow)
-            #q0_graupel, h0_graupel = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_graupel, q0_graupel)
-            #q0_o3mr, h0_o3mr = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_o3mr, q0_o3mr)
-            #q0_sgs_tke, h0_sgs_tke = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_sgs_tke, q0_sgs_tke)
-            #q0_cld, h0_cld = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_cld, q0_cld)
-            #if ri < ri_ref:
-                h0_u = mc * (u0 - u0[0, 0, -1])
-                u0 = u0 - h0_u / delp
-                h0_v = mc * (v0 - v0[0, 0, -1])
-                v0 = v0 - h0_v / delp
-                h0_w = mc * (w0 - w0[0, 0, -1])
-                w0 = w0 - h0_w / delp
-                h0_te = mc * (hd - hd[0, 0, -1])
-                te = te - h0_te / delp
-            #v0, h0_v = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_v, v0)
-            #w0, h0_w = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_w, w0)
-            #te, h0_te = KH_instability_adjustment_bottom_te(ri, ri_ref, mc, delp, h0_te, te, hd)
-           
+                h0_vapor = kh_adjustment(mc, q0_vapor)
+                q0_vapor = adjust_down(delp, h0_vapor, q0_vapor)
+                h0_liquid = kh_adjustment(mc, q0_liquid)
+                q0_liquid = adjust_down(delp, h0_liquid, q0_liquid)
+                h0_rain = kh_adjustment(mc, q0_rain)
+                q0_rain = adjust_down(delp, h0_rain, q0_rain)
+                h0_ice = kh_adjustment(mc, q0_ice)
+                q0_ice = adjust_down(delp, h0_ice, q0_ice)
+                h0_snow = kh_adjustment(mc, q0_snow)
+                q0_snow = adjust_down(delp, h0_snow, q0_snow)
+                h0_graupel = kh_adjustment(mc, q0_graupel)
+                q0_graupel = adjust_down(delp, h0_graupel, q0_graupel)
+                h0_o3mr = kh_adjustment(mc, q0_o3mr)
+                q0_o3mr = adjust_down(delp, h0_o3mr, q0_o3mr)
+                h0_sgs_tke = kh_adjustment(mc, q0_sgs_tke)
+                q0_sgs_tke = adjust_down(delp, h0_sgs_tke, q0_sgs_tke)
+                h0_cld = kh_adjustment(mc, q0_cld)
+                q0_cld = adjust_down(delp, h0_cld, q0_cld)
+               
+                h0_u = kh_adjustment(mc, u0)
+                u0 = adjust_down(delp, h0_u, u0)
+                h0_v = kh_adjustment(mc, v0)
+                v0 = adjust_down(delp, h0_v, v0)
+                h0_w = kh_adjustment(mc, w0)
+                w0 = adjust_down(delp, h0_w, w0)
+                h0_te = kh_adjustment(mc, hd)
+                te = adjust_down(delp, h0_te, te)
+        
             cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te, hd)
-        #with interval(3, 4)
+        with interval(3, 4):
+            if ri[0, 0, 1] < ri_ref[0, 0, 1]:
+                q0_vapor = adjust_up(delp, h0_vapor, q0_vapor)
+                q0_liquid = adjust_up(delp, h0_liquid, q0_liquid)
+                q0_rain = adjust_up(delp, h0_rain, q0_rain)
+                q0_ice = adjust_up(delp, h0_ice, q0_ice)
+                q0_snow = adjust_up(delp, h0_snow, q0_snow)
+                q0_graupel = adjust_up(delp, h0_graupel, q0_graupel)
+                q0_o3mr = adjust_up(delp, h0_o3mr, q0_o3mr)
+                q0_sgs_tke = adjust_up(delp, h0_sgs_tke, q0_sgs_tke)
+                q0_cld = adjust_up(delp, h0_cld, q0_cld)
+                # recompute qcon
+                qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
+                u0 = adjust_up(delp, h0_u, u0)
+                v0 = adjust_up(delp, h0_v, v0)
+                w0 = adjust_up(delp, h0_w, w0)
+                te = adjust_up(delp, h0_te, te)
+
+            cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
+            ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)
+            ri_ref = ri_ref * 1.5
+            mc = compute_mass_flux(ri, ri_ref, delp, mc, ratio)
+            if ri < ri_ref:
+                h0_vapor = kh_adjustment(mc, q0_vapor)
+                q0_vapor = adjust_down(delp, h0_vapor, q0_vapor)
+                h0_liquid = kh_adjustment(mc, q0_liquid)
+                q0_liquid = adjust_down(delp, h0_liquid, q0_liquid)
+                h0_rain = kh_adjustment(mc, q0_rain)
+                q0_rain = adjust_down(delp, h0_rain, q0_rain)
+                h0_ice = kh_adjustment(mc, q0_ice)
+                q0_ice = adjust_down(delp, h0_ice, q0_ice)
+                h0_snow = kh_adjustment(mc, q0_snow)
+                q0_snow = adjust_down(delp, h0_snow, q0_snow)
+                h0_graupel = kh_adjustment(mc, q0_graupel)
+                q0_graupel = adjust_down(delp, h0_graupel, q0_graupel)
+                h0_o3mr = kh_adjustment(mc, q0_o3mr)
+                q0_o3mr = adjust_down(delp, h0_o3mr, q0_o3mr)
+                h0_sgs_tke = kh_adjustment(mc, q0_sgs_tke)
+                q0_sgs_tke = adjust_down(delp, h0_sgs_tke, q0_sgs_tke)
+                h0_cld = kh_adjustment(mc, q0_cld)
+                q0_cld = adjust_down(delp, h0_cld, q0_cld)
+               
+                h0_u = kh_adjustment(mc, u0)
+                u0 = adjust_down(delp, h0_u, u0)
+                h0_v = kh_adjustment(mc, v0)
+                v0 = adjust_down(delp, h0_v, v0)
+                h0_w = kh_adjustment(mc, w0)
+                w0 = adjust_down(delp, h0_w, w0)
+                h0_te = kh_adjustment(mc, hd)
+                te = adjust_down(delp, h0_te, te)
+        
+            cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te, hd)
+        with interval(2, 3):
+            if ri[0, 0, 1] < ri_ref[0, 0, 1]:
+                q0_vapor = adjust_up(delp, h0_vapor, q0_vapor)
+                q0_liquid = adjust_up(delp, h0_liquid, q0_liquid)
+                q0_rain = adjust_up(delp, h0_rain, q0_rain)
+                q0_ice = adjust_up(delp, h0_ice, q0_ice)
+                q0_snow = adjust_up(delp, h0_snow, q0_snow)
+                q0_graupel = adjust_up(delp, h0_graupel, q0_graupel)
+                q0_o3mr = adjust_up(delp, h0_o3mr, q0_o3mr)
+                q0_sgs_tke = adjust_up(delp, h0_sgs_tke, q0_sgs_tke)
+                q0_cld = adjust_up(delp, h0_cld, q0_cld)
+                # recompute qcon
+                qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
+                u0 = adjust_up(delp, h0_u, u0)
+                v0 = adjust_up(delp, h0_v, v0)
+                w0 = adjust_up(delp, h0_w, w0)
+                te = adjust_up(delp, h0_te, te)
+
+            cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
+            ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)
+            ri_ref = ri_ref * 2.0
+            mc = compute_mass_flux(ri, ri_ref, delp, mc, ratio)
+            if ri < ri_ref:
+                h0_vapor = kh_adjustment(mc, q0_vapor)
+                q0_vapor = adjust_down(delp, h0_vapor, q0_vapor)
+                h0_liquid = kh_adjustment(mc, q0_liquid)
+                q0_liquid = adjust_down(delp, h0_liquid, q0_liquid)
+                h0_rain = kh_adjustment(mc, q0_rain)
+                q0_rain = adjust_down(delp, h0_rain, q0_rain)
+                h0_ice = kh_adjustment(mc, q0_ice)
+                q0_ice = adjust_down(delp, h0_ice, q0_ice)
+                h0_snow = kh_adjustment(mc, q0_snow)
+                q0_snow = adjust_down(delp, h0_snow, q0_snow)
+                h0_graupel = kh_adjustment(mc, q0_graupel)
+                q0_graupel = adjust_down(delp, h0_graupel, q0_graupel)
+                h0_o3mr = kh_adjustment(mc, q0_o3mr)
+                q0_o3mr = adjust_down(delp, h0_o3mr, q0_o3mr)
+                h0_sgs_tke = kh_adjustment(mc, q0_sgs_tke)
+                q0_sgs_tke = adjust_down(delp, h0_sgs_tke, q0_sgs_tke)
+                h0_cld = kh_adjustment(mc, q0_cld)
+                q0_cld = adjust_down(delp, h0_cld, q0_cld)
+               
+                h0_u = kh_adjustment(mc, u0)
+                u0 = adjust_down(delp, h0_u, u0)
+                h0_v = kh_adjustment(mc, v0)
+                v0 = adjust_down(delp, h0_v, v0)
+                h0_w = kh_adjustment(mc, w0)
+                w0 = adjust_down(delp, h0_w, w0)
+                h0_te = kh_adjustment(mc, hd)
+                te = adjust_down(delp, h0_te, te)
+        
+            cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te, hd)
+        with interval(1, 2):
+            if ri[0, 0, 1] < ri_ref[0, 0, 1]:
+                q0_vapor = adjust_up(delp, h0_vapor, q0_vapor)
+                q0_liquid = adjust_up(delp, h0_liquid, q0_liquid)
+                q0_rain = adjust_up(delp, h0_rain, q0_rain)
+                q0_ice = adjust_up(delp, h0_ice, q0_ice)
+                q0_snow = adjust_up(delp, h0_snow, q0_snow)
+                q0_graupel = adjust_up(delp, h0_graupel, q0_graupel)
+                q0_o3mr = adjust_up(delp, h0_o3mr, q0_o3mr)
+                q0_sgs_tke = adjust_up(delp, h0_sgs_tke, q0_sgs_tke)
+                q0_cld = adjust_up(delp, h0_cld, q0_cld)
+                # recompute qcon
+                qcon = qcon_func(qcon, q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel)
+                u0 = adjust_up(delp, h0_u, u0)
+                v0 = adjust_up(delp, h0_v, v0)
+                w0 = adjust_up(delp, h0_w, w0)
+                te = adjust_up(delp, h0_te, te)
+
+            cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te,hd)
+            ri, ri_ref = compute_ri(t0, q0_vapor, qcon, pkz, pm, gz, u0, v0,xvir, t_max, t_min)
+            ri_ref = ri_ref * 4.0
+            mc = compute_mass_flux(ri, ri_ref, delp, mc, ratio)
+            if ri < ri_ref:
+                h0_vapor = kh_adjustment(mc, q0_vapor)
+                q0_vapor = adjust_down(delp, h0_vapor, q0_vapor)
+                h0_liquid = kh_adjustment(mc, q0_liquid)
+                q0_liquid = adjust_down(delp, h0_liquid, q0_liquid)
+                h0_rain = kh_adjustment(mc, q0_rain)
+                q0_rain = adjust_down(delp, h0_rain, q0_rain)
+                h0_ice = kh_adjustment(mc, q0_ice)
+                q0_ice = adjust_down(delp, h0_ice, q0_ice)
+                h0_snow = kh_adjustment(mc, q0_snow)
+                q0_snow = adjust_down(delp, h0_snow, q0_snow)
+                h0_graupel = kh_adjustment(mc, q0_graupel)
+                q0_graupel = adjust_down(delp, h0_graupel, q0_graupel)
+                h0_o3mr = kh_adjustment(mc, q0_o3mr)
+                q0_o3mr = adjust_down(delp, h0_o3mr, q0_o3mr)
+                h0_sgs_tke = kh_adjustment(mc, q0_sgs_tke)
+                q0_sgs_tke = adjust_down(delp, h0_sgs_tke, q0_sgs_tke)
+                h0_cld = kh_adjustment(mc, q0_cld)
+                q0_cld = adjust_down(delp, h0_cld, q0_cld)
+               
+                h0_u = kh_adjustment(mc, u0)
+                u0 = adjust_down(delp, h0_u, u0)
+                h0_v = kh_adjustment(mc, v0)
+                v0 = adjust_down(delp, h0_v, v0)
+                h0_w = kh_adjustment(mc, w0)
+                w0 = adjust_down(delp, h0_w, w0)
+                h0_te = kh_adjustment(mc, hd)
+                te = adjust_down(delp, h0_te, te)
+        
+            cpm, cvm, t0, hd = adjust_cvm( cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel, gz, u0, v0, w0, t0, te, hd)
 """
  # kh_bottom tracers
             # with computation(BACKWARD), interval(...):
@@ -766,6 +892,7 @@ def compute(state, nq, dt):
             origin=grid.compute_origin(),
             domain=kbot_domain,
         )
+        """
         if n ==	0:
             i = 10
             j = 12
@@ -788,6 +915,7 @@ def compute(state, nq, dt):
                     print(z, k, v[i, j,z])
             #for z in range(ri.shape[2]):
             #    print('pm at ',z,  pm[i, j,z])
+        """
         #if k == 1:
         #    ri_ref *= 4.0
         #if k == 2:

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -296,6 +296,8 @@ def m_loop(
                 q0_o3mr = q0_o3mr - h0_o3mr / delp
                 h0_sgs_tke = mc * (q0_sgs_tke - q0_sgs_tke[0, 0, -1])
                 q0_sgs_tke = q0_sgs_tke - h0_sgs_tke / delp
+                h0_cld = mc * (q0_cld - q0_cld[0, 0, -1])
+                q0_cld = q0_cld - h0_cld / delp
                 h0_u = mc * (u0 - u0[0, 0, -1])
                 u0 = u0 - h0_u / delp
                 h0_v = mc * (v0 - v0[0, 0, -1])
@@ -320,6 +322,7 @@ def m_loop(
                 q0_graupel = q0_graupel + h0_graupel[0, 0, 1] / delp
                 q0_o3mr = q0_o3mr + h0_o3mr[0, 0, 1] / delp
                 q0_sgs_tke = q0_sgs_tke + h0_sgs_tke[0, 0, 1] / delp
+                q0_cld = q0_cld + h0_cld[0, 0, 1] / delp
             #q0_vapor  = KH_instability_adjustment_top(ri, ri_ref, delp, h0_vapor,q0_vapor)
             #q0_liquid= KH_instability_adjustment_top(ri, ri_ref,  delp, h0_liquid, q0_liquid)
             #q0_rain = KH_instability_adjustment_top(ri, ri_ref,  delp, h0_rain, q0_rain)
@@ -368,6 +371,8 @@ def m_loop(
                 q0_o3mr = q0_o3mr - h0_o3mr / delp
                 h0_sgs_tke = mc * (q0_sgs_tke - q0_sgs_tke[0, 0, -1])
                 q0_sgs_tke = q0_sgs_tke - h0_sgs_tke / delp
+                h0_cld = mc * (q0_cld - q0_cld[0, 0, -1])
+                q0_cld = q0_cld - h0_cld / delp
             #q0_vapor, h0_vapor =KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_vapor, q0_vapor)
             #q0_liquid, h0_liquid = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_liquid, q0_liquid)
             #q0_rain, h0_rain = KH_instability_adjustment_bottom(ri, ri_ref, mc, delp, h0_rain, q0_rain)

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -5,12 +5,11 @@ from typing import Any, Callable, Dict, Hashable, List, Optional, Tuple, Union
 import gt4py as gt
 import gt4py.storage as gt_storage
 import numpy as np
-from gt4py import gtscript
 
 import fv3core._config as spec
 import fv3core.utils.global_config as global_config
 from fv3core.utils.mpi import MPI
-from fv3core.utils.typing import DTypes, Field, Float, Int
+from fv3core.utils.typing import DTypes, Field, Float
 
 
 try:

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -23,10 +23,6 @@ logger = logging.getLogger("fv3ser")
 # If True, automatically transfers memory between CPU and GPU (see gt4py.storage)
 managed_memory = True
 
-# [DEPRECATED] field types
-sd = gtscript.Field[Float]
-si = gtscript.Field[Int]
-
 # Number of halo lines for each field and default origin
 halo = 3
 origin = (halo, halo, 0)

--- a/tests/translate/translate_fvsubgridz.py
+++ b/tests/translate/translate_fvsubgridz.py
@@ -1,11 +1,14 @@
+from types import SimpleNamespace
+
 import pytest
 
+import fv3core._config as spec
 import fv3core.stencils.fv_subgridz as fv_subgridz
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util as fv3util
 from fv3core.testing import ParallelTranslateBaseSlicing
-import fv3core._config as spec
-from types import SimpleNamespace
+
+
 # NOTE, does no halo updates, does not need to be a Parallel test,
 # but doing so here to make the interface match fv_dynamics.
 # Could add support to the TranslateFortranData2Py class
@@ -114,12 +117,11 @@ class TranslateFVSubgridZ(ParallelTranslateBaseSlicing):
             "dims": [fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
             "units": "m/s**2",
         },
-        "nq": {"dims": []},
         "dt": {"dims": []},
     }
     outputs = inputs.copy()
 
-    for name in ("nq", "dt", "pe", "peln", "delp", "delz", "pkz"):
+    for name in ("dt", "pe", "peln", "delp", "delz", "pkz"):
         outputs.pop(name)
 
     def __init__(self, grids, *args, **kwargs):
@@ -176,7 +178,7 @@ class TranslateFVSubgridZ(ParallelTranslateBaseSlicing):
             spec.namelist,
         )
         state = SimpleNamespace(**state)
-        fvsubgridz(state, inputs["nq"], inputs["dt"])
+        fvsubgridz(state, inputs["dt"])
         outputs = self.outputs_from_state(state.__dict__)
         return outputs
 

--- a/tests/translate/translate_fvsubgridz.py
+++ b/tests/translate/translate_fvsubgridz.py
@@ -4,8 +4,8 @@ import fv3core.stencils.fv_subgridz as fv_subgridz
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util as fv3util
 from fv3core.testing import ParallelTranslateBaseSlicing
-
-
+import fv3core._config as spec
+from types import SimpleNamespace
 # NOTE, does no halo updates, does not need to be a Parallel test,
 # but doing so here to make the interface match fv_dynamics.
 # Could add support to the TranslateFortranData2Py class
@@ -172,8 +172,12 @@ class TranslateFVSubgridZ(ParallelTranslateBaseSlicing):
 
     def compute_parallel(self, inputs, communicator):
         state = self.state_from_inputs(inputs)
-        fv_subgridz.compute(state, inputs["nq"], inputs["dt"])
-        outputs = self.outputs_from_state(state)
+        fvsubgridz = fv_subgridz.FVSubgridZ(
+            spec.namelist,
+        )
+        state = SimpleNamespace(**state)
+        fvsubgridz(state, inputs["nq"], inputs["dt"])
+        outputs = self.outputs_from_state(state.__dict__)
         return outputs
 
     def compute_sequential(self, inputs_list, communicator_list):


### PR DESCRIPTION
## Purpose

fv_subgridz is outside of the main 'fv_dynamics' loop and often gets left behind in refactors, and is the last piece preventing us from completing the transition from stencils decorated in the file and compiled JIT to one using objects to initialize/compile the whole model before running it. This PR catches it up, though a choice was made to unroll all of the tracers operations, with the idea we'll be adding a gt4py feature that can do this loop inside of the stencil. It was necessary to do so for the m_loop to be consolidated, and changed the other stencils to make them consistent. 
The main purpose of this PR:
  -- make a single stencil inside of the n-loop rather than looping over k to adjust both this layer and the one below it simultaneously. 
  -- make FVSubgridZ an object that matches the conventions of our other stencils. 
What this does not do:
 -- m_loop has a lot of repetition. We could make more effort to use more functions, but most variations tried resulted in failed validation. More could be done here, but in favor of getting this code up to date I suggest we delay that to a future optimization, when we revisit it to apply the loops over tracers. 

## Code changes:

- fv_subgridz is rewritten to be 3d and as a class
- removed remaining references to 'sd' and 'si'
- updated example runfiles to call the FvSubgridZ object


## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
