### PR TITLE
fxadv has minimal inits, no global access

### DIFF
--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -593,7 +593,21 @@ class DGridShallowWaterLagrangianDynamics:
             grid_type=namelist.grid_type,
             hord=namelist.hord_vt,
         )
-        self.fv_prep = FiniteVolumeFluxPrep()
+        self.fv_prep = FiniteVolumeFluxPrep(
+            self.grid.grid_indexing,
+            self.grid.dx,
+            self.grid.dy,
+            self.grid.rdxa,
+            self.grid.rdya,
+            self.grid.cosa_u,
+            self.grid.cosa_v,
+            self.grid.rsin_u,
+            self.grid.rsin_v,
+            self.grid.sin_sg1,
+            self.grid.sin_sg2,
+            self.grid.sin_sg3,
+            self.grid.sin_sg4,
+        )
         self.ytp_v = YTP_V(
             grid_indexing=self.grid.grid_indexing,
             dy=self.grid.dy,

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -438,9 +438,6 @@ class FiniteVolumeFluxPrep:
             ut: temporary x-velocity transformed from C-grid to D-grid equiv(?) (inout)
             vt: temporary y-velocity transformed from C-grid to D-grid equiv(?) (inout)
             dt: acoustic timestep in seconds
-
-        Grid variable inputs:
-            cosa_u, cosa_v, rsin_u, rsin_v, sin_sg1,sin_sg2, sin_sg3, sin_sg4, dx, dy
         """
 
         self._main_ut_stencil(

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -1,8 +1,7 @@
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
-import fv3core._config as spec
 from fv3core.decorators import FrozenStencil
-from fv3core.utils.grid import axis_offsets
+from fv3core.utils.grid import GridIndexing, axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -360,15 +359,41 @@ class FiniteVolumeFluxPrep:
     Known in this repo as FxAdv,
     """
 
-    def __init__(self):
-        self.grid = spec.grid
-        origin = self.grid.full_origin()
-        domain = self.grid.domain_shape_full()
-        ax_offsets = axis_offsets(self.grid, origin, domain)
+    def __init__(
+        self,
+        grid_indexing: GridIndexing,
+        dx,
+        dy,
+        rdxa,
+        rdya,
+        cosa_u,
+        cosa_v,
+        rsin_u,
+        rsin_v,
+        sin_sg1,
+        sin_sg2,
+        sin_sg3,
+        sin_sg4,
+    ):
+        self._dx = dx
+        self._dy = dy
+        self._rdxa = rdxa
+        self._rdya = rdya
+        self._cosa_u = cosa_u
+        self._cosa_v = cosa_v
+        self._rsin_u = rsin_u
+        self._rsin_v = rsin_v
+        self._sin_sg1 = sin_sg1
+        self._sin_sg2 = sin_sg2
+        self._sin_sg3 = sin_sg3
+        self._sin_sg4 = sin_sg4
+        origin = grid_indexing.origin_full()
+        domain = grid_indexing.domain_full()
+        ax_offsets = axis_offsets(grid_indexing, origin, domain)
         kwargs = {"externals": ax_offsets, "origin": origin, "domain": domain}
-        origin_corners = self.grid.full_origin(add=(1, 1, 0))
-        domain_corners = self.grid.domain_shape_full(add=(-1, -1, 0))
-        corner_offsets = axis_offsets(self.grid, origin_corners, domain_corners)
+        origin_corners = grid_indexing.origin_full(add=(1, 1, 0))
+        domain_corners = grid_indexing.domain_full(add=(-1, -1, 0))
+        corner_offsets = axis_offsets(grid_indexing, origin_corners, domain_corners)
         kwargs_corners = {
             "externals": corner_offsets,
             "origin": origin_corners,
@@ -421,68 +446,68 @@ class FiniteVolumeFluxPrep:
         self._main_ut_stencil(
             uc,
             vc,
-            self.grid.cosa_u,
-            self.grid.rsin_u,
+            self._cosa_u,
+            self._rsin_u,
             ut,
         )
         self._ut_y_edge_stencil(
             uc,
-            self.grid.sin_sg1,
-            self.grid.sin_sg3,
+            self._sin_sg1,
+            self._sin_sg3,
             ut,
             dt,
         )
         self._main_vt_stencil(
             uc,
             vc,
-            self.grid.cosa_v,
-            self.grid.rsin_v,
+            self._cosa_v,
+            self._rsin_v,
             vt,
         )
         self._vt_y_edge_stencil(
             vc,
-            self.grid.cosa_v,
+            self._cosa_v,
             ut,
             vt,
         )
         self._vt_x_edge_stencil(
             vc,
-            self.grid.sin_sg2,
-            self.grid.sin_sg4,
+            self._sin_sg2,
+            self._sin_sg4,
             vt,
             dt,
         )
         self._ut_x_edge_stencil(
             uc,
-            self.grid.cosa_u,
+            self._cosa_u,
             vt,
             ut,
         )
         self._ut_corners_stencil(
-            self.grid.cosa_u,
-            self.grid.cosa_v,
+            self._cosa_u,
+            self._cosa_v,
             uc,
             vc,
             ut,
             vt,
         )
         self._vt_corners_stencil(
-            self.grid.cosa_u,
-            self.grid.cosa_v,
+            self._cosa_u,
+            self._cosa_v,
             uc,
             vc,
             ut,
             vt,
         )
         self._fxadv_fluxes_stencil(
-            self.grid.sin_sg1,
-            self.grid.sin_sg2,
-            self.grid.sin_sg3,
-            self.grid.sin_sg4,
-            self.grid.rdxa,
-            self.grid.rdya,
-            self.grid.dy,
-            self.grid.dx,
+            self._sin_sg1,
+            self._sin_sg2,
+            self._sin_sg3,
+            self._sin_sg4,
+            self._rdxa,
+            self._rdya,
+            self._dy,
+            self._dx,
             crx,
             cry,
             x_area_flux,

--- a/tests/savepoint/translate/translate_fxadv.py
+++ b/tests/savepoint/translate/translate_fxadv.py
@@ -7,7 +7,21 @@ class TranslateFxAdv(TranslateFortranData2Py):
         super().__init__(grid)
         utinfo = grid.x3d_domain_dict()
         vtinfo = grid.y3d_domain_dict()
-        self.compute_func = FiniteVolumeFluxPrep()
+        self.compute_func = FiniteVolumeFluxPrep(
+            self.grid.grid_indexing,
+            self.grid.dx,
+            self.grid.dy,
+            self.grid.rdxa,
+            self.grid.rdya,
+            self.grid.cosa_u,
+            self.grid.cosa_v,
+            self.grid.rsin_u,
+            self.grid.rsin_v,
+            self.grid.sin_sg1,
+            self.grid.sin_sg2,
+            self.grid.sin_sg3,
+            self.grid.sin_sg4,
+        )
         self.in_vars["data_vars"] = {
             "uc": {},
             "vc": {},
@@ -31,3 +45,7 @@ class TranslateFxAdv(TranslateFortranData2Py):
         }
         for var in ["x_area_flux", "crx", "y_area_flux", "cry"]:
             self.out_vars[var] = self.in_vars["data_vars"][var]
+
+    def compute_from_storage(self, inputs):
+        self.compute_func(**inputs)
+        return inputs


### PR DESCRIPTION
## Purpose

This PR refactors FiniteVolumeFluxPrep to use no global state, expanding its init routine to take in all required variables explicitly.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
