### PR TITLE
remove region race condition associated with dm in xppm and yppm

### DIFF
--- a/fv3core/stencils/xppm.py
+++ b/fv3core/stencils/xppm.py
@@ -172,12 +172,25 @@ def bl_br_edges(bl, br, q, dxa, al, dm):
     from __externals__ import i_end, i_start
 
     with horizontal(region[i_start - 1, :]):
-        xt_bl = yppm.s14 * dm[-1, 0, 0] + yppm.s11 * (q[-1, 0, 0] - q) + q
+        # TODO(rheag) when possible
+        # dm_left = dm_iord8plus(q[-1, 0, 0])
+        xt = 0.25 * (q - q[-2, 0, 0])
+        dqr = max(max(q[-1, 0, 0], q[-2, 0, 0]), q) - q[-1, 0, 0]
+        dql = q[-1, 0, 0] - min(min(q[-1, 0, 0], q[-2, 0, 0]), q)
+        dm_left = sign(min(min(abs(xt), dqr), dql), xt)
+        xt_bl = yppm.s14 * dm_left + yppm.s11 * (q[-1, 0, 0] - q) + q
         xt_br = xt_dxa_edge_0(q, dxa)
 
     with horizontal(region[i_start, :]):
+        # TODO(rheag) when possible
+        # dm_right = dm_iord8plus(q[1, 0, 0])
+        xt = 0.25 * (q[2, 0, 0] - q)
+        dqr = max(max(q[1, 0, 0], q), q[2, 0, 0]) - q[1, 0, 0]
+        dql = q[1, 0, 0] - min(min(q[1, 0, 0], q), q[2, 0, 0])
+        dm_right = sign(min(min(abs(xt), dqr), dql), xt)
+        xt_bl = yppm.s14 * dm_left + yppm.s11 * (q[-1, 0, 0] - q) + q
         xt_bl = xt_dxa_edge_1(q, dxa)
-        xt_br = yppm.s15 * q + yppm.s11 * q[1, 0, 0] - yppm.s14 * dm[1, 0, 0]
+        xt_br = yppm.s15 * q + yppm.s11 * q[1, 0, 0] - yppm.s14 * dm_right
 
     with horizontal(region[i_start + 1, :]):
         xt_bl = yppm.s15 * q[-1, 0, 0] + yppm.s11 * q - yppm.s14 * dm
@@ -188,12 +201,24 @@ def bl_br_edges(bl, br, q, dxa, al, dm):
         xt_br = yppm.s15 * q[1, 0, 0] + yppm.s11 * q + yppm.s14 * dm
 
     with horizontal(region[i_end, :]):
-        xt_bl = yppm.s15 * q + yppm.s11 * q[-1, 0, 0] + yppm.s14 * dm[-1, 0, 0]
+        # TODO(rheag) when possible
+        # dm_left_end = dm_iord8plus(q[-1, 0, 0])
+        xt = 0.25 * (q - q[-2, 0, 0])
+        dqr = max(max(q[-1, 0, 0], q[-2, 0, 0]), q) - q[-1, 0, 0]
+        dql = q[-1, 0, 0] - min(min(q[-1, 0, 0], q[-2, 0, 0]), q)
+        dm_left_end = sign(min(min(abs(xt), dqr), dql), xt)
+        xt_bl = yppm.s15 * q + yppm.s11 * q[-1, 0, 0] + yppm.s14 * dm_left_end
         xt_br = xt_dxa_edge_0(q, dxa)
 
     with horizontal(region[i_end + 1, :]):
+        # TODO(rheag) when possible
+        # dm_right_end = dm_iord8plus(q[1, 0, 0])
+        xt = 0.25 * (q[2, 0, 0] - q)
+        dqr = max(max(q[1, 0, 0], q), q[2, 0, 0]) - q[1, 0, 0]
+        dql = q[1, 0, 0] - min(min(q[1, 0, 0], q), q[2, 0, 0])
+        dm_right_end = sign(min(min(abs(xt), dqr), dql), xt)
         xt_bl = xt_dxa_edge_1(q, dxa)
-        xt_br = yppm.s11 * (q[1, 0, 0] - q) - yppm.s14 * dm[1, 0, 0] + q
+        xt_br = yppm.s11 * (q[1, 0, 0] - q) - yppm.s14 * dm_right_end + q
 
     with horizontal(
         region[i_start - 1 : i_start + 2, :], region[i_end - 1 : i_end + 2, :]

--- a/fv3core/stencils/yppm.py
+++ b/fv3core/stencils/yppm.py
@@ -234,13 +234,26 @@ def compute_al(q: FloatField, dya: FloatFieldIJ):
 def bl_br_edges(bl, br, q, dya, al, dm):
     from __externals__ import j_end, j_start
 
+    #  dm_jord8plus(q: FloatField)
     with horizontal(region[:, j_start - 1]):
-        xt_bl = s14 * dm[0, -1, 0] + s11 * (q[0, -1, 0] - q) + q
+        # TODO(rheag) when possible
+        # dm_lower = dm_jord8plus(q[0, -1, 0])
+        xt = 0.25 * (q - q[0, -2, 0])
+        dqr = max(max(q[0, -1, 0], q[0, -2, 0]), q) - q[0, -1, 0]
+        dql = q[0, -1, 0] - min(min(q[0, -1, 0], q[0, -2, 0]), q)
+        dm_lower = sign(min(min(abs(xt), dqr), dql), xt)
+        xt_bl = s14 * dm_lower + s11 * (q[0, -1, 0] - q) + q
         xt_br = xt_dya_edge_0(q, dya)
 
     with horizontal(region[:, j_start]):
+        # TODO(rheag) when possible
+        # dm_upper = dm_jord8plus(q[0, 1, 0])
+        xt = 0.25 * (q[0, 2, 0] - q)
+        dqr = max(max(q[0, 1, 0], q), q[0, 2, 0]) - q[0, 1, 0]
+        dql = q[0, 1, 0] - min(min(q[0, 1, 0], q), q[0, 2, 0])
+        dm_upper = sign(min(min(abs(xt), dqr), dql), xt)
         xt_bl = xt_dya_edge_1(q, dya)
-        xt_br = s15 * q + s11 * q[0, 1, 0] - s14 * dm[0, 1, 0]
+        xt_br = s15 * q + s11 * q[0, 1, 0] - s14 * dm_upper
 
     with horizontal(region[:, j_start + 1]):
         xt_bl = s15 * q[0, -1, 0] + s11 * q - s14 * dm
@@ -251,12 +264,24 @@ def bl_br_edges(bl, br, q, dya, al, dm):
         xt_br = s15 * q[0, 1, 0] + s11 * q + s14 * dm
 
     with horizontal(region[:, j_end]):
-        xt_bl = s15 * q + s11 * q[0, -1, 0] + s14 * dm[0, -1, 0]
+        # TODO(rheag) when possible
+        # dm_lower_end = dm_jord8plus(q[0, -1, 0])
+        xt = 0.25 * (q - q[0, -2, 0])
+        dqr = max(max(q[0, -1, 0], q[0, -2, 0]), q) - q[0, -1, 0]
+        dql = q[0, -1, 0] - min(min(q[0, -1, 0], q[0, -2, 0]), q)
+        dm_lower_end = sign(min(min(abs(xt), dqr), dql), xt)
+        xt_bl = s15 * q + s11 * q[0, -1, 0] + s14 * dm_lower_end
         xt_br = xt_dya_edge_0(q, dya)
 
     with horizontal(region[:, j_end + 1]):
+        # TODO(rheag) when possible
+        # dm_upper_end = dm_jord8plus(q[0, 1, 0])
+        xt = 0.25 * (q[0, 2, 0] - q)
+        dqr = max(max(q[0, 1, 0], q), q[0, 2, 0]) - q[0, 1, 0]
+        dql = q[0, 1, 0] - min(min(q[0, 1, 0], q), q[0, 2, 0])
+        dm_upper_end = sign(min(min(abs(xt), dqr), dql), xt)
         xt_bl = xt_dya_edge_1(q, dya)
-        xt_br = s11 * (q[0, 1, 0] - q) - s14 * dm[0, 1, 0] + q
+        xt_br = s11 * (q[0, 1, 0] - q) - s14 * dm_upper_end + q
 
     with horizontal(
         region[:, j_start - 1 : j_start + 2], region[:, j_end - 1 : j_end + 2]


### PR DESCRIPTION
## Purpose

Recompute dm on edges rather than referring to dm with an offset inside of a region. This should help enable us move to GTC with regions and fv3core. 

## Code changes:

- xppm and yppm edge stencils

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
