### PR TITLE
GTC safety/fxadv pgradc

### DIFF
--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -183,7 +183,9 @@ def ut_corners(
                     + vt
                     + vt[0, 1, 0]
                     + vc[-1, 1, 0]
-                    - 0.25 * cosa_v[-1, 1] * (ut_copy[-1, 0, 0] + ut_copy[-1, 1, 0] + ut_copy[0, 1, 0])
+                    - 0.25
+                    * cosa_v[-1, 1]
+                    * (ut_copy[-1, 0, 0] + ut_copy[-1, 1, 0] + ut_copy[0, 1, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
@@ -197,7 +199,9 @@ def ut_corners(
                     + vt[-1, 1, 0]
                     + vt[-1, 0, 0]
                     + vc
-                    - 0.25 * cosa_v * (ut_copy[1, 0, 0] + ut_copy[1, -1, 0] + ut_copy[0, -1, 0])
+                    - 0.25
+                    * cosa_v
+                    * (ut_copy[1, 0, 0] + ut_copy[1, -1, 0] + ut_copy[0, -1, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[0, 1])
@@ -211,7 +215,9 @@ def ut_corners(
                     + vt[-1, 0, 0]
                     + vt[-1, 1, 0]
                     + vc[0, 1, 0]
-                    - 0.25 * cosa_v[0, 1] * (ut_copy[1, 0, 0] + ut_copy[1, 1, 0] + ut_copy[0, 1, 0])
+                    - 0.25
+                    * cosa_v[0, 1]
+                    * (ut_copy[1, 0, 0] + ut_copy[1, 1, 0] + ut_copy[0, 1, 0])
                 )
             ) * damp
 
@@ -255,7 +261,9 @@ def vt_corners(
                     + ut
                     + ut[1, 0, 0]
                     + uc[1, -1, 0]
-                    - 0.25 * cosa_u[1, -1] * (vt_copy[0, -1, 0] + vt_copy[1, -1, 0] + vt_copy[1, 0, 0])
+                    - 0.25
+                    * cosa_u[1, -1]
+                    * (vt_copy[0, -1, 0] + vt_copy[1, -1, 0] + vt_copy[1, 0, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, 0] * cosa_v)
@@ -269,7 +277,9 @@ def vt_corners(
                     + ut[0, -1, 0]
                     + ut[1, -1, 0]
                     + uc[1, 0, 0]
-                    - 0.25 * cosa_u[1, 0] * (vt_copy[0, 1, 0] + vt_copy[1, 1, 0] + vt_copy[1, 0, 0])
+                    - 0.25
+                    * cosa_u[1, 0]
+                    * (vt_copy[0, 1, 0] + vt_copy[1, 1, 0] + vt_copy[1, 0, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
@@ -283,7 +293,9 @@ def vt_corners(
                     + ut[1, -1, 0]
                     + ut[0, -1, 0]
                     + uc
-                    - 0.25 * cosa_u * (vt_copy[0, 1, 0] + vt_copy[-1, 1, 0] + vt_copy[-1, 0, 0])
+                    - 0.25
+                    * cosa_u
+                    * (vt_copy[0, 1, 0] + vt_copy[-1, 1, 0] + vt_copy[-1, 0, 0])
                 )
             ) * damp
 

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -136,6 +136,7 @@ def ut_corners(
     uc: FloatField,
     vc: FloatField,
     ut: FloatField,
+    ut_copy: FloatField,
     vt: FloatField,
 ):
 
@@ -167,7 +168,7 @@ def ut_corners(
                     + vc[-1, 0, 0]
                     - 0.25
                     * cosa_v[-1, 0]
-                    * (ut[-1, 0, 0] + ut[-1, -1, 0] + ut[0, -1, 0])
+                    * (ut_copy[-1, 0, 0] + ut_copy[-1, -1, 0] + ut_copy[0, -1, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[-1, 1])
@@ -182,7 +183,7 @@ def ut_corners(
                     + vt
                     + vt[0, 1, 0]
                     + vc[-1, 1, 0]
-                    - 0.25 * cosa_v[-1, 1] * (ut[-1, 0, 0] + ut[-1, 1, 0] + ut[0, 1, 0])
+                    - 0.25 * cosa_v[-1, 1] * (ut_copy[-1, 0, 0] + ut_copy[-1, 1, 0] + ut_copy[0, 1, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
@@ -196,7 +197,7 @@ def ut_corners(
                     + vt[-1, 1, 0]
                     + vt[-1, 0, 0]
                     + vc
-                    - 0.25 * cosa_v * (ut[1, 0, 0] + ut[1, -1, 0] + ut[0, -1, 0])
+                    - 0.25 * cosa_v * (ut_copy[1, 0, 0] + ut_copy[1, -1, 0] + ut_copy[0, -1, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v[0, 1])
@@ -210,7 +211,7 @@ def ut_corners(
                     + vt[-1, 0, 0]
                     + vt[-1, 1, 0]
                     + vc[0, 1, 0]
-                    - 0.25 * cosa_v[0, 1] * (ut[1, 0, 0] + ut[1, 1, 0] + ut[0, 1, 0])
+                    - 0.25 * cosa_v[0, 1] * (ut_copy[1, 0, 0] + ut_copy[1, 1, 0] + ut_copy[0, 1, 0])
                 )
             ) * damp
 
@@ -222,6 +223,7 @@ def vt_corners(
     vc: FloatField,
     ut: FloatField,
     vt: FloatField,
+    vt_copy: FloatField,
 ):
     from __externals__ import i_end, i_start, j_end, j_start
 
@@ -239,7 +241,7 @@ def vt_corners(
                     + uc[0, -1, 0]
                     - 0.25
                     * cosa_u[0, -1]
-                    * (vt[0, -1, 0] + vt[-1, -1, 0] + vt[-1, 0, 0])
+                    * (vt_copy[0, -1, 0] + vt_copy[-1, -1, 0] + vt_copy[-1, 0, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, -1] * cosa_v)
@@ -253,7 +255,7 @@ def vt_corners(
                     + ut
                     + ut[1, 0, 0]
                     + uc[1, -1, 0]
-                    - 0.25 * cosa_u[1, -1] * (vt[0, -1, 0] + vt[1, -1, 0] + vt[1, 0, 0])
+                    - 0.25 * cosa_u[1, -1] * (vt_copy[0, -1, 0] + vt_copy[1, -1, 0] + vt_copy[1, 0, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u[1, 0] * cosa_v)
@@ -267,7 +269,7 @@ def vt_corners(
                     + ut[0, -1, 0]
                     + ut[1, -1, 0]
                     + uc[1, 0, 0]
-                    - 0.25 * cosa_u[1, 0] * (vt[0, 1, 0] + vt[1, 1, 0] + vt[1, 0, 0])
+                    - 0.25 * cosa_u[1, 0] * (vt_copy[0, 1, 0] + vt_copy[1, 1, 0] + vt_copy[1, 0, 0])
                 )
             ) * damp
         damp = 1.0 / (1.0 - 0.0625 * cosa_u * cosa_v)
@@ -281,7 +283,7 @@ def vt_corners(
                     + ut[1, -1, 0]
                     + ut[0, -1, 0]
                     + uc
-                    - 0.25 * cosa_u * (vt[0, 1, 0] + vt[-1, 1, 0] + vt[-1, 0, 0])
+                    - 0.25 * cosa_u * (vt_copy[0, 1, 0] + vt_copy[-1, 1, 0] + vt_copy[-1, 0, 0])
                 )
             ) * damp
 
@@ -486,6 +488,7 @@ class FiniteVolumeFluxPrep:
             uc,
             vc,
             ut,
+            ut,
             vt,
         )
         self._vt_corners_stencil(
@@ -494,6 +497,7 @@ class FiniteVolumeFluxPrep:
             uc,
             vc,
             ut,
+            vt,
             vt,
         )
         self._fxadv_fluxes_stencil(

--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -494,6 +494,7 @@ class FiniteVolumeFluxPrep:
             vt,
             ut,
         )
+        # NOTE: this is aliasing memory
         self._ut_corners_stencil(
             self._cosa_u,
             self._cosa_v,
@@ -503,6 +504,7 @@ class FiniteVolumeFluxPrep:
             ut,
             vt,
         )
+        # NOTE: this is aliasing memory
         self._vt_corners_stencil(
             self._cosa_u,
             self._cosa_v,

--- a/tests/savepoint/translate/__init__.py
+++ b/tests/savepoint/translate/__init__.py
@@ -28,7 +28,7 @@ from .translate_del2cubed import TranslateDel2Cubed
 from .translate_del6vtflux import TranslateDel6VtFlux
 from .translate_delnflux import TranslateDelnFlux, TranslateDelnFlux_2
 from .translate_divergencedamping import TranslateDivergenceDamping
-from .translate_dyncore import TranslateDynCore, TranslatePGradC
+from .translate_dyncore import TranslateDynCore
 from .translate_fillz import TranslateFillz
 from .translate_fvsubgridz import TranslateFVSubgridZ
 from .translate_fvtp2d import TranslateFvTp2d, TranslateFvTp2d_2

--- a/tests/savepoint/translate/translate_dyncore.py
+++ b/tests/savepoint/translate/translate_dyncore.py
@@ -1,9 +1,7 @@
 import fv3core._config as spec
 import fv3core.stencils.dyn_core as dyn_core
 import fv3gfs.util as fv3util
-from fv3core.decorators import FrozenStencil
-from fv3core.testing import ParallelTranslate2PyState, TranslateFortranData2Py
-from fv3core.utils.grid import axis_offsets
+from fv3core.testing import ParallelTranslate2PyState
 
 
 class TranslateDynCore(ParallelTranslate2PyState):
@@ -126,37 +124,3 @@ class TranslateDynCore(ParallelTranslate2PyState):
             inputs["phis"],
         )
         return super().compute_parallel(inputs, communicator)
-
-
-class TranslatePGradC(TranslateFortranData2Py):
-    def __init__(self, grid):
-        super().__init__(grid)
-        self.in_vars["data_vars"] = {
-            "uc": {},
-            "vc": {},
-            "delpc": {},
-            "pkc": grid.default_buffer_k_dict(),
-            "gz": grid.default_buffer_k_dict(),
-        }
-        self.in_vars["parameters"] = ["dt2"]
-        self.out_vars = {"uc": grid.x3d_domain_dict(), "vc": grid.y3d_domain_dict()}
-
-    def compute_from_storage(self, inputs):
-        origin = self.grid.compute_origin()
-        domain = self.grid.domain_shape_compute(add=(1, 1, 0))
-        ax_offsets = axis_offsets(self.grid, origin, domain)
-        pgradc = FrozenStencil(
-            dyn_core.p_grad_c_stencil,
-            externals={
-                "hydrostatic": spec.namelist.hydrostatic,
-                **ax_offsets,
-            },
-            origin=origin,
-            domain=domain,
-        )
-        pgradc(
-            rdxc=self.grid.rdxc,
-            rdyc=self.grid.rdyc,
-            **inputs,
-        )
-        return inputs


### PR DESCRIPTION
## Purpose

Removing race conditions from stencils with regions. FxAdv corner stencils have self reference with an offset - although in theory there isn't a collision of the actual points, we know from our experience with GTC that those backends will not work with this pattern (in the without regions version, though is likely to also not be ok with regions). The solution to pass the save variable twice works here because the corner stencils aren't writing into the points being read. But if stencils get to be merged such that this is happening, we will likely need full copies of ut and vt variables. 
The regions are removed from p_grad_c, which overcomputes uc and vc both in 1 grid cell (the point that they aren't staggered for, which is undefined in the Fortran code). The Translate test for PGradC is removed. Using selective validation had some issues with DynCore validation and PGradC is a very small stencil test not covering any feature uniquely.  

## Code changes:

- fxadv ut and vt corner computations to not write and read with an offset the same variable. 
- dyn_core removes regions from p_grad_c
- test code for PGradC removed


## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
