### PR TITLE
Rename internal stencil function of XTP_U and YTP_U

### DIFF
--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -52,7 +52,7 @@ def _get_flux(
     return xppm.final_flux(courant, u, fx0, tmp)
 
 
-def _compute_stencil(
+def _xtp_u(
     courant: FloatField,
     u: FloatField,
     flux: FloatField,
@@ -113,7 +113,7 @@ class XTP_U:
         ax_offsets = axis_offsets(grid, self.origin, self.domain)
         assert namelist.grid_type < 3
         self.stencil = FrozenStencil(
-            _compute_stencil,
+            _xtp_u,
             externals={
                 "iord": iord,
                 "mord": iord,

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -50,7 +50,7 @@ def _get_flux(
     return yppm.final_flux(courant, v, fx0, tmp)
 
 
-def _compute_stencil(
+def _ytp_v(
     courant: FloatField,
     v: FloatField,
     flux: FloatField,
@@ -111,7 +111,7 @@ class YTP_V:
         assert namelist.grid_type < 3
 
         self.stencil = FrozenStencil(
-            _compute_stencil,
+            _ytp_v,
             externals={
                 "jord": jord,
                 "mord": jord,


### PR DESCRIPTION
## Purpose

Rename the internal function used in `FrozenStencil` for XTP_U and YTP_U to help with profiling effort

## Code changes:

Rename functions `_compute_stencil` to `_xtp_u` and `_ytp_u`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes

