### PR TITLE
divergence damping uses regions

### DIFF
--- a/fv3core/stencils/divergence_damping.py
+++ b/fv3core/stencils/divergence_damping.py
@@ -22,7 +22,7 @@ def damp_tmp(q, da_min_c, d2_bg, dddmp):
     return damp
 
 
-def ptc_main(
+def ptc_computation(
     u: FloatField,
     va: FloatField,
     vc: FloatField,
@@ -181,8 +181,8 @@ class DivergenceDamping:
             (self.grid.is_ - 1, self.grid.js, low_kstart),
             (self.grid.nic + 2, self.grid.njc + 1, low_nk),
         )
-        self._ptc_main_stencil = FrozenStencil(
-            ptc_main,
+        self._ptc_computation = FrozenStencil(
+            ptc_computation,
             origin=(self.grid.is_ - 1, self.grid.js, low_kstart),
             domain=(self.grid.nic + 2, self.grid.njc + 1, low_nk),
             externals=start_points,
@@ -386,7 +386,7 @@ class DivergenceDamping:
     ) -> None:
         # if nested
         # TODO: ptc and vort are equivalent, but x vs y, consolidate if possible.
-        self._ptc_main_stencil(
+        self._ptc_computation(
             u,
             va,
             vc,

--- a/fv3core/stencils/divergence_damping.py
+++ b/fv3core/stencils/divergence_damping.py
@@ -53,7 +53,7 @@ def vorticity_computation(
     sin_sg3: FloatFieldIJ,
     sin_sg1: FloatFieldIJ,
 ):
-    """computataion of the vorticity"""
+    """computation of the vorticity"""
     from __externals__ import i_end, i_start
 
     with computation(PARALLEL), interval(...):


### PR DESCRIPTION
## Purpose

Apply regions in divergence damping to simplify the code. 

## Code changes:

- Remove all the edge/corner handling stencils in `divergence_damping` and replace them with regions statements in their respective main stencils.

## Checklist
Before submitting this PR, please make sure:

- [X] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [X] Docstrings and type hints are added to new and updated routines, as appropriate
