### PR TITLE
NH_p_grad is 3D

### DIFF
--- a/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/stencils/nh_p_grad.py
@@ -106,7 +106,7 @@ class NonHydrostaticPressureGradient:
             grid.domain_shape_full(add=(0, 0, 1)), origin=self.orig
         )  # pp.shape
 
-        self._calc_wk_stencil = FrozenStencil(
+        self._set_k0_and_calc_wk_stencil = FrozenStencil(
             set_k0_and_calc_wk,
             origin=self.orig,
             domain=self.domain_full_k,
@@ -179,7 +179,7 @@ class NonHydrostaticPressureGradient:
         self.a2b_kbuffer(gz, self._tmp_wk1)
         self.a2b_kstandard(delp, self._tmp_wk1)
 
-        self._calc_wk_stencil(pp, pk3, self._tmp_wk, top_value)
+        self._set_k0_and_calc_wk_stencil(pp, pk3, self._tmp_wk, top_value)
 
         self._calc_u_stencil(
             u,

--- a/fv3core/stencils/nh_p_grad.py
+++ b/fv3core/stencils/nh_p_grad.py
@@ -7,15 +7,14 @@ from fv3core.stencils.a2b_ord4 import AGrid2BGridFourthOrder
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
-def set_k0(pp: FloatField, pk3: FloatField, top_value: float):
-    with computation(PARALLEL), interval(...):
+def set_k0_and_calc_wk(
+    pp: FloatField, pk3: FloatField, wk: FloatField, top_value: float
+):
+    with computation(PARALLEL), interval(0, 1):
         pp[0, 0, 0] = 0.0
         pk3[0, 0, 0] = top_value
-
-
-def calc_wk(pk: FloatField, wk: FloatField):
     with computation(PARALLEL), interval(...):
-        wk = pk[0, 0, 1] - pk[0, 0, 0]
+        wk = pk3[0, 0, 1] - pk3[0, 0, 0]
 
 
 def calc_u(
@@ -107,14 +106,8 @@ class NonHydrostaticPressureGradient:
             grid.domain_shape_full(add=(0, 0, 1)), origin=self.orig
         )  # pp.shape
 
-        self._set_k0_stencil = FrozenStencil(
-            set_k0,
-            origin=self.orig,
-            domain=self.domain_k1,
-        )
-
         self._calc_wk_stencil = FrozenStencil(
-            calc_wk,
+            set_k0_and_calc_wk,
             origin=self.orig,
             domain=self.domain_full_k,
         )
@@ -180,19 +173,13 @@ class NonHydrostaticPressureGradient:
         ptk = ptop ** akap
         top_value = ptk  # = peln1 if spec.namelist.use_logp else ptk
 
-        self._set_k0_stencil(
-            pp,
-            pk3,
-            top_value,
-        )
-
         self.a2b_k1(pp, self._tmp_wk1)
         self.a2b_k1(pk3, self._tmp_wk1)
 
         self.a2b_kbuffer(gz, self._tmp_wk1)
         self.a2b_kstandard(delp, self._tmp_wk1)
 
-        self._calc_wk_stencil(pk3, self._tmp_wk)
+        self._calc_wk_stencil(pp, pk3, self._tmp_wk, top_value)
 
         self._calc_u_stencil(
             u,


### PR DESCRIPTION
## Purpose

This PR combines the `set_k0` and `calc_wk` stencils to eliminate a 2D stencil call and reduce call counts overall

## Code changes:

- nh_p_grad.py: set_k0 and calc_wk are now one stencil, `set_k0_and_calc_wk`

## Checklist
Before submitting this PR, please make sure:

- [ ] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes
