### PR TITLE
Refactor inits of xtp_u and ytp_v

### DIFF
--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -594,8 +594,22 @@ class DGridShallowWaterLagrangianDynamics:
             hord=namelist.hord_vt,
         )
         self.fv_prep = FiniteVolumeFluxPrep()
-        self.ytp_v = YTP_V(namelist.grid_type, namelist.hord_mt)
-        self.xtp_u = XTP_U(namelist.grid_type, namelist.hord_mt)
+        self.ytp_v = YTP_V(
+            grid_indexing=self.grid.grid_indexing,
+            dy=self.grid.dy,
+            dya=self.grid.dya,
+            rdy=self.grid.rdy,
+            grid_type=namelist.grid_type,
+            jord=namelist.hord_mt,
+        )
+        self.xtp_u = XTP_U(
+            grid_indexing=self.grid.grid_indexing,
+            dx=self.grid.dx,
+            dxa=self.grid.dxa,
+            rdx=self.grid.rdx,
+            grid_type=namelist.grid_type,
+            iord=namelist.hord_mt,
+        )
         self.divergence_damping = DivergenceDamping(
             namelist, column_namelist["nord"], column_namelist["d2_divg"]
         )

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -594,8 +594,8 @@ class DGridShallowWaterLagrangianDynamics:
             hord=namelist.hord_vt,
         )
         self.fv_prep = FiniteVolumeFluxPrep()
-        self.ytp_v = YTP_V(namelist)
-        self.xtp_u = XTP_U(namelist)
+        self.ytp_v = YTP_V(namelist.grid_type, namelist.hord_mt)
+        self.xtp_u = XTP_U(namelist.grid_type, namelist.hord_mt)
         self.divergence_damping = DivergenceDamping(
             namelist, column_namelist["nord"], column_namelist["d2_divg"]
         )

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -9,10 +9,9 @@ from gt4py.gtscript import (
     region,
 )
 
-import fv3core._config as spec
 from fv3core.decorators import FrozenStencil
 from fv3core.stencils import xppm, yppm
-from fv3core.utils.grid import axis_offsets
+from fv3core.utils.grid import GridIndexing, axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -96,20 +95,21 @@ def _xtp_u(
 
 
 class XTP_U:
-    def __init__(self, grid_type: int, iord: int):
+    def __init__(
+        self, grid_indexing: GridIndexing, dx, dxa, rdx, grid_type: int, iord: int
+    ):
         if iord not in (5, 6, 7, 8):
             raise NotImplementedError(
                 "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
             )
         assert grid_type < 3
 
-        grid = spec.grid
-        self.origin = grid.compute_origin()
-        self.domain = grid.domain_shape_compute(add=(1, 1, 0))
-        self.dx = grid.dx
-        self.dxa = grid.dxa
-        self.rdx = grid.rdx
-        ax_offsets = axis_offsets(grid, self.origin, self.domain)
+        origin = grid_indexing.origin_compute()
+        domain = grid_indexing.domain_compute(add=(1, 1, 0))
+        self.dx = dx
+        self.dxa = dxa
+        self.rdx = rdx
+        ax_offsets = axis_offsets(grid_indexing, origin, domain)
         self.stencil = FrozenStencil(
             _xtp_u,
             externals={
@@ -118,8 +118,8 @@ class XTP_U:
                 "xt_minmax": False,
                 **ax_offsets,
             },
-            origin=self.origin,
-            domain=self.domain,
+            origin=origin,
+            domain=domain,
         )
 
     def __call__(self, c: FloatField, u: FloatField, flux: FloatField):

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -104,6 +104,10 @@ class XTP_U:
             )
         assert grid_type < 3
 
+        # TODO: XTP_U and YTP_V only depend on whether iord is less than 8 or
+        # greater than 8, not on the particular value of iord itself. We can
+        # refactor it to a boolean variable describing what iord < 8 means physically
+
         origin = grid_indexing.origin_compute()
         domain = grid_indexing.domain_compute(add=(1, 1, 0))
         self.dx = dx

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -96,13 +96,12 @@ def _xtp_u(
 
 
 class XTP_U:
-    def __init__(self, namelist):
-        iord = spec.namelist.hord_mt
+    def __init__(self, grid_type: int, iord: int):
         if iord not in (5, 6, 7, 8):
             raise NotImplementedError(
                 "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
             )
-        assert namelist.grid_type < 3
+        assert grid_type < 3
 
         grid = spec.grid
         self.origin = grid.compute_origin()
@@ -111,7 +110,6 @@ class XTP_U:
         self.dxa = grid.dxa
         self.rdx = grid.rdx
         ax_offsets = axis_offsets(grid, self.origin, self.domain)
-        assert namelist.grid_type < 3
         self.stencil = FrozenStencil(
             _xtp_u,
             externals={

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -118,7 +118,6 @@ class XTP_U:
             _xtp_u,
             externals={
                 "iord": iord,
-                "mord": iord,
                 "xt_minmax": False,
                 **ax_offsets,
             },

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -104,10 +104,6 @@ class XTP_U:
             )
         assert grid_type < 3
 
-        # TODO: XTP_U and YTP_V only depend on whether iord is less than 8 or
-        # greater than 8, not on the particular value of iord itself. We can
-        # refactor it to a boolean variable describing what iord < 8 means physically
-
         origin = grid_indexing.origin_compute()
         domain = grid_indexing.domain_compute(add=(1, 1, 0))
         self.dx = dx

--- a/fv3core/stencils/xtp_u.py
+++ b/fv3core/stencils/xtp_u.py
@@ -118,6 +118,7 @@ class XTP_U:
             _xtp_u,
             externals={
                 "iord": iord,
+                "mord": iord,
                 "xt_minmax": False,
                 **ax_offsets,
             },

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -12,7 +12,7 @@ from gt4py.gtscript import (
 import fv3core._config as spec
 from fv3core.decorators import FrozenStencil
 from fv3core.stencils import yppm
-from fv3core.utils.grid import axis_offsets
+from fv3core.utils.grid import GridIndexing, axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -93,7 +93,9 @@ def _ytp_v(
 
 
 class YTP_V:
-    def __init__(self, grid_type: int, jord: int):
+    def __init__(
+        self, grid_indexing: GridIndexing, dy, dya, rdy, grid_type: int, jord: int
+    ):
         if jord not in (5, 6, 7, 8):
             raise NotImplementedError(
                 "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
@@ -101,8 +103,8 @@ class YTP_V:
         assert grid_type < 3
 
         grid = spec.grid
-        origin = grid.compute_origin()
-        domain = grid.domain_shape_compute(add=(1, 1, 0))
+        origin = grid_indexing.origin_compute()
+        domain = grid_indexing.domain_compute(add=(1, 1, 0))
         self.dy = grid.dy
         self.dya = grid.dya
         self.rdy = grid.rdy

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -93,13 +93,12 @@ def _ytp_v(
 
 
 class YTP_V:
-    def __init__(self, namelist):
-        jord = spec.namelist.hord_mt
+    def __init__(self, grid_type: int, jord: int):
         if jord not in (5, 6, 7, 8):
             raise NotImplementedError(
                 "Currently xtp_v is only supported for hord_mt == 5,6,7,8"
             )
-        assert namelist.grid_type < 3
+        assert grid_type < 3
 
         grid = spec.grid
         origin = grid.compute_origin()
@@ -108,7 +107,6 @@ class YTP_V:
         self.dya = grid.dya
         self.rdy = grid.rdy
         ax_offsets = axis_offsets(grid, origin, domain)
-        assert namelist.grid_type < 3
 
         self.stencil = FrozenStencil(
             _ytp_v,

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -112,6 +112,7 @@ class YTP_V:
             _ytp_v,
             externals={
                 "jord": jord,
+                "mord": jord,
                 "xt_minmax": False,
                 **ax_offsets,
             },

--- a/fv3core/stencils/ytp_v.py
+++ b/fv3core/stencils/ytp_v.py
@@ -9,7 +9,6 @@ from gt4py.gtscript import (
     region,
 )
 
-import fv3core._config as spec
 from fv3core.decorators import FrozenStencil
 from fv3core.stencils import yppm
 from fv3core.utils.grid import GridIndexing, axis_offsets
@@ -102,19 +101,17 @@ class YTP_V:
             )
         assert grid_type < 3
 
-        grid = spec.grid
         origin = grid_indexing.origin_compute()
         domain = grid_indexing.domain_compute(add=(1, 1, 0))
-        self.dy = grid.dy
-        self.dya = grid.dya
-        self.rdy = grid.rdy
-        ax_offsets = axis_offsets(grid, origin, domain)
+        self.dy = dy
+        self.dya = dya
+        self.rdy = rdy
+        ax_offsets = axis_offsets(grid_indexing, origin, domain)
 
         self.stencil = FrozenStencil(
             _ytp_v,
             externals={
                 "jord": jord,
-                "mord": jord,
                 "xt_minmax": False,
                 **ax_offsets,
             },

--- a/tests/savepoint/translate/translate_xtp_u.py
+++ b/tests/savepoint/translate/translate_xtp_u.py
@@ -13,7 +13,12 @@ class TranslateXTP_U(TranslateYTP_V):
 
     def compute_from_storage(self, inputs):
         xtp_obj = xtp_u.XTP_U(
-            grid_type=spec.namelist.grid_type, iord=spec.namelist.hord_mt
+            grid_indexing=spec.grid.grid_indexing,
+            dx=spec.grid.dx,
+            dxa=spec.grid.dxa,
+            rdx=spec.grid.rdx,
+            grid_type=spec.namelist.grid_type,
+            iord=spec.namelist.hord_mt,
         )
         xtp_obj(inputs["c"], inputs["u"], inputs["flux"])
         return inputs

--- a/tests/savepoint/translate/translate_xtp_u.py
+++ b/tests/savepoint/translate/translate_xtp_u.py
@@ -12,6 +12,8 @@ class TranslateXTP_U(TranslateYTP_V):
         self.in_vars["data_vars"]["flux"]["serialname"] = "vb"
 
     def compute_from_storage(self, inputs):
-        xtp_obj = xtp_u.XTP_U(spec.namelist)
+        xtp_obj = xtp_u.XTP_U(
+            grid_type=spec.namelist.grid_type, iord=spec.namelist.hord_mt
+        )
         xtp_obj(inputs["c"], inputs["u"], inputs["flux"])
         return inputs

--- a/tests/savepoint/translate/translate_ytp_v.py
+++ b/tests/savepoint/translate/translate_ytp_v.py
@@ -16,7 +16,12 @@ class TranslateYTP_V(TranslateFortranData2Py):
 
     def compute_from_storage(self, inputs):
         ytp_obj = ytp_v.YTP_V(
-            grid_type=spec.namelist.grid_type, jord=spec.namelist.hord_mt
+            grid_indexing=spec.grid.grid_indexing,
+            dy=spec.grid.dy,
+            dya=spec.grid.dya,
+            rdy=spec.grid.rdy,
+            grid_type=spec.namelist.grid_type,
+            jord=spec.namelist.hord_mt,
         )
         ytp_obj(inputs["c"], inputs["v"], inputs["flux"])
         return inputs

--- a/tests/savepoint/translate/translate_ytp_v.py
+++ b/tests/savepoint/translate/translate_ytp_v.py
@@ -15,6 +15,8 @@ class TranslateYTP_V(TranslateFortranData2Py):
         self.out_vars = {"flux": flux_info}
 
     def compute_from_storage(self, inputs):
-        ytp_obj = ytp_v.YTP_V(spec.namelist)
+        ytp_obj = ytp_v.YTP_V(
+            grid_type=spec.namelist.grid_type, jord=spec.namelist.hord_mt
+        )
         ytp_obj(inputs["c"], inputs["v"], inputs["flux"])
         return inputs


### PR DESCRIPTION
## Purpose

Refactoring init routines of xtp_u and ytp_v to take in only arguments they use, to prepare for future init refactors.

## Code changes:

- Refactored initialization signatures of xtp_u and ytp_v

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)