### PR TITLE
fv3core works with GTC without regions

### DIFF
--- a/.jenkins/install_virtualenv.sh
+++ b/.jenkins/install_virtualenv.sh
@@ -17,6 +17,8 @@ virtualenv_path=$1
 fv3core_dir=`dirname $0`/../
 (cd ${fv3core_dir}/external/daint_venv && ./install.sh ${virtualenv_path})
 source ${virtualenv_path}/bin/activate
+# TODO: move this to daint_venv and update submodule
+python -m gt4py.gt_src_manager install -m 2
 python3 -m pip install ${fv3core_dir}/external/fv3gfs-util/
 python3 -m pip install $wheel_command -c ${fv3core_dir}/constraints.txt -r ${fv3core_dir}/requirements/requirements_daint.txt
 python3 -m pip install ${FV3CORE_INSTALL_FLAGS} ${fv3core_dir}

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -163,7 +163,7 @@ class FrozenStencil:
             self._mark_cuda_fields_written({**args_as_kwargs, **kwargs})
 
     def _mark_cuda_fields_written(self, fields: Mapping[str, Storage]):
-        if global_config.is_gpu_backend() in self.stencil_config.backend:
+        if global_config.is_gpu_backend():
             for write_field in self._written_fields:
                 fields[write_field]._set_device_modified()
 

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -163,7 +163,7 @@ class FrozenStencil:
             self._mark_cuda_fields_written({**args_as_kwargs, **kwargs})
 
     def _mark_cuda_fields_written(self, fields: Mapping[str, Storage]):
-        if "cuda" in self.stencil_config.backend:
+        if global_config.is_gpu_backend() in self.stencil_config.backend:
             for write_field in self._written_fields:
                 fields[write_field]._set_device_modified()
 

--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -247,7 +247,10 @@ def circulation_cgrid(
     with computation(PARALLEL), interval(...):
         fx = dxc * uc
         fy = dyc * vc
-
+    # TODO(rheag) this computation should not be required
+    # but was needed for GTC validation (cpu_ifirst)
+    # Check again and open an issue if repeatable
+    with computation(PARALLEL), interval(...):
         vort_c = fx[0, -1, 0] - fx - fy[-1, 0, 0] + fy
 
         with horizontal(region[i_start, j_start], region[i_start, j_end + 1]):

--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -247,7 +247,6 @@ def circulation_cgrid(
     with computation(PARALLEL), interval(...):
         fx = dxc * uc
         fy = dyc * vc
-
         vort_c = fx[0, -1, 0] - fx - fy[-1, 0, 0] + fy
 
         with horizontal(region[i_start, j_start], region[i_start, j_end + 1]):

--- a/fv3core/stencils/c_sw.py
+++ b/fv3core/stencils/c_sw.py
@@ -247,10 +247,7 @@ def circulation_cgrid(
     with computation(PARALLEL), interval(...):
         fx = dxc * uc
         fy = dyc * vc
-    # TODO(rheag) this computation should not be required
-    # but was needed for GTC validation (cpu_ifirst)
-    # Check again and open an issue if repeatable
-    with computation(PARALLEL), interval(...):
+
         vort_c = fx[0, -1, 0] - fx - fy[-1, 0, 0] + fy
 
         with horizontal(region[i_start, j_start], region[i_start, j_end + 1]):

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -295,7 +295,10 @@ def heat_source_from_vorticity_damping(
         damp_vt: column scalar for damping vorticity
     """
     from __externals__ import d_con, do_skeb, local_ie, local_is, local_je, local_js
-
+    # TODO(rheag) For GTC, due to a potential gt4py bug
+    # do these assignments in the next computation
+    # breaks validation for gtcuda
+    # alternative -- split into 2 stencils and allocate some more storages
     with computation(PARALLEL), interval(...):
         # if (kinetic_energy_fraction_to_damp[0] > dcon_threshold) or do_skeb:
         heat_s = heat_source

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -84,6 +84,29 @@ def flux_capacitor(
 
 
 @gtscript.function
+def horizontal_relative_vorticity_from_winds(u, v, ut, vt, dx, dy, rarea, vorticity):
+    """
+    Compute the area mean relative vorticity in the z-direction from the D-grid winds.
+
+    Args:
+        u (in): x-direction wind on D grid
+        v (in): y-direction wind on D grid
+        ut (out): u * dx
+        vt (out): v * dy
+        dx (in): gridcell width in x-direction
+        dy (in): gridcell width in y-direction
+        rarea (in): inverse of area
+        vorticity (out): area mean horizontal relative vorticity
+    """
+
+    vt = u * dx
+    ut = v * dy
+    vorticity = rarea * (vt - vt[0, 1, 0] - ut + ut[1, 0, 0])
+
+    return vt, ut, vorticity
+
+
+@gtscript.function
 def all_corners_ke(ke, u, v, ut, vt, dt):
     from __externals__ import i_end, i_start, j_end, j_start
 
@@ -354,16 +377,9 @@ def ke_horizontal_vorticity(
     with computation(PARALLEL), interval(...):
         ke = ke_from_bwind(ke, ub, vb)
         ke = all_corners_ke(ke, u, v, ut, vt, dt)
-        # Compute the area mean relative vorticity in the z-direction
-        # from the D-grid winds.
-        vt = u * dx
-        ut = v * dy
-    with computation(PARALLEL), interval(...):
-        # TODO(rheag) this computation should not be required
-        # but was needed for GTC validation (gpu)
-        # Check again and open an issue if repeatable
-        vorticity = rarea * (vt - vt[0, 1, 0] - ut + ut[1, 0, 0])
-
+        vt, ut, vorticity = horizontal_relative_vorticity_from_winds(
+            u, v, ut, vt, dx, dy, rarea, vorticity
+        )
 
 
 # Set the unique parameters for the smallest

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -295,6 +295,7 @@ def heat_source_from_vorticity_damping(
         damp_vt: column scalar for damping vorticity
     """
     from __externals__ import d_con, do_skeb, local_ie, local_is, local_je, local_js
+
     # TODO(rheag) For GTC, due to a potential gt4py bug
     # do these assignments in the next computation
     # breaks validation for gtcuda
@@ -360,9 +361,10 @@ def ke_horizontal_vorticity(
     # ut and vt are API fields. If the distinction
     # is removed, so can this computation.
     # Compute the area mean relative vorticity in the z-direction
-    # from the D-grid winds. 
+    # from the D-grid winds.
     with computation(PARALLEL), interval(...):
         vorticity = rarea * (vt - vt[0, 1, 0] - ut + ut[1, 0, 0])
+
 
 # Set the unique parameters for the smallest
 # k-values, e.g. k = 0, 1, 2 when generating

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -297,15 +297,14 @@ def heat_source_from_vorticity_damping(
     from __externals__ import d_con, do_skeb, local_ie, local_is, local_je, local_js
 
     with computation(PARALLEL), interval(...):
-        if (kinetic_energy_fraction_to_damp[0] > dcon_threshold) or do_skeb:
-            heat_s = heat_source
-            diss_e = dissipation_estimate
-            ubt = (ub + vt) * rdx
-            fy = u * rdx
-            gy = fy * ubt
-            vbt = (vb - ut) * rdy
-            fx = v * rdy
-            gx = fx * vbt
+        heat_s = heat_source
+        diss_e = dissipation_estimate
+        ubt = (ub + vt) * rdx
+        fy = u * rdx
+        gy = fy * ubt
+        vbt = (vb - ut) * rdy
+        fx = v * rdy
+        gx = fx * vbt
     with computation(PARALLEL), interval(...):
         if (kinetic_energy_fraction_to_damp[0] > dcon_threshold) or do_skeb:
             u2 = fy + fy[0, 1, 0]

--- a/fv3core/stencils/d_sw.py
+++ b/fv3core/stencils/d_sw.py
@@ -296,20 +296,16 @@ def heat_source_from_vorticity_damping(
     """
     from __externals__ import d_con, do_skeb, local_ie, local_is, local_je, local_js
 
-    # TODO(rheag) For GTC, due to a potential gt4py bug
-    # do these assignments in the next computation
-    # breaks validation for gtcuda
-    # alternative -- split into 2 stencils and allocate some more storages
     with computation(PARALLEL), interval(...):
-        # if (kinetic_energy_fraction_to_damp[0] > dcon_threshold) or do_skeb:
-        heat_s = heat_source
-        diss_e = dissipation_estimate
-        ubt = (ub + vt) * rdx
-        fy = u * rdx
-        gy = fy * ubt
-        vbt = (vb - ut) * rdy
-        fx = v * rdy
-        gx = fx * vbt
+        if (kinetic_energy_fraction_to_damp[0] > dcon_threshold) or do_skeb:
+            heat_s = heat_source
+            diss_e = dissipation_estimate
+            ubt = (ub + vt) * rdx
+            fy = u * rdx
+            gy = fy * ubt
+            vbt = (vb - ut) * rdy
+            fx = v * rdy
+            gx = fx * vbt
     with computation(PARALLEL), interval(...):
         if (kinetic_energy_fraction_to_damp[0] > dcon_threshold) or do_skeb:
             u2 = fy + fy[0, 1, 0]

--- a/fv3core/stencils/divergence_damping.py
+++ b/fv3core/stencils/divergence_damping.py
@@ -221,6 +221,7 @@ class DivergenceDamping:
         self._stretched_grid = stretched_grid
         kstart = nonzero_nord_k
         nk = self._idx.domain[2] - kstart
+        self._do_zero_order = nonzero_nord_k > 0
         low_k_idx = self._idx.restrict_vertical(k_start=0, nk=nonzero_nord_k)
         high_k_idx = grid_indexing.restrict_vertical(k_start=nonzero_nord_k)
         self.a2b_ord4 = AGrid2BGridFourthOrder(
@@ -376,10 +377,10 @@ class DivergenceDamping:
         wk: FloatField,
         dt: float,
     ) -> None:
-
-        self.damping_zero_order(
-            u, v, va, ptc, vort, ua, vc, uc, delpc, ke, self._d2_bg_column, dt
-        )
+        if self._do_zero_order:
+            self.damping_zero_order(
+                u, v, va, ptc, vort, ua, vc, uc, delpc, ke, self._d2_bg_column, dt
+            )
         self._copy_computeplus(
             divg_d,
             delpc,

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -121,8 +121,9 @@ def p_grad_c_stencil(
         rdxc, rdyc
     """
     from __externals__ import hydrostatic
-
-    with computation(PARALLEL), interval(...):
+    # TODO(rheag) change back to interval(...)
+    # https://github.com/GridTools/gt4py/issues/437
+    with computation(PARALLEL), interval(0, -1):
         if __INLINED(hydrostatic):
             wk = pkc[0, 0, 1] - pkc
         else:
@@ -322,7 +323,9 @@ class AcousticDynamics:
         self._p_grad_c = FrozenStencil(
             p_grad_c_stencil,
             origin=self.grid.compute_origin(),
-            domain=self.grid.domain_shape_compute(add=(1, 1, 0)),
+            # TODO(rheag) change back to add=(1, 1,0)
+            # https://github.com/GridTools/gt4py/issues/437
+            domain=self.grid.domain_shape_compute(add=(1, 1, 1)),
             externals={"hydrostatic": self.namelist.hydrostatic},
         )
 

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -121,9 +121,8 @@ def p_grad_c_stencil(
         rdxc, rdyc
     """
     from __externals__ import hydrostatic
-    # TODO(rheag) change back to interval(...)
-    # https://github.com/GridTools/gt4py/issues/437
-    with computation(PARALLEL), interval(0, -1):
+
+    with computation(PARALLEL), interval(...):
         if __INLINED(hydrostatic):
             wk = pkc[0, 0, 1] - pkc
         else:
@@ -323,9 +322,7 @@ class AcousticDynamics:
         self._p_grad_c = FrozenStencil(
             p_grad_c_stencil,
             origin=self.grid.compute_origin(),
-            # TODO(rheag) change back to add=(1, 1,0)
-            # https://github.com/GridTools/gt4py/issues/437
-            domain=self.grid.domain_shape_compute(add=(1, 1, 1)),
+            domain=self.grid.domain_shape_compute(add=(1, 1, 0)),
             externals={"hydrostatic": self.namelist.hydrostatic},
         )
 

--- a/fv3core/stencils/neg_adj3.py
+++ b/fv3core/stencils/neg_adj3.py
@@ -228,8 +228,8 @@ def fix_water_vapor_k_loop(i, j, kbot, qvapor, dp):
 # Stencil version
 def fix_water_vapor_down(qvapor: FloatField, dp: FloatField):
     with computation(PARALLEL), interval(...):
-            upper_fix = 0.0  # type: FloatField
-            lower_fix = 0.0  # type: FloatField
+        upper_fix = 0.0  # type: FloatField
+        lower_fix = 0.0  # type: FloatField
     with computation(PARALLEL):
         with interval(0, 1):
             if qvapor < 0.0:

--- a/fv3core/stencils/neg_adj3.py
+++ b/fv3core/stencils/neg_adj3.py
@@ -227,23 +227,24 @@ def fix_water_vapor_k_loop(i, j, kbot, qvapor, dp):
 
 # Stencil version
 def fix_water_vapor_down(qvapor: FloatField, dp: FloatField):
-    with computation(PARALLEL):
-        with interval(...):
+    with computation(PARALLEL), interval(...):
             upper_fix = 0.0  # type: FloatField
             lower_fix = 0.0  # type: FloatField
+    with computation(PARALLEL):
         with interval(0, 1):
-            qvapor = qvapor if qvapor >= 0 else 0
+            if qvapor < 0.0:
+                qvapor = 0.0
         with interval(1, 2):
             if qvapor[0, 0, -1] < 0:
                 qvapor = qvapor + qvapor[0, 0, -1] * dp[0, 0, -1] / dp
     with computation(FORWARD), interval(1, -1):
         dq = qvapor[0, 0, -1] * dp[0, 0, -1]
         if lower_fix[0, 0, -1] != 0:
-            qvapor = qvapor + lower_fix[0, 0, -1] / dp
+            qvapor += lower_fix[0, 0, -1] / dp
         if (qvapor < 0) and (qvapor[0, 0, -1] > 0):
             dq = dq if dq < -qvapor * dp else -qvapor * dp
             upper_fix = dq
-            qvapor = qvapor + dq / dp
+            qvapor += dq / dp
         if qvapor < 0:
             lower_fix = qvapor * dp
             qvapor = 0
@@ -259,15 +260,12 @@ def fix_water_vapor_down(qvapor: FloatField, dp: FloatField):
         upper_fix = qvapor
         # If we didn't have to worry about float valitation and negative column
         # mass we could set qvapor[k_bot] to 0 here...
-        dp_bot = dp[0, 0, 0]
+        dp_bot = dp
     with computation(BACKWARD), interval(0, -1):
         dq = qvapor * dp
         if (upper_fix[0, 0, 1] < 0) and (qvapor > 0):
-            dq = (
-                dq
-                if dq < -upper_fix[0, 0, 1] * dp_bot
-                else -upper_fix[0, 0, 1] * dp_bot
-            )
+            if dq >= -upper_fix[0, 0, 1] * dp_bot:
+                dq = -upper_fix[0, 0, 1] * dp_bot
             qvapor = qvapor - dq / dp
             upper_fix = upper_fix[0, 0, 1] + dq / dp_bot
         else:
@@ -275,7 +273,7 @@ def fix_water_vapor_down(qvapor: FloatField, dp: FloatField):
     with computation(FORWARD), interval(1, None):
         upper_fix = upper_fix[0, 0, -1]
     with computation(PARALLEL), interval(-1, None):
-        qvapor[0, 0, 0] = upper_fix[0, 0, 0]
+        qvapor = upper_fix
 
 
 class AdjustNegativeTracerMixingRatio:

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -476,7 +476,9 @@ def set_interpolation_coefficients(
         if __INLINED(iv == 0):
             a4_1, a4_2, a4_3, a4_4 = posdef_constraint_iv0(a4_1, a4_2, a4_3, a4_4)
     # set_bottom_as_iv0, set_bottom_as_iv1
-    with computation(PARALLEL), interval(-1, None):
+    # TODO(rheag) temporary workaround to gtc:gt:gpu bug
+    # this computation can get out of order with the one that follows
+    with computation(FORWARD), interval(-1, None):
         if __INLINED(iv == 0):
             if a4_3 < 0.0:
                 a4_3 = 0.0

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -119,24 +119,25 @@ def set_initial_vals(
 ):
     from __externals__ import iv, kord
 
-    with computation(PARALLEL), interval(0, 1):
-        # set top
-        if __INLINED(iv == -2):
-            # gam = 0.5
-            q = 1.5 * a4_1
-        else:
-            grid_ratio = delp[0, 0, 1] / delp
-            bet = grid_ratio * (grid_ratio + 0.5)
-            q = (
-                (grid_ratio + grid_ratio) * (grid_ratio + 1.0) * a4_1 + a4_1[0, 0, 1]
-            ) / bet
-            gam = (1.0 + grid_ratio * (grid_ratio + 1.5)) / bet
-    with computation(FORWARD), interval(1, 2):
-        if __INLINED(iv == -2):
-            gam = 0.5
-            grid_ratio = delp[0, 0, -1] / delp
-            bet = 2.0 + grid_ratio + grid_ratio - gam
-            q = (3.0 * (a4_1[0, 0, -1] + a4_1) - q[0, 0, -1]) / bet
+    with computation(FORWARD):
+        with interval(0, 1):
+            # set top
+            if __INLINED(iv == -2):
+                # gam = 0.5
+                q = 1.5 * a4_1
+            else:
+                grid_ratio = delp[0, 0, 1] / delp
+                bet = grid_ratio * (grid_ratio + 0.5)
+                q = (
+                    (grid_ratio + grid_ratio) * (grid_ratio + 1.0) * a4_1 + a4_1[0, 0, 1]
+                ) / bet
+                gam = (1.0 + grid_ratio * (grid_ratio + 1.5)) / bet
+        with interval(1, 2):
+            if __INLINED(iv == -2):
+                gam = 0.5
+                grid_ratio = delp[0, 0, -1] / delp
+                bet = 2.0 + grid_ratio + grid_ratio - gam
+                q = (3.0 * (a4_1[0, 0, -1] + a4_1) - q[0, 0, -1]) / bet
     with computation(FORWARD), interval(1, -1):
         if __INLINED(iv != -2):
             # set middle
@@ -145,23 +146,22 @@ def set_initial_vals(
             q = (3.0 * (a4_1[0, 0, -1] + d4 * a4_1) - q[0, 0, -1]) / bet
             gam = d4 / bet
     with computation(FORWARD):
+        with interval(2, -1):
+            if __INLINED(iv == -2):
+                old_grid_ratio = delp[0, 0, -2] / delp[0, 0, -1]
+                old_bet = 2.0 + old_grid_ratio + old_grid_ratio - gam[0, 0, -1]
+                gam = old_grid_ratio / old_bet
+                grid_ratio = delp[0, 0, -1] / delp
+    with computation(FORWARD):
         with interval(2, -2):
             if __INLINED(iv == -2):
                 # set middle
-                old_grid_ratio = delp[0, 0, -2] / delp[0, 0, -1]
-                old_bet = 2.0 + old_grid_ratio + old_grid_ratio - gam[0, 0, -1]
-                gam = old_grid_ratio / old_bet
-                grid_ratio = delp[0, 0, -1] / delp
                 bet = 2.0 + grid_ratio + grid_ratio - gam
                 q = (3.0 * (a4_1[0, 0, -1] + a4_1) - q[0, 0, -1]) / bet
-                # gam[0, 0, 1] = grid_ratio / bet
+                # gam[0, 0, 1] = grid_ratio / bet                                                                                                                                                                             
         with interval(-2, -1):
             if __INLINED(iv == -2):
                 # set bottom
-                old_grid_ratio = delp[0, 0, -2] / delp[0, 0, -1]
-                old_bet = 2.0 + old_grid_ratio + old_grid_ratio - gam[0, 0, -1]
-                gam = old_grid_ratio / old_bet
-                grid_ratio = delp[0, 0, -1] / delp
                 q = (3.0 * (a4_1[0, 0, -1] + a4_1) - grid_ratio * qs - q[0, 0, -1]) / (
                     2.0 + grid_ratio + grid_ratio - gam
                 )
@@ -186,18 +186,14 @@ def set_initial_vals(
         if __INLINED(iv == -2):
             q = q - gam[0, 0, 1] * q[0, 0, 1]
     # set_avals
-    with computation(PARALLEL):
-        with interval(0, -1):
-            if __INLINED(kord > 16):
-                a4_2 = q
-                a4_3 = q[0, 0, 1]
-                a4_4 = 3.0 * (2.0 * a4_1 - (a4_2 + a4_3))
-        with interval(-1, None):
-            if __INLINED(kord > 16):
-                a4_2 = q
-                a4_3 = q_bot
-                a4_4 = 3.0 * (2.0 * a4_1 - (a4_2 + a4_3))
-
+    with computation(PARALLEL), interval(...):
+        if __INLINED(kord > 16):
+            a4_2 = q
+            a4_3 = q[0, 0, 1]
+            a4_4 = 3.0 * (2.0 * a4_1 - (a4_2 + a4_3))
+    with computation(PARALLEL), interval(-1, None):
+        if __INLINED(kord > 16):
+            a4_3 = q_bot
 
 def apply_constraints(
     q: FloatField,

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -485,8 +485,7 @@ def set_interpolation_coefficients(
                 a4_3 = 0.0
     with computation(PARALLEL), interval(-2, None):
         # set_bottom_as_iv0, set_bottom_as_iv1, set_bottom_as_else
-        if __INLINED(iv == 0 or iv == -1 or iv > 0 or iv < -1):
-            a4_4 = 3.0 * (2.0 * a4_1 - (a4_2 + a4_3))
+        a4_4 = 3.0 * (2.0 * a4_1 - (a4_2 + a4_3))
     with computation(FORWARD):
         with interval(-2, -1):
             a4_1, a4_2, a4_3, a4_4 = remap_constraint(a4_1, a4_2, a4_3, a4_4, extm)

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -6,7 +6,7 @@ from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, 
 import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import FrozenStencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ
+from fv3core.utils.typing import FloatField, FloatFieldIJ, BoolField
 
 
 @gtscript.function
@@ -99,12 +99,12 @@ def remap_constraint(
     a4_2: FloatField,
     a4_3: FloatField,
     a4_4: FloatField,
-    extm: FloatField,
+    extm: BoolField,
 ):
     da1 = a4_3 - a4_2
     da2 = da1 * da1
     a6da = a4_4 * da1
-    if extm == 1:
+    if extm:
         a4_2 = a4_1
         a4_3 = a4_1
         a4_4 = 0.0
@@ -214,9 +214,9 @@ def apply_constraints(
     a4_2: FloatField,
     a4_3: FloatField,
     a4_4: FloatField,
-    ext5: FloatField,
-    ext6: FloatField,
-    extm: FloatField,
+    ext5: BoolField,
+    ext6: BoolField,
+    extm: BoolField,
 ):
     from __externals__ import iv, kord
 
@@ -287,9 +287,9 @@ def set_interpolation_coefficients(
     a4_2: FloatField,
     a4_3: FloatField,
     a4_4: FloatField,
-    ext5: FloatField,
-    ext6: FloatField,
-    extm: FloatField,
+    ext5: BoolField,
+    ext6: BoolField,
+    extm: BoolField,
     qmin: float,
 ):
     from __externals__ import iv, kord
@@ -383,9 +383,9 @@ def set_interpolation_coefficients(
             tmp_max = a4_2
             tmp_max0 = a4_1
             if (
-                (extm != 0.0 and extm[0, 0, -1] != 0.0)
-                or (extm != 0.0 and extm[0, 0, 1] != 0.0)
-                or (extm > 0.0 and (qmin > 0.0 and a4_1 < qmin))
+                (extm and extm[0, 0, -1])
+                or (extm and extm[0, 0, 1])
+                or (extm and (qmin > 0.0 and a4_1 < qmin))
             ):
                 a4_2 = a4_1
                 a4_3 = a4_1
@@ -534,14 +534,14 @@ class RemapProfile:
         self._q_bot: FloatField = utils.make_storage_from_shape(
             grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig
         )
-        self._extm: FloatField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig
+        self._extm: BoolField = utils.make_storage_from_shape(
+            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=utils.booltype
         )
-        self._ext5: FloatField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig
+        self._ext5: BoolField = utils.make_storage_from_shape(
+            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=utils.booltype
         )
-        self._ext6: FloatField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig
+        self._ext6: BoolField = utils.make_storage_from_shape(
+            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=utils.booltype
         )
 
         i_extent: int = i2 - i1 + 1

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -220,27 +220,36 @@ def apply_constraints(
         gam = a4_1 - a4_1_0
     with computation(PARALLEL), interval(1, 2):
         # do top
-        q = q if q < tmp else tmp
-        q = q if q > tmp2 else tmp2
+        if q >= tmp:
+            q = tmp
+        if q <= tmp2:
+            q = tmp2
     with computation(FORWARD):
         with interval(2, -1):
             # do middle
             if (gam[0, 0, -1] * gam[0, 0, 1]) > 0:
-                q = q if q < tmp else tmp
-                q = q if q > tmp2 else tmp2
+                if q >= tmp:
+                    q = tmp
+                if q <= tmp2:
+                    q = tmp2
             elif gam[0, 0, -1] > 0:
                 # there's a local maximum
-                q = q if q > tmp2 else tmp2
+                if q <= tmp2:
+                    q = tmp2
             else:
                 # there's a local minimum
-                q = q if q < tmp else tmp
+                if q >= tmp:
+                    q = tmp
                 if __INLINED(iv == 0):
-                    q = 0.0 if (q < 0.0) else q
+                    if q < 0.0:
+                        q = 0.0
             # q = constrain_interior(q, gam, a4_1)
         with interval(-1, None):
             # do bottom
-            q = q if q < tmp else tmp
-            q = q if q > tmp2 else tmp2
+            if q >= tmp:
+                q = tmp
+            if q <= tmp2:
+                q = tmp2
     with computation(PARALLEL), interval(...):
         # re-set a4_2 and a4_3
         a4_2 = q
@@ -280,7 +289,8 @@ def set_interpolation_coefficients(
     # set_top_as_iv0
     with computation(PARALLEL), interval(0, 1):
         if __INLINED(iv == 0):
-            a4_2 = a4_2 if a4_2 > 0.0 else 0.0
+            if a4_2 < 0.0:
+                a4_2 = 0.0
     with computation(PARALLEL), interval(0, 2):
         if __INLINED(iv == 0):
             a4_4 = 3 * (2 * a4_1 - (a4_2 + a4_3))

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -6,7 +6,7 @@ from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, 
 import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import FrozenStencil
-from fv3core.utils.typing import FloatField, FloatFieldIJ, BoolField
+from fv3core.utils.typing import BoolField, FloatField, FloatFieldIJ
 
 
 @gtscript.function
@@ -170,7 +170,7 @@ def set_initial_vals(
                 # set middle
                 bet = 2.0 + grid_ratio + grid_ratio - gam
                 q = (3.0 * (a4_1[0, 0, -1] + a4_1) - q[0, 0, -1]) / bet
-                # gam[0, 0, 1] = grid_ratio / bet                                                                                                                                                                             
+                # gam[0, 0, 1] = grid_ratio / bet
         with interval(-2, -1):
             if __INLINED(iv == -2):
                 # set bottom
@@ -206,6 +206,7 @@ def set_initial_vals(
     with computation(PARALLEL), interval(-1, None):
         if __INLINED(kord > 16):
             a4_3 = q_bot
+
 
 def apply_constraints(
     q: FloatField,

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -535,13 +535,13 @@ class RemapProfile:
             grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig
         )
         self._extm: BoolField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=utils.booltype
+            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
         )
         self._ext5: BoolField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=utils.booltype
+            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
         )
         self._ext6: BoolField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=utils.booltype
+            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
         )
 
         i_extent: int = i2 - i1 + 1

--- a/fv3core/stencils/saturation_adjustment.py
+++ b/fv3core/stencils/saturation_adjustment.py
@@ -1,7 +1,7 @@
 import math
 
 import gt4py.gtscript as gtscript
-from gt4py.gtscript import __INLINED, FORWARD, PARALLEL, computation, exp, floor, interval, log
+from gt4py.gtscript import __INLINED, PARALLEL, computation, exp, floor, interval, log
 
 import fv3core._config as spec
 import fv3core.utils.global_constants as constants

--- a/fv3core/stencils/saturation_adjustment.py
+++ b/fv3core/stencils/saturation_adjustment.py
@@ -783,14 +783,14 @@ def satadjust(
         q_con = q_liq + q_sol
         tmp = 1.0 + zvir * qv
         pt = pt1 * tmp * (1.0 - q_con)
-        tmp = constants.RDGAS * tmp
+        tmp *= constants.RDGAS
         cappa = tmp / (tmp + cvm)
         #  fix negative graupel with available cloud ice
         if qg < 0:
             maxtmp = max(0.0, qi)
-            tmp = min(-qg, maxtmp)
-            qg = qg + tmp
-            qi = qi - tmp
+            mintmp = min(-qg, maxtmp)
+            qg = qg + mintmp
+            qi = qi - mintmp
         else:
             qg = qg
         #  autoconversion from cloud ice to snow
@@ -853,7 +853,7 @@ def satadjust(
             dw = dw_ocean + (dw_land - dw_ocean) * mindw
             # "scale - aware" subgrid variability: 100 - km as the base
             dbl_sqrt_area = dw * (area ** 0.5 / 100.0e3) ** 0.5
-            maxtmp = 0.01 if 0.01 > dbl_sqrt_area else dbl_sqrt_area
+            maxtmp = max(0.01, dbl_sqrt_area)
             hvar = min(0.2, maxtmp)
             # partial cloudiness by pdf:
             # assuming subgrid linear distribution in horizontal; this is

--- a/fv3core/stencils/temperature_adjust.py
+++ b/fv3core/stencils/temperature_adjust.py
@@ -28,11 +28,11 @@ def compute_pkz_tempadjust(
         pkz: Layer mean pressure raised to the power of Kappa (in)
         delta_time_factor: scaled time step (in)
     """
-    with computation(PARALLEL):
-        with interval(...):
+    with computation(PARALLEL), interval(...):
             pkz = exp(cappa / (1.0 - cappa) * log(constants.RDG * delp / delz * pt))
             pkz = (constants.RDG * delp / delz * pt) ** (cappa / (1.0 - cappa))
             dtmp = heat_source / (constants.CV_AIR * delp)
+    with computation(PARALLEL):
         with interval(0, 1):
             deltmin = sign(min(delt_time_factor * 0.1, abs(dtmp)), dtmp)
             pt = pt + deltmin / pkz

--- a/fv3core/stencils/temperature_adjust.py
+++ b/fv3core/stencils/temperature_adjust.py
@@ -29,9 +29,9 @@ def compute_pkz_tempadjust(
         delta_time_factor: scaled time step (in)
     """
     with computation(PARALLEL), interval(...):
-            pkz = exp(cappa / (1.0 - cappa) * log(constants.RDG * delp / delz * pt))
-            pkz = (constants.RDG * delp / delz * pt) ** (cappa / (1.0 - cappa))
-            dtmp = heat_source / (constants.CV_AIR * delp)
+        pkz = exp(cappa / (1.0 - cappa) * log(constants.RDG * delp / delz * pt))
+        pkz = (constants.RDG * delp / delz * pt) ** (cappa / (1.0 - cappa))
+        dtmp = heat_source / (constants.CV_AIR * delp)
     with computation(PARALLEL):
         with interval(0, 1):
             deltmin = sign(min(delt_time_factor * 0.1, abs(dtmp)), dtmp)

--- a/fv3core/utils/global_config.py
+++ b/fv3core/utils/global_config.py
@@ -62,6 +62,8 @@ def set_device_sync(flag: bool):
 def get_device_sync() -> bool:
     return _DEVICE_SYNC
 
+def is_gpu_backend() -> bool:
+    return get_backend().endswith("cuda") or get_backend().endswith("gpu")
 
 class StencilConfig(Hashable):
     def __init__(
@@ -107,7 +109,7 @@ class StencilConfig(Hashable):
             "rebuild": self.rebuild,
             "format_source": self.format_source,
         }
-        if "cuda" in self.backend:
+        if is_gpu_backend():
             kwargs["device_sync"] = self.device_sync
         return kwargs
 

--- a/fv3core/utils/global_config.py
+++ b/fv3core/utils/global_config.py
@@ -62,8 +62,10 @@ def set_device_sync(flag: bool):
 def get_device_sync() -> bool:
     return _DEVICE_SYNC
 
+
 def is_gpu_backend() -> bool:
     return get_backend().endswith("cuda") or get_backend().endswith("gpu")
+
 
 class StencilConfig(Hashable):
     def __init__(

--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -463,7 +463,7 @@ def asarray(array, to_type=np.ndarray, dtype=None, order=None):
 
 
 def zeros(shape, dtype=Float):
-    storage_type = cp.ndarray if "cuda" in global_config.get_backend() else np.ndarray
+    storage_type = cp.ndarray if global_config.is_gpu_backend() else np.ndarray
     xp = cp if cp and storage_type is cp.ndarray else np
     return xp.zeros(shape)
 
@@ -547,5 +547,5 @@ def stack(tup, axis: int = 0, out=None):
 
 
 def device_sync() -> None:
-    if cp and "cuda" in global_config.get_backend():
+    if cp and global_config.is_gpu_backend():
         cp.cuda.Device(0).synchronize()

--- a/tests/savepoint/test_translate.py
+++ b/tests/savepoint/test_translate.py
@@ -10,6 +10,7 @@ import serialbox as ser
 import xarray as xr
 
 import fv3core._config
+import fv3core.utils.global_config as config
 import fv3core.utils.gt4py_utils as gt_utils
 import fv3gfs.util as fv3util
 from fv3core.utils.mpi import MPI
@@ -230,7 +231,7 @@ def test_sequential_savepoint(
     if testobj is None:
         pytest.xfail(f"no translate object available for savepoint {test_name}")
     # Reduce error threshold for GPU
-    if backend.endswith("cuda"):
+    if config.is_gpu_backend():
         testobj.max_error = max(testobj.max_error, GPU_MAX_ERR)
         testobj.near_zero = max(testobj.near_zero, GPU_NEAR_ZERO)
     if threshold_overrides is not None:
@@ -320,7 +321,7 @@ def test_mock_parallel_savepoint(
     if testobj is None:
         pytest.xfail(f"no translate object available for savepoint {test_name}")
     # Reduce error threshold for GPU
-    if backend.endswith("cuda"):
+    if config.is_gpu_backend():
         testobj.max_error = max(testobj.max_error, GPU_MAX_ERR)
         testobj.near_zero = max(testobj.near_zero, GPU_NEAR_ZERO)
     if threshold_overrides is not None:
@@ -413,7 +414,7 @@ def test_parallel_savepoint(
     if testobj is None:
         pytest.xfail(f"no translate object available for savepoint {test_name}")
     # Increase minimum error threshold for GPU
-    if backend.endswith("cuda"):
+    if config.is_gpu_backend():
         testobj.max_error = max(testobj.max_error, GPU_MAX_ERR)
         testobj.near_zero = max(testobj.near_zero, GPU_NEAR_ZERO)
     if threshold_overrides is not None:

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -49,6 +49,7 @@ Remapping:
       - q_con
       - tracers
   - backend: gtc:gt:gpu
+    max_error: 1e-5
     near_zero: 5e-6
     ignore_near_zero_errors:
       - q_con

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -60,7 +60,7 @@ Remapping:
       - q_con
       - tracers
   - backend: gtc:gt:gpu
-    max_error: 1e-5
+    max_error: 1e-9
     near_zero: 5e-6
     ignore_near_zero_errors:
       - q_con

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -2,16 +2,23 @@ CS_Profile_2d:
   - backend: gtcuda
     max_error: 2.5e-9
     near_zero: 1.5e-14
+  - backend: gtc:gt:gpu	
+    max_error: 2.5e-9
+    near_zero: 1.5e-14
 
 CS_Profile_2d-2:
   - backend: gtcuda
     max_error: 3e-8
     near_zero: 1.5e-14
-
+  - backend: gtc:gt:gpu
+    max_error: 3e-8
+    near_zero: 1.5e-14
 Fillz:
   - backend: gtcuda
     max_error: 1e-13
     near_zero: 3e-15
+  - backend: gtc:gt:gpu
+    max_error: 5e-6
 
 MapN_Tracer_2d:
   - backend: gtcuda
@@ -35,20 +42,13 @@ Riem_Solver3:
     backend: numpy
     max_error: 1e-11 # 48_6ranks
 
-Remapping_Part1:
-  - backend: gtcuda
-    max_error: 5e-6
-    near_zero: 8.5e-15
-    ignore_near_zero_errors:
-      - q_con
-      - qtracers
-
-Remapping_Part2:
-  - backend: gtcuda
-    max_error: 3e-10
-
 Remapping:
   - backend: gtcuda
+    near_zero: 5e-6
+    ignore_near_zero_errors:
+      - q_con
+      - tracers
+  - backend: gtc:gt:gpu
     near_zero: 5e-6
     ignore_near_zero_errors:
       - q_con
@@ -60,9 +60,18 @@ UpdateDzC:
     near_zero: 4.5e-15
     ignore_near_zero_errors:
       - ws
+  - backend: gtc:gt:gpu
+    max_error: 5e-10
+    near_zero: 4.5e-15
+    ignore_near_zero_errors:
+      - ws
 
 UpdateDzD:
   - backend: gtcuda
+    max_error: 5e-10
+    ignore_near_zero_errors:
+      - wsd
+  - backend: gtc:gt:gpu
     max_error: 5e-10
     ignore_near_zero_errors:
       - wsd

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -2,7 +2,7 @@ CS_Profile_2d:
   - backend: gtcuda
     max_error: 2.5e-9
     near_zero: 1.5e-14
-  - backend: gtc:gt:gpu	
+  - backend: gtc:gt:gpu
     max_error: 2.5e-9
     near_zero: 1.5e-14
 

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -5,6 +5,9 @@ CS_Profile_2d:
   - backend: gtc:gt:gpu
     max_error: 2.5e-9
     near_zero: 1.5e-14
+  - backend: gtc:cuda
+    max_error: 2.5e-9
+    near_zero: 1.5e-14
 
 CS_Profile_2d-2:
   - backend: gtcuda
@@ -13,6 +16,10 @@ CS_Profile_2d-2:
   - backend: gtc:gt:gpu
     max_error: 3e-8
     near_zero: 1.5e-14
+  - backend: gtc:cuda
+    max_error: 3e-8
+    near_zero: 1.5e-14
+
 Fillz:
   - backend: gtcuda
     max_error: 1e-13
@@ -37,6 +44,10 @@ NH_P_Grad:
 
 Riem_Solver3:
   - backend: gtcuda
+    max_error: 5e-6
+  - backend: gtc:gt:gpu
+    max_error: 5e-6
+  - backend: gtc:cuda
     max_error: 5e-6
   - platform: metal
     backend: numpy
@@ -66,6 +77,11 @@ UpdateDzC:
     near_zero: 4.5e-15
     ignore_near_zero_errors:
       - ws
+  - backend: gtc:cuda
+    max_error: 5e-10
+    near_zero: 4.5e-15
+    ignore_near_zero_errors:
+      - ws
 
 UpdateDzD:
   - backend: gtcuda
@@ -73,6 +89,10 @@ UpdateDzD:
     ignore_near_zero_errors:
       - wsd
   - backend: gtc:gt:gpu
+    max_error: 5e-10
+    ignore_near_zero_errors:
+      - wsd
+  - backend: gtc:cuda
     max_error: 5e-10
     ignore_near_zero_errors:
       - wsd


### PR DESCRIPTION
## Purpose

In the feature/gtc-dace branch, we removed regions from fv3core and tested the rest of the code. This PR brings the changes needed we found there once FVDynamics validated with the gtc:gt:cpu_ifirst and gtc:gt:gpu backwnd, as well as some optimizations done along the way. With this, and the known regions race conditions we are also fixing, we should be able to test fv3core with regions with the GTC backends. 

NOTE, there is one change needed in D_SW:heat_source_from_vorticity_damping for the gtc:gt:gpu to validate that breaks the old (current) gtcuda backend. So instead of a code change a TODO was added. When we shift to GTC, that code change will need to happen at the same time. 

## Code changes:

- Fix to D_SW calculation of horizontal relative vorticity by adding a computation, otherwise reading with an offset API fields that have just been written does not work. 
- DivergenceDamping won't run the stencils for 'low k values' where nord=0, if there are in fact 0 vertical indices that meet this criteria. Otherwise some backends crashed. 
- NegAdj3 no longer has overlapping intervals and also has terniary conditions that involve self assignment turned into simple if statements
- RemapProfile has several refactors. On changes a PARALLEL to a FORWARD to prevent out of order calculations(workaround for a potential bug), factoring terniary if statements with self assignment to simple if statments and logic condensation to make it more efficient and other requirements to pass on GTC (@eddie-c-davis, would you mind updating this if there is anything else ?). Also the 'ext' variables are BoolFields -- not required for GTC but was a concern setting a float to a logical value and checkin == 1 could be a recipe for trouble. 
- SaturationAdjustment uses hydrostatic INLINED and temporary fields are cleaned up -- not required for GTC, but changes came about when investigating failures, and looks to be more efficient. 
- Remove an overlapping interval from temperature_adjust
- Overrides file includes gtc:gt:gpu and gtc:gtcuda backends

## Infrastructure changes:

- added installation of the GridTools v2 to the jenkins install venv script. Instead this should be done in daint_venv when we are ready to move to GTC (or anytime before)
- added (Eddie) a global config method to check wither the backend is gpu rather than matching the cuda string

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
