### PR TITLE
Allow ignore_near_zero_errors to have variable specific value

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ common options for our tests, which you can add to `TEST_ARGS`:
 
 * `-m` - will let you run only certain groups of tests. For example, `-m=parallel` will run only parallel stencils, while `-m=sequential` will run only stencils that operate on one rank at a time.
 
-* `--threshold_overrides_file` - will read a yaml file with error thresholds specified for specific backend and platform (docker or metal) configurations, overriding the max_error thresholds defined in the Translate classes.
+* `--threshold_overrides_file` - will read a yaml file with error thresholds specified for specific backend and platform (docker or metal) configurations, overriding the max_error thresholds defined in the Translate classes. Format of the yaml file is described [here](tests/savepoint/translate/overrides/README.md).
 
 **NOTE:** FV3 is current assumed to be by default in a "development mode", where stencils are checked each time they execute for code changes (which can trigger regeneration). This process is somewhat expensive, so there is an option to put FV3 in a performance mode by telling it that stencils should not automatically be rebuilt:
 

--- a/tests/savepoint/test_translate.py
+++ b/tests/savepoint/test_translate.py
@@ -190,7 +190,9 @@ def process_override(threshold_overrides, testobj, test_name, backend):
                                 ] = float(match["all_other_near_zero"])
 
                 else:
-                    raise TypeError("ignore_near_zero_errors is either a list or a dict")
+                    raise TypeError(
+                        "ignore_near_zero_errors is either a list or a dict"
+                    )
         elif len(matches) > 1:
             raise Exception(
                 "misconfigured threshold overrides file, more than 1 specification for "

--- a/tests/savepoint/test_translate.py
+++ b/tests/savepoint/test_translate.py
@@ -34,13 +34,24 @@ def success_array(computed_data, ref_data, eps, ignore_near_zero_errors, near_ze
         np.logical_and(np.isnan(computed_data), np.isnan(ref_data)),
         compare_arr(computed_data, ref_data) < eps,
     )
-    if ignore_near_zero_errors:
+    if isinstance(ignore_near_zero_errors, dict):
+        if ignore_near_zero_errors.keys():
+            near_zero = ignore_near_zero_errors["near_zero"]
+            success = np.logical_or(
+                success,
+                np.logical_and(
+                    np.abs(computed_data) < near_zero,
+                    np.abs(ref_data) < near_zero,
+                ),
+            )
+    elif ignore_near_zero_errors:
         success = np.logical_or(
             success,
             np.logical_and(
                 np.abs(computed_data) < near_zero, np.abs(ref_data) < near_zero
             ),
         )
+
     return success
 
 
@@ -148,9 +159,22 @@ def process_override(threshold_overrides, testobj, test_name, backend):
             if "near_zero" in match:
                 testobj.near_zero = float(match["near_zero"])
             if "ignore_near_zero_errors" in match:
-                testobj.ignore_near_zero_errors = {
-                    field: True for field in match["ignore_near_zero_errors"]
-                }
+                parsed_ignore_zero = match["ignore_near_zero_errors"]
+                if isinstance(parsed_ignore_zero, list):
+                    testobj.ignore_near_zero_errors = {
+                        field: True for field in match["ignore_near_zero_errors"]
+                    }
+                elif isinstance(parsed_ignore_zero, dict):
+                    testobj.ignore_near_zero_errors = {
+                        field: True for field in parsed_ignore_zero.keys()
+                    }
+                    for key in testobj.ignore_near_zero_errors.keys():
+                        testobj.ignore_near_zero_errors[key] = {}
+                        testobj.ignore_near_zero_errors[key]["near_zero"] = float(
+                            parsed_ignore_zero[key]
+                        )
+                else:
+                    raise TypeError("ignore_near_zero_erros is either a list or a dict")
         elif len(matches) > 1:
             raise Exception(
                 "misconfigured threshold overrides file, more than 1 specification for "

--- a/tests/savepoint/test_translate.py
+++ b/tests/savepoint/test_translate.py
@@ -190,7 +190,7 @@ def process_override(threshold_overrides, testobj, test_name, backend):
                                 ] = float(match["all_other_near_zero"])
 
                 else:
-                    raise TypeError("ignore_near_zero_erros is either a list or a dict")
+                    raise TypeError("ignore_near_zero_errors is either a list or a dict")
         elif len(matches) > 1:
             raise Exception(
                 "misconfigured threshold overrides file, more than 1 specification for "

--- a/tests/savepoint/test_translate.py
+++ b/tests/savepoint/test_translate.py
@@ -2,6 +2,7 @@ import contextlib
 import hashlib
 import logging
 import os
+from typing import Union
 
 import numpy as np
 import pytest
@@ -29,7 +30,13 @@ def compare_arr(computed_data, ref_data):
     return compare
 
 
-def success_array(computed_data, ref_data, eps, ignore_near_zero_errors, near_zero):
+def success_array(
+    computed_data: np.ndarray,
+    ref_data: np.ndarray,
+    eps: float,
+    ignore_near_zero_errors: Union[dict, bool],
+    near_zero: float,
+):
     success = np.logical_or(
         np.logical_and(np.isnan(computed_data), np.isnan(ref_data)),
         compare_arr(computed_data, ref_data) < eps,
@@ -173,6 +180,15 @@ def process_override(threshold_overrides, testobj, test_name, backend):
                         testobj.ignore_near_zero_errors[key]["near_zero"] = float(
                             parsed_ignore_zero[key]
                         )
+                    if "all_other_near_zero" in match:
+                        for key in testobj.out_vars.keys():
+                            if key not in testobj.ignore_near_zero_errors:
+                                testobj.ignore_near_zero_errors[key] = True
+                                testobj.ignore_near_zero_errors[key] = {}
+                                testobj.ignore_near_zero_errors[key][
+                                    "near_zero"
+                                ] = float(match["all_other_near_zero"])
+
                 else:
                     raise TypeError("ignore_near_zero_erros is either a list or a dict")
         elif len(matches) > 1:

--- a/tests/savepoint/translate/overrides/README.md
+++ b/tests/savepoint/translate/overrides/README.md
@@ -4,7 +4,7 @@
 
 For maximum error, a blanket `max_error` is specified to override the parent classes relative error threshold.
 
-For near zero override, `ignore_near_zero_errors` is specified to allow some fields to pass with higher relative error if the absolute error is very small.
+For near zero override, `ignore_near_zero_errors` is specified to allow some fields to pass with higher relative error if the absolute error is very small. Additionally, it is also possible to define a global near zero value for all remaining fields not specified in `ignore_near_zero_errors`. This is done by specifying `all_other_near_zero=<value>`.
 
 Override yaml file should have one of the following formats:
 
@@ -15,7 +15,7 @@ Override yaml file should have one of the following formats:
    max_error: <value>
    near_zero: <value>
    ignore_near_zero_errors:
-    - <var>
+    - <var1>
     - <var2>
     - ...
 ```
@@ -24,9 +24,22 @@ Override yaml file should have one of the following formats:
 ```Stencil_name:
  - backend: <backend>
    max_error: <value>
-   near_zero: <value>
    ignore_near_zero_errors:
-    <var>:<value>
-    <var2>:<value>
+    <var1>:<value1>
+    <var2>:<value2>
     ...
 ```
+
+## [optional] Global near zero value for remaining fields
+
+```Stencil_name:
+ - backend: <backend>
+   max_error: <value>
+   ignore_near_zero_errors:
+    <var1>:<value1>
+    <var2>:<value2>
+   all_other_near_zero:<global_value>
+    ...
+```
+
+where fields other than `var1` and `var2` will use `global_value`.

--- a/tests/savepoint/translate/overrides/README.md
+++ b/tests/savepoint/translate/overrides/README.md
@@ -1,0 +1,32 @@
+# Threshold overrides
+
+`--threshold_overrides_file` takes in a yaml file with error thresholds specified for specific backend and platform configuration. Currently, two types of error overrides are allowed: maximum error and near zero.
+
+For maximum error, a blanket `max_error` is specified to override the parent classes relative error threshold.
+
+For near zero override, `ignore_near_zero_errors` is specified to allow some fields to pass with higher relative error if the absolute error is very small.
+
+Override yaml file should have one of the following formats:
+
+## One near zero value for all variables
+
+```Stencil_name:
+ - backend: <backend>
+   max_error: <value>
+   near_zero: <value>
+   ignore_near_zero_errors:
+    - <var>
+    - <var2>
+    - ...
+```
+## Variable specific near zero value
+
+```Stencil_name:
+ - backend: <backend>
+   max_error: <value>
+   near_zero: <value>
+   ignore_near_zero_errors:
+    <var>:<value>
+    <var2>:<value>
+    ...
+```

--- a/tests/savepoint/translate/overrides/baroclinic.yaml
+++ b/tests/savepoint/translate/overrides/baroclinic.yaml
@@ -1,3 +1,37 @@
 C_SW:
   - backend: numpy
     max_error: 5e-2
+
+FVDynamics:
+  - backend: numpy
+    ignore_near_zero_errors:
+      uc: 1e-13
+      vc: 1e-13
+      mfxd: 1e-3
+      mfyd: 1e-3
+      cxd: 1e-3
+      cyd: 1e-3
+
+DynCore:
+  - backend: numpy
+    ignore_near_zero_errors:
+      uc: 1e-13
+      vc: 1e-13
+      mfxd: 1e-3
+      mfyd: 1e-3
+      cxd: 1e-3
+      cyd: 1e-3
+
+D_SW:
+  - backend: numpy
+    ignore_near_zero_errors:
+      divgdd: 1e-20
+      ucd: 1e-20
+      vcd: 1e-20
+      delpcd: 1e-15
+
+DivergenceDamping:
+  - backend: numpy
+    ignore_near_zero_errors:
+      vort: 6e-8
+      delpc: 1e-15


### PR DESCRIPTION
## Purpose

This PR introduces the option to specify `ignore_near_zero_errors` as a dictionary with variable specific near_zero value. As a result of this PR, `c12_6ranks_baroclinic` passes tests using `baroclinic.yaml`.


## Code changes:

- When reading `ignore_near_zero_errors` with `--threshold_overrides_file` option, if it's a dictionary, the key is the variable and the value is its near_zero value
- `ignore_near_zero_errors` functionality is unchanged if the previous format is passed (a list of values with near_zero specified separately)
- If `near_zero` is specified and `ignore_near_zero_errors` is a dictionary, the value in `ignore_near_zero_errors` is used.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
