### PR TITLE
Merging stencils in c_sw

### DIFF
--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -120,6 +120,7 @@ def transportdelp_update_vorticity_and_kineticenergy(
     from __externals__ import grid_type, i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
+        # transport delP
         compile_assert(grid_type < 3)
         # additional assumption (not grid.nested)
 
@@ -140,6 +141,7 @@ def transportdelp_update_vorticity_and_kineticenergy(
         wc = (w * delp + (fx2 - fx2[1, 0, 0] + fy2 - fy2[0, 1, 0]) * rarea) / delpc
 
     with computation(PARALLEL), interval(...):
+        # update vorticity and kinetic energy
         compile_assert(grid_type < 3)
 
         ke = uc if ua > 0.0 else uc[1, 0, 0]

--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -69,7 +69,7 @@ def nonhydro_y_fluxes(delp: FloatField, pt: FloatField, w: FloatField, vtc: Floa
     return fy, fy1, fy2
 
 
-def transportdelp(
+def transportdelp_update_vorticity_and_kineticenergy(
     delp: FloatField,
     pt: FloatField,
     utc: FloatField,
@@ -79,8 +79,25 @@ def transportdelp(
     delpc: FloatField,
     ptc: FloatField,
     wc: FloatField,
+    ke: FloatField,
+    vort: FloatField,
+    ua: FloatField,
+    va: FloatField,
+    uc: FloatField,
+    vc: FloatField,
+    u: FloatField,
+    v: FloatField,
+    sin_sg1: FloatFieldIJ,
+    cos_sg1: FloatFieldIJ,
+    sin_sg2: FloatFieldIJ,
+    cos_sg2: FloatFieldIJ,
+    sin_sg3: FloatFieldIJ,
+    cos_sg3: FloatFieldIJ,
+    sin_sg4: FloatFieldIJ,
+    cos_sg4: FloatFieldIJ,
+    dt2: float,
 ):
-    """Transport delp.
+    """Transport delp then update vorticity and kinetic energy
 
     Args:
         delp: What is transported (input)
@@ -92,9 +109,15 @@ def transportdelp(
         delpc: Updated delp (output)
         ptc: Updated pt (output)
         wc: Updated w (output)
+        ke: kinetic energy (inout)
+        vort: vorticity (inout)
+        ua/uc/u: u wind on the a/c/d grid (in)
+        va/vc/v: v wind on the a/c/d grid (in)
+        sin_sg/cos_sg 1/2/3/4: variables that specify grid geometry grid (in)
+        dt2: length of half a timestep (in)
     """
 
-    from __externals__ import grid_type
+    from __externals__ import grid_type, i_end, i_start, j_end, j_start
 
     with computation(PARALLEL), interval(...):
         compile_assert(grid_type < 3)
@@ -115,6 +138,24 @@ def transportdelp(
         delpc = delp + (fx1 - fx1[1, 0, 0] + fy1 - fy1[0, 1, 0]) * rarea
         ptc = (pt * delp + (fx - fx[1, 0, 0] + fy - fy[0, 1, 0]) * rarea) / delpc
         wc = (w * delp + (fx2 - fx2[1, 0, 0] + fy2 - fy2[0, 1, 0]) * rarea) / delpc
+
+    with computation(PARALLEL), interval(...):
+        compile_assert(grid_type < 3)
+
+        ke = uc if ua > 0.0 else uc[1, 0, 0]
+        vort = vc if va > 0.0 else vc[0, 1, 0]
+
+        with horizontal(region[:, j_start - 1], region[:, j_end]):
+            vort = vort * sin_sg4 + u[0, 1, 0] * cos_sg4 if va <= 0.0 else vort
+        with horizontal(region[:, j_start], region[:, j_end + 1]):
+            vort = vort * sin_sg2 + u * cos_sg2 if va > 0.0 else vort
+
+        with horizontal(region[i_end, :], region[i_start - 1, :]):
+            ke = ke * sin_sg3 + v[1, 0, 0] * cos_sg3 if ua <= 0.0 else ke
+        with horizontal(region[i_end + 1, :], region[i_start, :]):
+            ke = ke * sin_sg1 + v * cos_sg1 if ua > 0.0 else ke
+
+        ke = 0.5 * dt2 * (ua * ke + va * vort)
 
 
 def divergence_corner(
@@ -212,46 +253,6 @@ def circulation_cgrid(
 
         with horizontal(region[i_end + 1, j_start], region[i_end + 1, j_end + 1]):
             vort_c -= fy[0, 0, 0]
-
-
-def update_vorticity_and_kinetic_energy(
-    ke: FloatField,
-    vort: FloatField,
-    ua: FloatField,
-    va: FloatField,
-    uc: FloatField,
-    vc: FloatField,
-    u: FloatField,
-    v: FloatField,
-    sin_sg1: FloatFieldIJ,
-    cos_sg1: FloatFieldIJ,
-    sin_sg2: FloatFieldIJ,
-    cos_sg2: FloatFieldIJ,
-    sin_sg3: FloatFieldIJ,
-    cos_sg3: FloatFieldIJ,
-    sin_sg4: FloatFieldIJ,
-    cos_sg4: FloatFieldIJ,
-    dt2: float,
-):
-    from __externals__ import grid_type, i_end, i_start, j_end, j_start
-
-    with computation(PARALLEL), interval(...):
-        compile_assert(grid_type < 3)
-
-        ke = uc if ua > 0.0 else uc[1, 0, 0]
-        vort = vc if va > 0.0 else vc[0, 1, 0]
-
-        with horizontal(region[:, j_start - 1], region[:, j_end]):
-            vort = vort * sin_sg4 + u[0, 1, 0] * cos_sg4 if va <= 0.0 else vort
-        with horizontal(region[:, j_start], region[:, j_end + 1]):
-            vort = vort * sin_sg2 + u * cos_sg2 if va > 0.0 else vort
-
-        with horizontal(region[i_end, :], region[i_start - 1, :]):
-            ke = ke * sin_sg3 + v[1, 0, 0] * cos_sg3 if ua <= 0.0 else ke
-        with horizontal(region[i_end + 1, :], region[i_start, :]):
-            ke = ke * sin_sg1 + v * cos_sg1 if ua > 0.0 else ke
-
-        ke = 0.5 * dt2 * (ua * ke + va * vort)
 
 
 def update_x_velocity(
@@ -369,26 +370,14 @@ class CGridShallowWaterDynamics:
         ax_offsets_transportdelp = axis_offsets(
             self.grid, geo_origin, domain_transportdelp
         )
-        self._transportdelp = FrozenStencil(
-            func=transportdelp,
+        self._transportdelp_updatevorticity_and_ke = FrozenStencil(
+            func=transportdelp_update_vorticity_and_kineticenergy,
             externals={
                 "grid_type": grid_type,
                 **ax_offsets_transportdelp,
             },
             origin=geo_origin,
             domain=(self.grid.nic + 2, self.grid.njc + 2, self.grid.npz),
-        )
-        origin_vort_ke = (self.grid.is_ - 1, self.grid.js - 1, 0)
-        domain_vort_ke = (self.grid.nic + 2, self.grid.njc + 2, self.grid.npz)
-        ax_offsets_vort_ke = axis_offsets(self.grid, origin_vort_ke, domain_vort_ke)
-        self._update_vorticity_and_kinetic_energy = FrozenStencil(
-            func=update_vorticity_and_kinetic_energy,
-            externals={
-                "grid_type": grid_type,
-                **ax_offsets_vort_ke,
-            },
-            origin=origin_vort_ke,
-            domain=domain_vort_ke,
         )
         self._circulation_cgrid = FrozenStencil(
             func=circulation_cgrid,
@@ -400,7 +389,7 @@ class CGridShallowWaterDynamics:
         )
         self._absolute_vorticity = FrozenStencil(
             func=absolute_vorticity,
-            origin=self.grid.compute_origin(),
+            origin=origin,
             domain=(self.grid.nic + 1, self.grid.njc + 1, self.grid.npz),
         )
 
@@ -546,7 +535,7 @@ class CGridShallowWaterDynamics:
             self.grid.sin_sg2,
             dt2,
         )
-        self._transportdelp(
+        self._transportdelp_updatevorticity_and_ke(
             delp,
             pt,
             ut,
@@ -556,8 +545,6 @@ class CGridShallowWaterDynamics:
             self.delpc,
             self.ptc,
             omga,
-        )
-        self._update_vorticity_and_kinetic_energy(
             self._ke,
             self._vort,
             ua,

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -290,7 +290,6 @@ def vt_corners(
     return vt
 
 
-# Single stencil version to use when possible with gt backends
 def fxadv_stencil(
     cosa_u: FloatFieldIJ,
     cosa_v: FloatFieldIJ,

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -1,3 +1,4 @@
+from gt4py import gtscript
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
 import fv3core._config as spec
@@ -8,6 +9,7 @@ from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 # TODO: the mix of local and global regions is strange here
 # it's a workaround to specify DON'T do this calculation if on the tile edge
+@gtscript.function
 def main_ut(
     uc: FloatField,
     vc: FloatField,
@@ -17,20 +19,19 @@ def main_ut(
 ):
     from __externals__ import j_end, j_start, local_ie, local_is
 
-    with computation(PARALLEL), interval(...):
-        utmp = ut
-        with horizontal(region[local_is - 1 : local_ie + 3, :]):
-            ut = (
-                uc - 0.25 * cosa_u * (vc[-1, 0, 0] + vc + vc[-1, 1, 0] + vc[0, 1, 0])
-            ) * rsin_u
-        with horizontal(
-            region[:, j_start - 1 : j_start + 1], region[:, j_end : j_end + 2]
-        ):
-            ut = utmp
+    utmp = ut
+    with horizontal(region[local_is - 1 : local_ie + 3, :]):
+        ut = (
+            uc - 0.25 * cosa_u * (vc[-1, 0, 0] + vc + vc[-1, 1, 0] + vc[0, 1, 0])
+        ) * rsin_u
+    with horizontal(region[:, j_start - 1 : j_start + 1], region[:, j_end : j_end + 2]):
+        ut = utmp
+    return ut
 
 
 # TODO: the mix of local and global regions is strange here
 # it's a workaround to specify DON'T do this calculation if on the tile edge
+@gtscript.function
 def main_vt(
     uc: FloatField,
     vc: FloatField,
@@ -40,16 +41,17 @@ def main_vt(
 ):
     from __externals__ import j_end, j_start, local_je, local_js
 
-    with computation(PARALLEL), interval(...):
-        vtmp = vt
-        with horizontal(region[:, local_js - 1 : local_je + 3]):
-            vt = (
-                vc - 0.25 * cosa_v * (uc[0, -1, 0] + uc[1, -1, 0] + uc + uc[1, 0, 0])
-            ) * rsin_v
-        with horizontal(region[:, j_start], region[:, j_end + 1]):
-            vt = vtmp
+    vtmp = vt
+    with horizontal(region[:, local_js - 1 : local_je + 3]):
+        vt = (
+            vc - 0.25 * cosa_v * (uc[0, -1, 0] + uc[1, -1, 0] + uc + uc[1, 0, 0])
+        ) * rsin_v
+    with horizontal(region[:, j_start], region[:, j_end + 1]):
+        vt = vtmp
+    return vt
 
 
+@gtscript.function
 def ut_y_edge(
     uc: FloatField,
     sin_sg1: FloatFieldIJ,
@@ -59,31 +61,33 @@ def ut_y_edge(
 ):
     from __externals__ import i_end, i_start
 
-    with computation(PARALLEL), interval(...):
-        with horizontal(region[i_start, :], region[i_end + 1, :]):
-            ut = (uc / sin_sg3[-1, 0]) if (uc * dt > 0) else (uc / sin_sg1)
+    with horizontal(region[i_start, :], region[i_end + 1, :]):
+        ut = (uc / sin_sg3[-1, 0]) if (uc * dt > 0) else (uc / sin_sg1)
+    return ut
 
 
+@gtscript.function
 def ut_x_edge(uc: FloatField, cosa_u: FloatFieldIJ, vt: FloatField, ut: FloatField):
     from __externals__ import i_end, i_start, j_end, j_start, local_ie, local_is
 
-    with computation(PARALLEL), interval(...):
-        # TODO: parallel to what done for the vt_y_edge section
-        utmp = ut
-        with horizontal(
-            region[local_is : local_ie + 2, j_start - 1 : j_start + 1],
-            region[local_is : local_ie + 2, j_end : j_end + 2],
-        ):
-            ut = uc - 0.25 * cosa_u * (vt[-1, 0, 0] + vt + vt[-1, 1, 0] + vt[0, 1, 0])
-        with horizontal(
-            region[i_start : i_start + 2, j_start - 1 : j_start + 1],
-            region[i_start : i_start + 2, j_end : j_end + 2],
-            region[i_end : i_end + 2, j_start - 1 : j_start + 1],
-            region[i_end : i_end + 2, j_end : j_end + 2],
-        ):
-            ut = utmp
+    # TODO: parallel to what done for the vt_y_edge section
+    utmp = ut
+    with horizontal(
+        region[local_is : local_ie + 2, j_start - 1 : j_start + 1],
+        region[local_is : local_ie + 2, j_end : j_end + 2],
+    ):
+        ut = uc - 0.25 * cosa_u * (vt[-1, 0, 0] + vt + vt[-1, 1, 0] + vt[0, 1, 0])
+    with horizontal(
+        region[i_start : i_start + 2, j_start - 1 : j_start + 1],
+        region[i_start : i_start + 2, j_end : j_end + 2],
+        region[i_end : i_end + 2, j_start - 1 : j_start + 1],
+        region[i_end : i_end + 2, j_end : j_end + 2],
+    ):
+        ut = utmp
+    return ut
 
 
+@gtscript.function
 def vt_y_edge(vc: FloatField, cosa_v: FloatFieldIJ, ut: FloatField, vt: FloatField):
     from __externals__ import i_end, i_start, j_end, j_start, local_je, local_js
 
@@ -101,22 +105,23 @@ def vt_y_edge(vc: FloatField, cosa_v: FloatFieldIJ, ut: FloatField, vt: FloatFie
     # rank 0, 1, 2: local_js + 2:local_je + 2
     # rank 3, 4, 5: local_js:local_je + 2
     # rank 6, 7, 8: local_js:local_je
-    with computation(PARALLEL), interval(...):
-        vtmp = vt
-        with horizontal(
-            region[i_start - 1 : i_start + 1, local_js : local_je + 2],
-            region[i_end : i_end + 2, local_js : local_je + 2],
-        ):
-            vt = vc - 0.25 * cosa_v * (ut[0, -1, 0] + ut[1, -1, 0] + ut + ut[1, 0, 0])
-        with horizontal(
-            region[i_start - 1 : i_start + 1, j_start : j_start + 2],
-            region[i_end : i_end + 2, j_start : j_start + 2],
-            region[i_start - 1 : i_start + 1, j_end : j_end + 2],
-            region[i_end : i_end + 2, j_end : j_end + 2],
-        ):
-            vt = vtmp
+    vtmp = vt
+    with horizontal(
+        region[i_start - 1 : i_start + 1, local_js : local_je + 2],
+        region[i_end : i_end + 2, local_js : local_je + 2],
+    ):
+        vt = vc - 0.25 * cosa_v * (ut[0, -1, 0] + ut[1, -1, 0] + ut + ut[1, 0, 0])
+    with horizontal(
+        region[i_start - 1 : i_start + 1, j_start : j_start + 2],
+        region[i_end : i_end + 2, j_start : j_start + 2],
+        region[i_start - 1 : i_start + 1, j_end : j_end + 2],
+        region[i_end : i_end + 2, j_end : j_end + 2],
+    ):
+        vt = vtmp
+    return vt
 
 
+@gtscript.function
 def vt_x_edge(
     vc: FloatField,
     sin_sg2: FloatFieldIJ,
@@ -126,11 +131,12 @@ def vt_x_edge(
 ):
     from __externals__ import j_end, j_start
 
-    with computation(PARALLEL), interval(...):
-        with horizontal(region[:, j_start], region[:, j_end + 1]):
-            vt = (vc / sin_sg4[0, -1]) if (vc * dt > 0) else (vc / sin_sg2)
+    with horizontal(region[:, j_start], region[:, j_end + 1]):
+        vt = (vc / sin_sg4[0, -1]) if (vc * dt > 0) else (vc / sin_sg2)
+    return vt
 
 
+@gtscript.function
 def ut_corners(
     cosa_u: FloatFieldIJ,
     cosa_v: FloatFieldIJ,
@@ -154,68 +160,67 @@ def ut_corners(
     """
     from __externals__ import i_end, i_start, j_end, j_start
 
-    with computation(PARALLEL), interval(...):
-        damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 0])
-        with horizontal(region[i_start + 1, j_start - 1], region[i_start + 1, j_end]):
-            ut = (
-                uc
-                - 0.25
-                * cosa_u
-                * (
-                    vt[-1, 1, 0]
-                    + vt[0, 1, 0]
-                    + vt
-                    + vc[-1, 0, 0]
-                    - 0.25
-                    * cosa_v[-1, 0]
-                    * (ut[-1, 0, 0] + ut[-1, -1, 0] + ut[0, -1, 0])
-                )
-            ) * damp
+    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 0])
+    with horizontal(region[i_start + 1, j_start - 1], region[i_start + 1, j_end]):
+        ut = (
+            uc
+            - 0.25
+            * cosa_u
+            * (
+                vt[-1, 1, 0]
+                + vt[0, 1, 0]
+                + vt
+                + vc[-1, 0, 0]
+                - 0.25 * cosa_v[-1, 0] * (ut[-1, 0, 0] + ut[-1, -1, 0] + ut[0, -1, 0])
+            )
+        ) * damp
+    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 1])
+    with horizontal(region[i_start + 1, j_start], region[i_start + 1, j_end + 1]):
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 1])
-        with horizontal(region[i_start + 1, j_start], region[i_start + 1, j_end + 1]):
-            damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 1])
-            ut = (
-                uc
-                - 0.25
-                * cosa_u
-                * (
-                    vt[-1, 0, 0]
-                    + vt
-                    + vt[0, 1, 0]
-                    + vc[-1, 1, 0]
-                    - 0.25 * cosa_v[-1, 1] * (ut[-1, 0, 0] + ut[-1, 1, 0] + ut[0, 1, 0])
-                )
-            ) * damp
-        damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
-        with horizontal(region[i_end, j_start - 1], region[i_end, j_end]):
-            ut = (
-                uc
-                - 0.25
-                * cosa_u
-                * (
-                    vt[0, 1, 0]
-                    + vt[-1, 1, 0]
-                    + vt[-1, 0, 0]
-                    + vc
-                    - 0.25 * cosa_v * (ut[1, 0, 0] + ut[1, -1, 0] + ut[0, -1, 0])
-                )
-            ) * damp
-        damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[0, 1])
-        with horizontal(region[i_end, j_start], region[i_end, j_end + 1]):
-            ut = (
-                uc
-                - 0.25
-                * cosa_u
-                * (
-                    vt
-                    + vt[-1, 0, 0]
-                    + vt[-1, 1, 0]
-                    + vc[0, 1, 0]
-                    - 0.25 * cosa_v[0, 1] * (ut[1, 0, 0] + ut[1, 1, 0] + ut[0, 1, 0])
-                )
-            ) * damp
+        ut = (
+            uc
+            - 0.25
+            * cosa_u
+            * (
+                vt[-1, 0, 0]
+                + vt
+                + vt[0, 1, 0]
+                + vc[-1, 1, 0]
+                - 0.25 * cosa_v[-1, 1] * (ut[-1, 0, 0] + ut[-1, 1, 0] + ut[0, 1, 0])
+            )
+        ) * damp
+    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
+    with horizontal(region[i_end, j_start - 1], region[i_end, j_end]):
+        ut = (
+            uc
+            - 0.25
+            * cosa_u
+            * (
+                vt[0, 1, 0]
+                + vt[-1, 1, 0]
+                + vt[-1, 0, 0]
+                + vc
+                - 0.25 * cosa_v * (ut[1, 0, 0] + ut[1, -1, 0] + ut[0, -1, 0])
+            )
+        ) * damp
+    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[0, 1])
+    with horizontal(region[i_end, j_start], region[i_end, j_end + 1]):
+        ut = (
+            uc
+            - 0.25
+            * cosa_u
+            * (
+                vt
+                + vt[-1, 0, 0]
+                + vt[-1, 1, 0]
+                + vc[0, 1, 0]
+                - 0.25 * cosa_v[0, 1] * (ut[1, 0, 0] + ut[1, 1, 0] + ut[0, 1, 0])
+            )
+        ) * damp
+    return ut
 
 
+@gtscript.function
 def vt_corners(
     cosa_u: FloatFieldIJ,
     cosa_v: FloatFieldIJ,
@@ -226,68 +231,65 @@ def vt_corners(
 ):
     from __externals__ import i_end, i_start, j_end, j_start
 
-    with computation(PARALLEL), interval(...):
-        damp = 1.0 / (1.0 - 0.0625 * cosa_u[0, -1] * cosa_v)
-        with horizontal(region[i_start - 1, j_start + 1], region[i_end, j_start + 1]):
-            vt = (
-                vc
-                - 0.25
-                * cosa_v
-                * (
-                    ut[1, -1, 0]
-                    + ut[1, 0, 0]
-                    + ut
-                    + uc[0, -1, 0]
-                    - 0.25
-                    * cosa_u[0, -1]
-                    * (vt[0, -1, 0] + vt[-1, -1, 0] + vt[-1, 0, 0])
-                )
-            ) * damp
-        damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, -1] * cosa_v)
-        with horizontal(region[i_start, j_start + 1], region[i_end + 1, j_start + 1]):
-            vt = (
-                vc
-                - 0.25
-                * cosa_v
-                * (
-                    ut[0, -1, 0]
-                    + ut
-                    + ut[1, 0, 0]
-                    + uc[1, -1, 0]
-                    - 0.25 * cosa_u[1, -1] * (vt[0, -1, 0] + vt[1, -1, 0] + vt[1, 0, 0])
-                )
-            ) * damp
-        damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, 0] * cosa_v)
-        with horizontal(region[i_end + 1, j_end], region[i_start, j_end]):
-            vt = (
-                vc
-                - 0.25
-                * cosa_v
-                * (
-                    ut
-                    + ut[0, -1, 0]
-                    + ut[1, -1, 0]
-                    + uc[1, 0, 0]
-                    - 0.25 * cosa_u[1, 0] * (vt[0, 1, 0] + vt[1, 1, 0] + vt[1, 0, 0])
-                )
-            ) * damp
-        damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
-        with horizontal(region[i_end, j_end], region[i_start - 1, j_end]):
-            vt = (
-                vc
-                - 0.25
-                * cosa_v
-                * (
-                    ut[1, 0, 0]
-                    + ut[1, -1, 0]
-                    + ut[0, -1, 0]
-                    + uc
-                    - 0.25 * cosa_u * (vt[0, 1, 0] + vt[-1, 1, 0] + vt[-1, 0, 0])
-                )
-            ) * damp
+    damp = 1.0 / (1.0 - 0.0625 * cosa_u[0, -1] * cosa_v)
+    with horizontal(region[i_start - 1, j_start + 1], region[i_end, j_start + 1]):
+        vt = (
+            vc
+            - 0.25
+            * cosa_v
+            * (
+                ut[1, -1, 0]
+                + ut[1, 0, 0]
+                + ut
+                + uc[0, -1, 0]
+                - 0.25 * cosa_u[0, -1] * (vt[0, -1, 0] + vt[-1, -1, 0] + vt[-1, 0, 0])
+            )
+        ) * damp
+    damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, -1] * cosa_v)
+    with horizontal(region[i_start, j_start + 1], region[i_end + 1, j_start + 1]):
+        vt = (
+            vc
+            - 0.25
+            * cosa_v
+            * (
+                ut[0, -1, 0]
+                + ut
+                + ut[1, 0, 0]
+                + uc[1, -1, 0]
+                - 0.25 * cosa_u[1, -1] * (vt[0, -1, 0] + vt[1, -1, 0] + vt[1, 0, 0])
+            )
+        ) * damp
+    damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, 0] * cosa_v)
+    with horizontal(region[i_end + 1, j_end], region[i_start, j_end]):
+        vt = (
+            vc
+            - 0.25
+            * cosa_v
+            * (
+                ut
+                + ut[0, -1, 0]
+                + ut[1, -1, 0]
+                + uc[1, 0, 0]
+                - 0.25 * cosa_u[1, 0] * (vt[0, 1, 0] + vt[1, 1, 0] + vt[1, 0, 0])
+            )
+        ) * damp
+    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
+    with horizontal(region[i_end, j_end], region[i_start - 1, j_end]):
+        vt = (
+            vc
+            - 0.25
+            * cosa_v
+            * (
+                ut[1, 0, 0]
+                + ut[1, -1, 0]
+                + ut[0, -1, 0]
+                + uc
+                - 0.25 * cosa_u * (vt[0, 1, 0] + vt[-1, 1, 0] + vt[-1, 0, 0])
+            )
+        ) * damp
+    return vt
 
 
-"""
 # Single stencil version to use when possible with gt backends
 def fxadv_stencil(
     cosa_u: FloatFieldIJ,
@@ -304,6 +306,8 @@ def fxadv_stencil(
     vt: FloatField,
     dt: float,
 ):
+    # from __externals__ import i_end, i_start, j_end, j_start, local_ie, local_is
+
     with computation(PARALLEL), interval(...):
         ut = main_ut(uc, vc, cosa_u, rsin_u, ut)
         ut = ut_y_edge(uc, sin_sg1, sin_sg3, ut, dt)
@@ -311,9 +315,21 @@ def fxadv_stencil(
         vt = vt_y_edge(vc, cosa_v, ut, vt)
         vt = vt_x_edge(vc, sin_sg2, sin_sg4, vt, dt)
         ut = ut_x_edge(uc, cosa_u, vt, ut)
+
+
+def fxadv_corners_stencil(
+    uc: FloatField,
+    vc: FloatField,
+    ut: FloatField,
+    vt: FloatField,
+    cosa_u: FloatFieldIJ,
+    cosa_v: FloatFieldIJ,
+):
+    # from __externals__ import i_end, i_start, j_end, j_start, local_ie, local_is
+
+    with computation(PARALLEL), interval(...):
         ut = ut_corners(uc, vc, cosa_u, cosa_v, ut, vt)
         vt = vt_corners(uc, vc, cosa_u, cosa_v, ut, vt)
-"""
 
 
 def fxadv_fluxes_stencil(
@@ -356,7 +372,7 @@ def fxadv_fluxes_stencil(
 
 class FiniteVolumeFluxPrep:
     """
-    A large section of code near the beginning of Fortran's d_sw subroutinw
+    A large section of code near the beginning of Fortran's d_sw subroutine
     Known in this repo as FxAdv,
     """
 
@@ -374,14 +390,18 @@ class FiniteVolumeFluxPrep:
             "origin": origin_corners,
             "domain": domain_corners,
         }
-        self._main_ut_stencil = FrozenStencil(main_ut, **kwargs)
-        self._main_vt_stencil = FrozenStencil(main_vt, **kwargs)
-        self._ut_y_edge_stencil = FrozenStencil(ut_y_edge, **kwargs)
-        self._vt_y_edge_stencil = FrozenStencil(vt_y_edge, **kwargs)
-        self._ut_x_edge_stencil = FrozenStencil(ut_x_edge, **kwargs)
-        self._vt_x_edge_stencil = FrozenStencil(vt_x_edge, **kwargs)
-        self._ut_corners_stencil = FrozenStencil(ut_corners, **kwargs_corners)
-        self._vt_corners_stencil = FrozenStencil(vt_corners, **kwargs_corners)
+        # self._main_ut_stencil = FrozenStencil(main_ut, **kwargs)
+        # self._main_vt_stencil = FrozenStencil(main_vt, **kwargs)
+        # self._ut_y_edge_stencil = FrozenStencil(ut_y_edge, **kwargs)
+        # self._vt_y_edge_stencil = FrozenStencil(vt_y_edge, **kwargs)
+        # self._ut_x_edge_stencil = FrozenStencil(ut_x_edge, **kwargs)
+        # self._vt_x_edge_stencil = FrozenStencil(vt_x_edge, **kwargs)
+        self._fxadv_stencil = FrozenStencil(fxadv_stencil, **kwargs)
+        # self._ut_corners_stencil = FrozenStencil(ut_corners, **kwargs_corners)
+        # self._vt_corners_stencil = FrozenStencil(vt_corners, **kwargs_corners)
+        self._fxadv_corners_stencil = FrozenStencil(
+            fxadv_corners_stencil, **kwargs_corners
+        )
         self._fxadv_fluxes_stencil = FrozenStencil(fxadv_fluxes_stencil, **kwargs)
 
     def __call__(
@@ -418,62 +438,85 @@ class FiniteVolumeFluxPrep:
             cosa_u, cosa_v, rsin_u, rsin_v, sin_sg1,sin_sg2, sin_sg3, sin_sg4, dx, dy
         """
 
-        self._main_ut_stencil(
-            uc,
-            vc,
+        # self._main_ut_stencil(
+        #     uc,
+        #     vc,
+        #     self.grid.cosa_u,
+        #     self.grid.rsin_u,
+        #     ut,
+        # )
+        # self._ut_y_edge_stencil(
+        #     uc,
+        #     self.grid.sin_sg1,
+        #     self.grid.sin_sg3,
+        #     ut,
+        #     dt,
+        # )
+        # self._main_vt_stencil(
+        #     uc,
+        #     vc,
+        #     self.grid.cosa_v,
+        #     self.grid.rsin_v,
+        #     vt,
+        # )
+        # self._vt_y_edge_stencil(
+        #     vc,
+        #     self.grid.cosa_v,
+        #     ut,
+        #     vt,
+        # )
+        # self._vt_x_edge_stencil(
+        #     vc,
+        #     self.grid.sin_sg2,
+        #     self.grid.sin_sg4,
+        #     vt,
+        #     dt,
+        # )
+        # self._ut_x_edge_stencil(
+        #     uc,
+        #     self.grid.cosa_u,
+        #     vt,
+        #     ut,
+        # )
+        self._fxadv_stencil(
             self.grid.cosa_u,
+            self.grid.cosa_v,
             self.grid.rsin_u,
-            ut,
-        )
-        self._ut_y_edge_stencil(
-            uc,
-            self.grid.sin_sg1,
-            self.grid.sin_sg3,
-            ut,
-            dt,
-        )
-        self._main_vt_stencil(
-            uc,
-            vc,
-            self.grid.cosa_v,
             self.grid.rsin_v,
-            vt,
-        )
-        self._vt_y_edge_stencil(
-            vc,
-            self.grid.cosa_v,
-            ut,
-            vt,
-        )
-        self._vt_x_edge_stencil(
-            vc,
+            self.grid.sin_sg1,
             self.grid.sin_sg2,
+            self.grid.sin_sg3,
             self.grid.sin_sg4,
+            uc,
+            vc,
+            ut,
             vt,
             dt,
         )
-        self._ut_x_edge_stencil(
-            uc,
-            self.grid.cosa_u,
-            vt,
-            ut,
-        )
-        self._ut_corners_stencil(
-            self.grid.cosa_u,
-            self.grid.cosa_v,
+        self._fxadv_corners_stencil(
             uc,
             vc,
             ut,
             vt,
-        )
-        self._vt_corners_stencil(
             self.grid.cosa_u,
             self.grid.cosa_v,
-            uc,
-            vc,
-            ut,
-            vt,
         )
+        # self._ut_corners_stencil(
+        #     self.grid.cosa_u,
+        #     self.grid.cosa_v,
+        #     uc,
+        #     vc,
+        #     ut,
+        #     vt,
+        # )
+        # self._vt_corners_stencil(
+        #     self.grid.cosa_u,
+        #     self.grid.cosa_v,
+        #     uc,
+        #     vc,
+        #     ut,
+        #     vt,
+        # )
         self._fxadv_fluxes_stencil(
             self.grid.sin_sg1,
             self.grid.sin_sg2,

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -306,7 +306,6 @@ def fxadv_stencil(
     vt: FloatField,
     dt: float,
 ):
-    # from __externals__ import i_end, i_start, j_end, j_start, local_ie, local_is
 
     with computation(PARALLEL), interval(...):
         ut = main_ut(uc, vc, cosa_u, rsin_u, ut)
@@ -325,7 +324,6 @@ def fxadv_corners_stencil(
     cosa_u: FloatFieldIJ,
     cosa_v: FloatFieldIJ,
 ):
-    # from __externals__ import i_end, i_start, j_end, j_start, local_ie, local_is
 
     with computation(PARALLEL), interval(...):
         ut = ut_corners(cosa_u, cosa_v, uc, vc, ut, vt)
@@ -390,15 +388,7 @@ class FiniteVolumeFluxPrep:
             "origin": origin_corners,
             "domain": domain_corners,
         }
-        # self._main_ut_stencil = FrozenStencil(main_ut, **kwargs)
-        # self._main_vt_stencil = FrozenStencil(main_vt, **kwargs)
-        # self._ut_y_edge_stencil = FrozenStencil(ut_y_edge, **kwargs)
-        # self._vt_y_edge_stencil = FrozenStencil(vt_y_edge, **kwargs)
-        # self._ut_x_edge_stencil = FrozenStencil(ut_x_edge, **kwargs)
-        # self._vt_x_edge_stencil = FrozenStencil(vt_x_edge, **kwargs)
         self._fxadv_stencil = FrozenStencil(fxadv_stencil, **kwargs)
-        # self._ut_corners_stencil = FrozenStencil(ut_corners, **kwargs_corners)
-        # self._vt_corners_stencil = FrozenStencil(vt_corners, **kwargs_corners)
         self._fxadv_corners_stencil = FrozenStencil(
             fxadv_corners_stencil, **kwargs_corners
         )
@@ -438,46 +428,6 @@ class FiniteVolumeFluxPrep:
             cosa_u, cosa_v, rsin_u, rsin_v, sin_sg1,sin_sg2, sin_sg3, sin_sg4, dx, dy
         """
 
-        # self._main_ut_stencil(
-        #     uc,
-        #     vc,
-        #     self.grid.cosa_u,
-        #     self.grid.rsin_u,
-        #     ut,
-        # )
-        # self._ut_y_edge_stencil(
-        #     uc,
-        #     self.grid.sin_sg1,
-        #     self.grid.sin_sg3,
-        #     ut,
-        #     dt,
-        # )
-        # self._main_vt_stencil(
-        #     uc,
-        #     vc,
-        #     self.grid.cosa_v,
-        #     self.grid.rsin_v,
-        #     vt,
-        # )
-        # self._vt_y_edge_stencil(
-        #     vc,
-        #     self.grid.cosa_v,
-        #     ut,
-        #     vt,
-        # )
-        # self._vt_x_edge_stencil(
-        #     vc,
-        #     self.grid.sin_sg2,
-        #     self.grid.sin_sg4,
-        #     vt,
-        #     dt,
-        # )
-        # self._ut_x_edge_stencil(
-        #     uc,
-        #     self.grid.cosa_u,
-        #     vt,
-        #     ut,
-        # )
         self._fxadv_stencil(
             self.grid.cosa_u,
             self.grid.cosa_v,
@@ -501,22 +451,6 @@ class FiniteVolumeFluxPrep:
             self.grid.cosa_u,
             self.grid.cosa_v,
         )
-        # self._ut_corners_stencil(
-        #     self.grid.cosa_u,
-        #     self.grid.cosa_v,
-        #     uc,
-        #     vc,
-        #     ut,
-        #     vt,
-        # )
-        # self._vt_corners_stencil(
-        #     self.grid.cosa_u,
-        #     self.grid.cosa_v,
-        #     uc,
-        #     vc,
-        #     ut,
-        #     vt,
-        # )
         self._fxadv_fluxes_stencil(
             self.grid.sin_sg1,
             self.grid.sin_sg2,

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -1,4 +1,3 @@
-from gt4py import gtscript
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
 import fv3core._config as spec
@@ -9,7 +8,6 @@ from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 # TODO: the mix of local and global regions is strange here
 # it's a workaround to specify DON'T do this calculation if on the tile edge
-@gtscript.function
 def main_ut(
     uc: FloatField,
     vc: FloatField,
@@ -19,19 +17,20 @@ def main_ut(
 ):
     from __externals__ import j_end, j_start, local_ie, local_is
 
-    utmp = ut
-    with horizontal(region[local_is - 1 : local_ie + 3, :]):
-        ut = (
-            uc - 0.25 * cosa_u * (vc[-1, 0, 0] + vc + vc[-1, 1, 0] + vc[0, 1, 0])
-        ) * rsin_u
-    with horizontal(region[:, j_start - 1 : j_start + 1], region[:, j_end : j_end + 2]):
-        ut = utmp
-    return ut
+    with computation(PARALLEL), interval(...):
+        utmp = ut
+        with horizontal(region[local_is - 1 : local_ie + 3, :]):
+            ut = (
+                uc - 0.25 * cosa_u * (vc[-1, 0, 0] + vc + vc[-1, 1, 0] + vc[0, 1, 0])
+            ) * rsin_u
+        with horizontal(
+            region[:, j_start - 1 : j_start + 1], region[:, j_end : j_end + 2]
+        ):
+            ut = utmp
 
 
 # TODO: the mix of local and global regions is strange here
 # it's a workaround to specify DON'T do this calculation if on the tile edge
-@gtscript.function
 def main_vt(
     uc: FloatField,
     vc: FloatField,
@@ -41,17 +40,16 @@ def main_vt(
 ):
     from __externals__ import j_end, j_start, local_je, local_js
 
-    vtmp = vt
-    with horizontal(region[:, local_js - 1 : local_je + 3]):
-        vt = (
-            vc - 0.25 * cosa_v * (uc[0, -1, 0] + uc[1, -1, 0] + uc + uc[1, 0, 0])
-        ) * rsin_v
-    with horizontal(region[:, j_start], region[:, j_end + 1]):
-        vt = vtmp
-    return vt
+    with computation(PARALLEL), interval(...):
+        vtmp = vt
+        with horizontal(region[:, local_js - 1 : local_je + 3]):
+            vt = (
+                vc - 0.25 * cosa_v * (uc[0, -1, 0] + uc[1, -1, 0] + uc + uc[1, 0, 0])
+            ) * rsin_v
+        with horizontal(region[:, j_start], region[:, j_end + 1]):
+            vt = vtmp
 
 
-@gtscript.function
 def ut_y_edge(
     uc: FloatField,
     sin_sg1: FloatFieldIJ,
@@ -61,33 +59,31 @@ def ut_y_edge(
 ):
     from __externals__ import i_end, i_start
 
-    with horizontal(region[i_start, :], region[i_end + 1, :]):
-        ut = (uc / sin_sg3[-1, 0]) if (uc * dt > 0) else (uc / sin_sg1)
-    return ut
+    with computation(PARALLEL), interval(...):
+        with horizontal(region[i_start, :], region[i_end + 1, :]):
+            ut = (uc / sin_sg3[-1, 0]) if (uc * dt > 0) else (uc / sin_sg1)
 
 
-@gtscript.function
 def ut_x_edge(uc: FloatField, cosa_u: FloatFieldIJ, vt: FloatField, ut: FloatField):
     from __externals__ import i_end, i_start, j_end, j_start, local_ie, local_is
 
-    # TODO: parallel to what done for the vt_y_edge section
-    utmp = ut
-    with horizontal(
-        region[local_is : local_ie + 2, j_start - 1 : j_start + 1],
-        region[local_is : local_ie + 2, j_end : j_end + 2],
-    ):
-        ut = uc - 0.25 * cosa_u * (vt[-1, 0, 0] + vt + vt[-1, 1, 0] + vt[0, 1, 0])
-    with horizontal(
-        region[i_start : i_start + 2, j_start - 1 : j_start + 1],
-        region[i_start : i_start + 2, j_end : j_end + 2],
-        region[i_end : i_end + 2, j_start - 1 : j_start + 1],
-        region[i_end : i_end + 2, j_end : j_end + 2],
-    ):
-        ut = utmp
-    return ut
+    with computation(PARALLEL), interval(...):
+        # TODO: parallel to what done for the vt_y_edge section
+        utmp = ut
+        with horizontal(
+            region[local_is : local_ie + 2, j_start - 1 : j_start + 1],
+            region[local_is : local_ie + 2, j_end : j_end + 2],
+        ):
+            ut = uc - 0.25 * cosa_u * (vt[-1, 0, 0] + vt + vt[-1, 1, 0] + vt[0, 1, 0])
+        with horizontal(
+            region[i_start : i_start + 2, j_start - 1 : j_start + 1],
+            region[i_start : i_start + 2, j_end : j_end + 2],
+            region[i_end : i_end + 2, j_start - 1 : j_start + 1],
+            region[i_end : i_end + 2, j_end : j_end + 2],
+        ):
+            ut = utmp
 
 
-@gtscript.function
 def vt_y_edge(vc: FloatField, cosa_v: FloatFieldIJ, ut: FloatField, vt: FloatField):
     from __externals__ import i_end, i_start, j_end, j_start, local_je, local_js
 
@@ -105,23 +101,22 @@ def vt_y_edge(vc: FloatField, cosa_v: FloatFieldIJ, ut: FloatField, vt: FloatFie
     # rank 0, 1, 2: local_js + 2:local_je + 2
     # rank 3, 4, 5: local_js:local_je + 2
     # rank 6, 7, 8: local_js:local_je
-    vtmp = vt
-    with horizontal(
-        region[i_start - 1 : i_start + 1, local_js : local_je + 2],
-        region[i_end : i_end + 2, local_js : local_je + 2],
-    ):
-        vt = vc - 0.25 * cosa_v * (ut[0, -1, 0] + ut[1, -1, 0] + ut + ut[1, 0, 0])
-    with horizontal(
-        region[i_start - 1 : i_start + 1, j_start : j_start + 2],
-        region[i_end : i_end + 2, j_start : j_start + 2],
-        region[i_start - 1 : i_start + 1, j_end : j_end + 2],
-        region[i_end : i_end + 2, j_end : j_end + 2],
-    ):
-        vt = vtmp
-    return vt
+    with computation(PARALLEL), interval(...):
+        vtmp = vt
+        with horizontal(
+            region[i_start - 1 : i_start + 1, local_js : local_je + 2],
+            region[i_end : i_end + 2, local_js : local_je + 2],
+        ):
+            vt = vc - 0.25 * cosa_v * (ut[0, -1, 0] + ut[1, -1, 0] + ut + ut[1, 0, 0])
+        with horizontal(
+            region[i_start - 1 : i_start + 1, j_start : j_start + 2],
+            region[i_end : i_end + 2, j_start : j_start + 2],
+            region[i_start - 1 : i_start + 1, j_end : j_end + 2],
+            region[i_end : i_end + 2, j_end : j_end + 2],
+        ):
+            vt = vtmp
 
 
-@gtscript.function
 def vt_x_edge(
     vc: FloatField,
     sin_sg2: FloatFieldIJ,
@@ -131,12 +126,11 @@ def vt_x_edge(
 ):
     from __externals__ import j_end, j_start
 
-    with horizontal(region[:, j_start], region[:, j_end + 1]):
-        vt = (vc / sin_sg4[0, -1]) if (vc * dt > 0) else (vc / sin_sg2)
-    return vt
+    with computation(PARALLEL), interval(...):
+        with horizontal(region[:, j_start], region[:, j_end + 1]):
+            vt = (vc / sin_sg4[0, -1]) if (vc * dt > 0) else (vc / sin_sg2)
 
 
-@gtscript.function
 def ut_corners(
     cosa_u: FloatFieldIJ,
     cosa_v: FloatFieldIJ,
@@ -160,67 +154,68 @@ def ut_corners(
     """
     from __externals__ import i_end, i_start, j_end, j_start
 
-    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 0])
-    with horizontal(region[i_start + 1, j_start - 1], region[i_start + 1, j_end]):
-        ut = (
-            uc
-            - 0.25
-            * cosa_u
-            * (
-                vt[-1, 1, 0]
-                + vt[0, 1, 0]
-                + vt
-                + vc[-1, 0, 0]
-                - 0.25 * cosa_v[-1, 0] * (ut[-1, 0, 0] + ut[-1, -1, 0] + ut[0, -1, 0])
-            )
-        ) * damp
-    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 1])
-    with horizontal(region[i_start + 1, j_start], region[i_start + 1, j_end + 1]):
+    with computation(PARALLEL), interval(...):
+        damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 0])
+        with horizontal(region[i_start + 1, j_start - 1], region[i_start + 1, j_end]):
+            ut = (
+                uc
+                - 0.25
+                * cosa_u
+                * (
+                    vt[-1, 1, 0]
+                    + vt[0, 1, 0]
+                    + vt
+                    + vc[-1, 0, 0]
+                    - 0.25
+                    * cosa_v[-1, 0]
+                    * (ut[-1, 0, 0] + ut[-1, -1, 0] + ut[0, -1, 0])
+                )
+            ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 1])
-        ut = (
-            uc
-            - 0.25
-            * cosa_u
-            * (
-                vt[-1, 0, 0]
-                + vt
-                + vt[0, 1, 0]
-                + vc[-1, 1, 0]
-                - 0.25 * cosa_v[-1, 1] * (ut[-1, 0, 0] + ut[-1, 1, 0] + ut[0, 1, 0])
-            )
-        ) * damp
-    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
-    with horizontal(region[i_end, j_start - 1], region[i_end, j_end]):
-        ut = (
-            uc
-            - 0.25
-            * cosa_u
-            * (
-                vt[0, 1, 0]
-                + vt[-1, 1, 0]
-                + vt[-1, 0, 0]
-                + vc
-                - 0.25 * cosa_v * (ut[1, 0, 0] + ut[1, -1, 0] + ut[0, -1, 0])
-            )
-        ) * damp
-    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[0, 1])
-    with horizontal(region[i_end, j_start], region[i_end, j_end + 1]):
-        ut = (
-            uc
-            - 0.25
-            * cosa_u
-            * (
-                vt
-                + vt[-1, 0, 0]
-                + vt[-1, 1, 0]
-                + vc[0, 1, 0]
-                - 0.25 * cosa_v[0, 1] * (ut[1, 0, 0] + ut[1, 1, 0] + ut[0, 1, 0])
-            )
-        ) * damp
-    return ut
+        with horizontal(region[i_start + 1, j_start], region[i_start + 1, j_end + 1]):
+            damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 1])
+            ut = (
+                uc
+                - 0.25
+                * cosa_u
+                * (
+                    vt[-1, 0, 0]
+                    + vt
+                    + vt[0, 1, 0]
+                    + vc[-1, 1, 0]
+                    - 0.25 * cosa_v[-1, 1] * (ut[-1, 0, 0] + ut[-1, 1, 0] + ut[0, 1, 0])
+                )
+            ) * damp
+        damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
+        with horizontal(region[i_end, j_start - 1], region[i_end, j_end]):
+            ut = (
+                uc
+                - 0.25
+                * cosa_u
+                * (
+                    vt[0, 1, 0]
+                    + vt[-1, 1, 0]
+                    + vt[-1, 0, 0]
+                    + vc
+                    - 0.25 * cosa_v * (ut[1, 0, 0] + ut[1, -1, 0] + ut[0, -1, 0])
+                )
+            ) * damp
+        damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[0, 1])
+        with horizontal(region[i_end, j_start], region[i_end, j_end + 1]):
+            ut = (
+                uc
+                - 0.25
+                * cosa_u
+                * (
+                    vt
+                    + vt[-1, 0, 0]
+                    + vt[-1, 1, 0]
+                    + vc[0, 1, 0]
+                    - 0.25 * cosa_v[0, 1] * (ut[1, 0, 0] + ut[1, 1, 0] + ut[0, 1, 0])
+                )
+            ) * damp
 
 
-@gtscript.function
 def vt_corners(
     cosa_u: FloatFieldIJ,
     cosa_v: FloatFieldIJ,
@@ -231,65 +226,69 @@ def vt_corners(
 ):
     from __externals__ import i_end, i_start, j_end, j_start
 
-    damp = 1.0 / (1.0 - 0.0625 * cosa_u[0, -1] * cosa_v)
-    with horizontal(region[i_start - 1, j_start + 1], region[i_end, j_start + 1]):
-        vt = (
-            vc
-            - 0.25
-            * cosa_v
-            * (
-                ut[1, -1, 0]
-                + ut[1, 0, 0]
-                + ut
-                + uc[0, -1, 0]
-                - 0.25 * cosa_u[0, -1] * (vt[0, -1, 0] + vt[-1, -1, 0] + vt[-1, 0, 0])
-            )
-        ) * damp
-    damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, -1] * cosa_v)
-    with horizontal(region[i_start, j_start + 1], region[i_end + 1, j_start + 1]):
-        vt = (
-            vc
-            - 0.25
-            * cosa_v
-            * (
-                ut[0, -1, 0]
-                + ut
-                + ut[1, 0, 0]
-                + uc[1, -1, 0]
-                - 0.25 * cosa_u[1, -1] * (vt[0, -1, 0] + vt[1, -1, 0] + vt[1, 0, 0])
-            )
-        ) * damp
-    damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, 0] * cosa_v)
-    with horizontal(region[i_end + 1, j_end], region[i_start, j_end]):
-        vt = (
-            vc
-            - 0.25
-            * cosa_v
-            * (
-                ut
-                + ut[0, -1, 0]
-                + ut[1, -1, 0]
-                + uc[1, 0, 0]
-                - 0.25 * cosa_u[1, 0] * (vt[0, 1, 0] + vt[1, 1, 0] + vt[1, 0, 0])
-            )
-        ) * damp
-    damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
-    with horizontal(region[i_end, j_end], region[i_start - 1, j_end]):
-        vt = (
-            vc
-            - 0.25
-            * cosa_v
-            * (
-                ut[1, 0, 0]
-                + ut[1, -1, 0]
-                + ut[0, -1, 0]
-                + uc
-                - 0.25 * cosa_u * (vt[0, 1, 0] + vt[-1, 1, 0] + vt[-1, 0, 0])
-            )
-        ) * damp
-    return vt
+    with computation(PARALLEL), interval(...):
+        damp = 1.0 / (1.0 - 0.0625 * cosa_u[0, -1] * cosa_v)
+        with horizontal(region[i_start - 1, j_start + 1], region[i_end, j_start + 1]):
+            vt = (
+                vc
+                - 0.25
+                * cosa_v
+                * (
+                    ut[1, -1, 0]
+                    + ut[1, 0, 0]
+                    + ut
+                    + uc[0, -1, 0]
+                    - 0.25
+                    * cosa_u[0, -1]
+                    * (vt[0, -1, 0] + vt[-1, -1, 0] + vt[-1, 0, 0])
+                )
+            ) * damp
+        damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, -1] * cosa_v)
+        with horizontal(region[i_start, j_start + 1], region[i_end + 1, j_start + 1]):
+            vt = (
+                vc
+                - 0.25
+                * cosa_v
+                * (
+                    ut[0, -1, 0]
+                    + ut
+                    + ut[1, 0, 0]
+                    + uc[1, -1, 0]
+                    - 0.25 * cosa_u[1, -1] * (vt[0, -1, 0] + vt[1, -1, 0] + vt[1, 0, 0])
+                )
+            ) * damp
+        damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, 0] * cosa_v)
+        with horizontal(region[i_end + 1, j_end], region[i_start, j_end]):
+            vt = (
+                vc
+                - 0.25
+                * cosa_v
+                * (
+                    ut
+                    + ut[0, -1, 0]
+                    + ut[1, -1, 0]
+                    + uc[1, 0, 0]
+                    - 0.25 * cosa_u[1, 0] * (vt[0, 1, 0] + vt[1, 1, 0] + vt[1, 0, 0])
+                )
+            ) * damp
+        damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
+        with horizontal(region[i_end, j_end], region[i_start - 1, j_end]):
+            vt = (
+                vc
+                - 0.25
+                * cosa_v
+                * (
+                    ut[1, 0, 0]
+                    + ut[1, -1, 0]
+                    + ut[0, -1, 0]
+                    + uc
+                    - 0.25 * cosa_u * (vt[0, 1, 0] + vt[-1, 1, 0] + vt[-1, 0, 0])
+                )
+            ) * damp
 
 
+"""
+# Single stencil version to use when possible with gt backends
 def fxadv_stencil(
     cosa_u: FloatFieldIJ,
     cosa_v: FloatFieldIJ,
@@ -305,7 +304,6 @@ def fxadv_stencil(
     vt: FloatField,
     dt: float,
 ):
-
     with computation(PARALLEL), interval(...):
         ut = main_ut(uc, vc, cosa_u, rsin_u, ut)
         ut = ut_y_edge(uc, sin_sg1, sin_sg3, ut, dt)
@@ -313,20 +311,9 @@ def fxadv_stencil(
         vt = vt_y_edge(vc, cosa_v, ut, vt)
         vt = vt_x_edge(vc, sin_sg2, sin_sg4, vt, dt)
         ut = ut_x_edge(uc, cosa_u, vt, ut)
-
-
-def fxadv_corners_stencil(
-    uc: FloatField,
-    vc: FloatField,
-    ut: FloatField,
-    vt: FloatField,
-    cosa_u: FloatFieldIJ,
-    cosa_v: FloatFieldIJ,
-):
-
-    with computation(PARALLEL), interval(...):
-        ut = ut_corners(cosa_u, cosa_v, uc, vc, ut, vt)
-        vt = vt_corners(cosa_u, cosa_v, uc, vc, ut, vt)
+        ut = ut_corners(uc, vc, cosa_u, cosa_v, ut, vt)
+        vt = vt_corners(uc, vc, cosa_u, cosa_v, ut, vt)
+"""
 
 
 def fxadv_fluxes_stencil(
@@ -369,7 +356,7 @@ def fxadv_fluxes_stencil(
 
 class FiniteVolumeFluxPrep:
     """
-    A large section of code near the beginning of Fortran's d_sw subroutine
+    A large section of code near the beginning of Fortran's d_sw subroutinw
     Known in this repo as FxAdv,
     """
 
@@ -387,10 +374,14 @@ class FiniteVolumeFluxPrep:
             "origin": origin_corners,
             "domain": domain_corners,
         }
-        self._fxadv_stencil = FrozenStencil(fxadv_stencil, **kwargs)
-        self._fxadv_corners_stencil = FrozenStencil(
-            fxadv_corners_stencil, **kwargs_corners
-        )
+        self._main_ut_stencil = FrozenStencil(main_ut, **kwargs)
+        self._main_vt_stencil = FrozenStencil(main_vt, **kwargs)
+        self._ut_y_edge_stencil = FrozenStencil(ut_y_edge, **kwargs)
+        self._vt_y_edge_stencil = FrozenStencil(vt_y_edge, **kwargs)
+        self._ut_x_edge_stencil = FrozenStencil(ut_x_edge, **kwargs)
+        self._vt_x_edge_stencil = FrozenStencil(vt_x_edge, **kwargs)
+        self._ut_corners_stencil = FrozenStencil(ut_corners, **kwargs_corners)
+        self._vt_corners_stencil = FrozenStencil(vt_corners, **kwargs_corners)
         self._fxadv_fluxes_stencil = FrozenStencil(fxadv_fluxes_stencil, **kwargs)
 
     def __call__(
@@ -427,28 +418,61 @@ class FiniteVolumeFluxPrep:
             cosa_u, cosa_v, rsin_u, rsin_v, sin_sg1,sin_sg2, sin_sg3, sin_sg4, dx, dy
         """
 
-        self._fxadv_stencil(
-            self.grid.cosa_u,
-            self.grid.cosa_v,
-            self.grid.rsin_u,
-            self.grid.rsin_v,
-            self.grid.sin_sg1,
-            self.grid.sin_sg2,
-            self.grid.sin_sg3,
-            self.grid.sin_sg4,
+        self._main_ut_stencil(
             uc,
             vc,
+            self.grid.cosa_u,
+            self.grid.rsin_u,
             ut,
+        )
+        self._ut_y_edge_stencil(
+            uc,
+            self.grid.sin_sg1,
+            self.grid.sin_sg3,
+            ut,
+            dt,
+        )
+        self._main_vt_stencil(
+            uc,
+            vc,
+            self.grid.cosa_v,
+            self.grid.rsin_v,
+            vt,
+        )
+        self._vt_y_edge_stencil(
+            vc,
+            self.grid.cosa_v,
+            ut,
+            vt,
+        )
+        self._vt_x_edge_stencil(
+            vc,
+            self.grid.sin_sg2,
+            self.grid.sin_sg4,
             vt,
             dt,
         )
-        self._fxadv_corners_stencil(
+        self._ut_x_edge_stencil(
+            uc,
+            self.grid.cosa_u,
+            vt,
+            ut,
+        )
+        self._ut_corners_stencil(
+            self.grid.cosa_u,
+            self.grid.cosa_v,
             uc,
             vc,
             ut,
             vt,
+        )
+        self._vt_corners_stencil(
             self.grid.cosa_u,
             self.grid.cosa_v,
+            uc,
+            vc,
+            ut,
+            vt,
         )
         self._fxadv_fluxes_stencil(
             self.grid.sin_sg1,

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -328,8 +328,8 @@ def fxadv_corners_stencil(
     # from __externals__ import i_end, i_start, j_end, j_start, local_ie, local_is
 
     with computation(PARALLEL), interval(...):
-        ut = ut_corners(uc, vc, cosa_u, cosa_v, ut, vt)
-        vt = vt_corners(uc, vc, cosa_u, cosa_v, ut, vt)
+        ut = ut_corners(cosa_u, cosa_v, uc, vc, ut, vt)
+        vt = vt_corners(cosa_u, cosa_v, uc, vc, ut, vt)
 
 
 def fxadv_fluxes_stencil(

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -595,6 +595,7 @@ class RemapProfile:
         )
 
         if abs(self._kord) <= 16:
+            # TODO: These stencils could be combined once the backend can handle it
             self._apply_constraints(
                 self._q,
                 self._gam,

--- a/tests/translate/__init__.py
+++ b/tests/translate/__init__.py
@@ -6,8 +6,6 @@ from .translate_c_sw import (
     TranslateC_SW,
     TranslateCirculation_Cgrid,
     TranslateDivergenceCorner,
-    TranslateKE_C_SW,
-    TranslateTransportDelp,
     TranslateVorticityTransport_Cgrid,
 )
 from .translate_corners import (


### PR DESCRIPTION
## Purpose

This PR reduces the number of stencils called by c_sw by combining stencils with the same origins and domains.

## Code changes:

- c_sw.py: combined `transportdelp` and `update_vorticity_and_kinetic_energy` into one stencil to reduce overhead
- translate_c_sw.py: removed separate tests for `transportdelp` and `update_vorticity_and_kinetic_energy` as they are no longer separate stencils
- tests/translate/__init__.py: removed c_sw tests for `transportdelp` and `update_vorticity_and_kinetic_energy` since they no longer exist in the translate classes
- remap_profile.py: added a TODO about future stencil combinations when possible

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
