### PR TITLE
GTC regions safety/a2b ord4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,9 @@ dev_wrapper:
 
 test_base:
 ifneq ($(findstring docker,$(CONTAINER_CMD)),)
+    ifeq ($(DEV),n)
 	$(MAKE) build
+    endif
 endif
 	$(CONTAINER_CMD) bash -c "pip list && $(PYTEST_CMD)"
 

--- a/fv3core/stencils/a2b_ord4.py
+++ b/fv3core/stencils/a2b_ord4.py
@@ -287,7 +287,7 @@ def a2b_interpolation(
     with computation(PARALLEL), interval(...):
         qxx = a2 * (qx[0, -2, 0] + qx[0, 1, 0]) + a1 * (qx[0, -1, 0] + qx)
         qyy = a2 * (qy[-2, 0, 0] + qy[1, 0, 0]) + a1 * (qy[-1, 0, 0] + qy)
-        # TODO use a function with an offset when that works consistently
+        # TODO(rheag) use a function with an offset when that works consistently
         with horizontal(region[:, j_start + 1]):
             qxx_upper = a2 * (qx[0, -1, 0] + qx[0, 2, 0]) + a1 * (qx + qx[0, 1, 0])
             qxx = c1 * (qx[0, -1, 0] + qx) + c2 * (qout[0, -1, 0] + qxx_upper)
@@ -363,7 +363,7 @@ def qx_edge_east(qin: FloatField, dxa: FloatFieldIJ):
 
 @gtscript.function
 def qx_edge_east2(qin: FloatField, dxa: FloatFieldIJ):
-    # TODO when possible
+    # TODO(rheag) use a function with an offset when that works consistently
     # qxright = qx_edge_east(qin[1, 0, 0], dxa[1, 0])
     # qxleft = ppm_volume_mean_x_main(qin[-1, 0, 0])
     g_in = dxa[-1, 0] / dxa
@@ -390,7 +390,7 @@ def qy_edge_south(qin: FloatField, dya: FloatFieldIJ):
 
 @gtscript.function
 def qy_edge_south2(qin: FloatField, dya: FloatFieldIJ):
-    # TODO
+    # TODO(rheag) use a function with an offset when that works consistently
     # qy_lower = qy_edge_south(qin[0, -1, 0], dya[0, -1])
     # qy_upper = ppm_volume_mean_y_main(qin[0, 1, 0])
     g_in = dya / dya[0, -1]
@@ -417,7 +417,7 @@ def qy_edge_north(qin: FloatField, dya: FloatFieldIJ):
 
 @gtscript.function
 def qy_edge_north2(qin: FloatField, dya: FloatFieldIJ):
-    # TODO
+    # TODO(rheag) use a function with an offset when that works consistently
     # qy_lower = ppm_volume_mean_y_main(qin[0, -1, 0])
     # qy_upper = qy_edge_north(qin[0, 1, 0], dya[0, 1])
     g_in = dya[0, -1] / dya


### PR DESCRIPTION
## Purpose

A2B_Ord4 has regions that depend on computations in neighboring regions. This can be a race condition and also is not efficient. Previous attempts to inline these same one resulted in memory issues, but that was with a more aggressive refactor of A2B_Ord4 to reduce the stencil count. Here we do the minimal necessary to unblock testing fv3core with regions in GTC.
It has been verified that this change does not slow does the code (https://jenkins.ginko.ch/job/fv3core-performance-test/573/backend=gtcuda,experiment=c128_6ranks_baroclinic,slave=daint_submit/artifact/2021-07-07-06-30-26.json)

## Code changes:

- a2b_ord4 has a light refactor to inline region calculations

## Infrastructure changes:

- Update the DEV=y setting with the Makefile to not docker build when that was set, as was intended with the previous dev_tests endpoint

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
