### PR TITLE
Fix/cache rebuild behavior

### DIFF
--- a/fv3core/utils/global_config.py
+++ b/fv3core/utils/global_config.py
@@ -123,7 +123,7 @@ def get_stencil_config():
 
 
 _BACKEND = None  # Options: numpy, gtx86, gtcuda, debug
-_REBUILD = getenv_bool("FV3_STENCIL_REBUILD_FLAG", "True")
+_REBUILD = getenv_bool("FV3_STENCIL_REBUILD_FLAG", "False")
 _FORMAT_SOURCE = getenv_bool("FV3_STENCIL_FORMAT_SOURCE", "False")
 _DO_HALO_EXCHANGE = True
 _VALIDATE_ARGS = True

--- a/fv3core/utils/global_config.py
+++ b/fv3core/utils/global_config.py
@@ -122,7 +122,10 @@ def get_stencil_config():
     )
 
 
-_BACKEND = None  # Options: numpy, gtx86, gtcuda, debug
+# Options: numpy, gtx86, gtcuda, debug
+_BACKEND = None
+# If TRUE, all caches will bypassed and stencils recompiled
+# if FALSE, caches will be checked and rebuild if code changes
 _REBUILD = getenv_bool("FV3_STENCIL_REBUILD_FLAG", "False")
 _FORMAT_SOURCE = getenv_bool("FV3_STENCIL_FORMAT_SOURCE", "False")
 _DO_HALO_EXCHANGE = True


### PR DESCRIPTION
## Purpose

The purpose of `FV3_STENCIL_REBUILD_FLAG` have changed since original implementation, it's default should now be FALSE.

Current behavior
- TRUE, all caches will bypassed and stencils recompiled
- FALSE, caches will be checked and rebuild if code changes

## Code changes:

- `global_config.py` change default when loading `FV3_STENCIL_REBUILD_FLAG` env var

## Requirements changes:

N/A

## Infrastructure changes:

`jenkins` already set the var and do not use the default

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
