### PR TITLE
add --print_domains option to savepoint tests

### DIFF
--- a/fv3core/__init__.py
+++ b/fv3core/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F401
+from . import decorators
 from .stencils.fv_dynamics import DynamicalCore
 from .stencils.fv_subgridz import FVSubgridZ
 from .utils.global_config import (

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -84,13 +84,7 @@ class FrozenStencil:
     This is useful when the stencil itself is meant to be used on a certain
     grid, for example if a compile-time external variable is tied to the
     values of origin and domain.
-
-    Attributes:
-        DEBUG: if True, instances print function name, origin, and domain
-            at initialization time
     """
-
-    DEBUG: bool = False
 
     def __init__(
         self,
@@ -108,8 +102,6 @@ class FrozenStencil:
             stencil_config: container for stencil configuration
             externals: compile-time external variables required by stencil
         """
-        if FrozenStencil.DEBUG:
-            print(func.__name__, origin, domain)
         self.origin = origin
         self.domain = domain
 

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -84,7 +84,13 @@ class FrozenStencil:
     This is useful when the stencil itself is meant to be used on a certain
     grid, for example if a compile-time external variable is tied to the
     values of origin and domain.
+
+    Attributes:
+        DEBUG: if True, instances print function name, origin, and domain
+            at initialization time
     """
+
+    DEBUG: bool = False
 
     def __init__(
         self,
@@ -102,8 +108,9 @@ class FrozenStencil:
             stencil_config: container for stencil configuration
             externals: compile-time external variables required by stencil
         """
+        if FrozenStencil.DEBUG:
+            print(func.__name__, origin, domain)
         self.origin = origin
-
         self.domain = domain
 
         if stencil_config is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ def pytest_addoption(parser):
     parser.addoption("--data_path", action="store", default="./")
     parser.addoption("--python_regression", action="store_true")
     parser.addoption("--threshold_overrides_file", action="store", default=None)
+    parser.addoption("--print_domains", action="store_true")
 
 
 def pytest_configure(config):

--- a/tests/savepoint/conftest.py
+++ b/tests/savepoint/conftest.py
@@ -492,5 +492,16 @@ def failure_stride(pytestconfig):
 
 
 @pytest.fixture()
+def print_domains(pytestconfig):
+    value = bool(pytestconfig.getoption("print_domains"))
+    original_value = fv3core.decorators.FrozenStencil.DEBUG
+    try:
+        fv3core.decorators.FrozenStencil.DEBUG = value
+        yield value
+    finally:
+        fv3core.decorators.FrozenStencil.DEBUG = original_value
+
+
+@pytest.fixture()
 def python_regression(pytestconfig):
     return pytestconfig.getoption("python_regression")

--- a/tests/savepoint/conftest.py
+++ b/tests/savepoint/conftest.py
@@ -494,12 +494,18 @@ def failure_stride(pytestconfig):
 @pytest.fixture()
 def print_domains(pytestconfig):
     value = bool(pytestconfig.getoption("print_domains"))
-    original_value = fv3core.decorators.FrozenStencil.DEBUG
+    original_init = fv3core.decorators.FrozenStencil.__init__
     try:
-        fv3core.decorators.FrozenStencil.DEBUG = value
+        if value:
+
+            def __init__(self, func, origin, domain, *args, **kwargs):
+                print(func.__name__, origin, domain)
+                original_init(self, func, origin, domain, *args, **kwargs)
+
+            fv3core.decorators.FrozenStencil.__init__ = __init__
         yield value
     finally:
-        fv3core.decorators.FrozenStencil.DEBUG = original_value
+        fv3core.decorators.FrozenStencil.__init__ = original_init
 
 
 @pytest.fixture()

--- a/tests/savepoint/test_translate.py
+++ b/tests/savepoint/test_translate.py
@@ -181,6 +181,7 @@ def test_sequential_savepoint(
     subtests,
     caplog,
     threshold_overrides,
+    print_domains,
     xy_indices=True,
 ):
     caplog.set_level(logging.DEBUG, logger="fv3core")
@@ -269,6 +270,7 @@ def test_mock_parallel_savepoint(
     subtests,
     caplog,
     threshold_overrides,
+    print_domains,
     xy_indices=False,
 ):
     caplog.set_level(logging.DEBUG, logger="fv3core")
@@ -360,6 +362,7 @@ def test_parallel_savepoint(
     caplog,
     python_regression,
     threshold_overrides,
+    print_domains,
     xy_indices=True,
 ):
     caplog.set_level(logging.DEBUG, logger="fv3core")


### PR DESCRIPTION
## Purpose

It can be difficult to track regressions that are due to inadvertently changing the origin and domain of stencil calls. This PR makes that process much easier by adding a `--print_domains` argument to the savepoint tests which causes the function name, origin, and domain to be printed whenever a FrozenStencil is created, allowing these values to be compared between the main branch and a PR branch.

## Code changes:

- `fv3core.decorators` is now imported automatically when `fv3core` is imported

## Infrastructure changes:

- Added --print-domains argument for savepoint tests which causes the function name, origin, and domain to be printed whenever a FrozenStencil is created

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
