### PR TITLE
Feature/integrate halo updater

### DIFF
--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -227,9 +227,11 @@ class AcousticDynamics:
     """
 
     class HaloUpdaters:
-        """Encapsulate all HaloUpdaters required in the AcousticDynamics"""
+        """Encapsulate all HaloUpdater objects"""
 
         def __init__(self, grid, shape, origin):
+            # Define the memory specification required
+            # Those can be re-used as they are read-only descriptors
             full_size_xyz_halo_spec = grid.get_halo_update_spec(
                 shape,
                 origin,
@@ -261,6 +263,10 @@ class AcousticDynamics:
                 dims=[fv3util.X_INTERFACE_DIM, fv3util.Y_INTERFACE_DIM, fv3util.Z_DIM],
             )
 
+            # Build the HaloUpdater. We could build one updater per specification group
+            # but because of call overlap between different variable, we kept the straighforward
+            # solution of one HaloUpdater per group of updated variable.
+            # It also makes the code in call() more readable
             self.q_con__cappa = self.comm.get_scalar_halo_updater(
                 [full_size_xyz_halo_spec] * 2
             )

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -264,8 +264,8 @@ class AcousticDynamics:
             )
 
             # Build the HaloUpdater. We could build one updater per specification group
-            # but because of call overlap between different variable, we kept the straighforward
-            # solution of one HaloUpdater per group of updated variable.
+            # but because of call overlap between different variable, we kept the
+            # straighforward solution of one HaloUpdater per group of updated variable.
             # It also makes the code in call() more readable
             self.q_con__cappa = self.comm.get_scalar_halo_updater(
                 [full_size_xyz_halo_spec] * 2

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -1,4 +1,5 @@
 from typing import Mapping
+from fv3gfs.util.halo_updater import HaloUpdater
 
 from gt4py.gtscript import PARALLEL, computation, interval, log
 
@@ -103,6 +104,7 @@ def post_remap(
     namelist,
     hyperdiffusion: HyperdiffusionDamping,
     set_omega_stencil: FrozenStencil,
+    omega_halo_updater: HaloUpdater,
 ):
     grid = grid
     if not namelist.hydrostatic:
@@ -120,7 +122,7 @@ def post_remap(
             if grid.rank == 0:
                 print("Del2Cubed")
         if global_config.get_do_halo_exchange():
-            comm.halo_update(state.omga_quantity, n_points=utils.halo)
+            omega_halo_updater.update([state.omga_quantity])
         hyperdiffusion(state.omga, 0.18 * grid.da_min)
 
 
@@ -278,7 +280,9 @@ class DynamicalCore:
         self.namelist = namelist
         self.do_halo_exchange = global_config.get_do_halo_exchange()
 
-        self.tracer_advection = tracer_2d_1l.TracerAdvection(comm, namelist)
+        self.tracer_advection = tracer_2d_1l.TracerAdvection(
+            comm, namelist, DynamicalCore.NQ
+        )
         self._ak = ak.storage
         self._bk = bk.storage
         self._phis = phis.storage
@@ -331,6 +335,18 @@ class DynamicalCore:
         self._lagrangian_to_eulerian_obj = LagrangianToEulerian(
             self.grid, namelist, DynamicalCore.NQ, self._pfull
         )
+
+        phis_spec = self.grid.get_halo_update_spec(
+            phis.data.shape, phis.origin, utils.halo, phis.dims
+        )
+        self._phis_halo_updater = self.comm.get_scalar_halo_updater([phis_spec])
+
+        full_xyz_spec = self.grid.get_halo_update_spec(
+            self.grid.domain_shape_full(add=(1, 1, 1)),
+            self.grid.compute_origin(),
+            utils.halo,
+        )
+        self._omega_halo_updater = self.comm.get_scalar_halo_updater([full_xyz_spec])
 
     def step_dynamics(
         self,
@@ -388,7 +404,7 @@ class DynamicalCore:
         state.bk = self._bk
         last_step = False
         if self.do_halo_exchange:
-            self.comm.halo_update(state.phis_quantity, n_points=utils.halo)
+            self._phis_halo_updater.update([state.phis_quantity])
         compute_preamble(
             state,
             self.grid,
@@ -462,6 +478,7 @@ class DynamicalCore:
                         self.namelist,
                         self._hyperdiffusion,
                         self._set_omega_stencil,
+                        self._omega_halo_updater,
                     )
         wrapup(
             state,

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -122,7 +122,9 @@ class TracerAdvection:
     Corresponds to tracer_2D_1L in the Fortran code.
     """
 
-    def __init__(self, comm: fv3gfs.util.CubedSphereCommunicator, namelist):
+    def __init__(
+        self, comm: fv3gfs.util.CubedSphereCommunicator, namelist, tracers_count
+    ):
         self.comm = comm
         self.grid = spec.grid
         self._do_halo_exchange = global_config.get_do_halo_exchange()
@@ -182,6 +184,12 @@ class TracerAdvection:
         # self._cmax_1 = FrozenStencil(cmax_stencil1)
         # self._cmax_2 = FrozenStencil(cmax_stencil2)
 
+        # Setup halo updater for tracers
+        tracer_halo_spec = self.grid.get_halo_update_spec(shape, origin, utils.halo)
+        self._tracers_halo_updater = self.comm.get_scalar_halo_updater(
+            [tracer_halo_spec] * tracers_count
+        )
+
     def __call__(self, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt):
         # start HALO update on q (in dyn_core in fortran -- just has started when
         # this function is called...)
@@ -238,13 +246,8 @@ class TracerAdvection:
                 n_split,
             )
 
-        reqs = []
         if self._do_halo_exchange:
-            reqs.clear()
-            for q in tracers.values():
-                reqs.append(self.comm.start_halo_update(q, n_points=utils.halo))
-            for req in reqs:
-                req.wait()
+            self._tracers_halo_updater.update(tracers.values())
 
         dp2 = self._tmp_dp
 
@@ -279,11 +282,6 @@ class TracerAdvection:
                 )
             if not last_call:
                 if self._do_halo_exchange:
-                    reqs.clear()
-                    for q in tracers.values():
-                        reqs.append(self.comm.start_halo_update(q, n_points=utils.halo))
-                    for req in reqs:
-                        req.wait()
-
+                    self._tracers_halo_updater.update(tracers.values())
                 # use variable assignment to avoid a data copy
                 dp1, dp2 = dp2, dp1

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -373,6 +373,7 @@ class Grid:
         # memory layout. Firther work in GT4PY will allow for deferred allocation
         # which will give access to those information while making sure
         # we don't allocate
+        # Refactor is filed in ticker DSL-820
 
         temp_storage = utils.make_storage_from_shape(shape, origin)
         temp_quantity = self.quantity_wrap(temp_storage, dims=dims)

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -1,7 +1,7 @@
 import dataclasses
 import functools
 from typing import Iterable, List, Mapping, Sequence, Tuple, Union
-from fv3gfs.util.halo_data_transformer import HaloUpdateSpec
+from fv3gfs.util.halo_data_transformer import QuantityHaloSpec
 
 import numpy as np
 from gt4py import gtscript
@@ -366,7 +366,7 @@ class Grid:
         origin,
         halo_points,
         dims=[fv3util.X_DIM, fv3util.Y_DIM, fv3util.Z_DIM],
-    ) -> HaloUpdateSpec:
+    ) -> QuantityHaloSpec:
         """Build memory specification for the halo update of a give shape/halo_points."""
 
         # TEMPORARY: we do a nasty temporary allocation here to read in the hardware
@@ -376,7 +376,7 @@ class Grid:
         temp_storage = utils.make_storage_from_shape(shape, origin)
         temp_quantity = self.quantity_wrap(temp_storage, dims=dims)
 
-        spec = HaloUpdateSpec(
+        spec = QuantityHaloSpec(
             halo_points,
             temp_quantity.data.strides,
             temp_quantity.data.itemsize,

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -370,10 +370,10 @@ class Grid:
         """Build memory specifications for the halo update."""
 
         # TEMPORARY: we do a nasty temporary allocation here to read in the hardware
-        # memory layout. Firther work in GT4PY will allow for deferred allocation
+        # memory layout. Further work in GT4PY will allow for deferred allocation
         # which will give access to those information while making sure
         # we don't allocate
-        # Refactor is filed in ticker DSL-820
+        # Refactor is filed in ticket DSL-820
 
         temp_storage = utils.make_storage_from_shape(shape, origin)
         temp_quantity = self.quantity_wrap(temp_storage, dims=dims)

--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -1,14 +1,13 @@
 import dataclasses
 import functools
 from typing import Iterable, List, Mapping, Sequence, Tuple, Union
-from fv3gfs.util.halo_data_transformer import QuantityHaloSpec
 
 import numpy as np
 from gt4py import gtscript
 
 import fv3core.utils.global_config as global_config
 import fv3gfs.util as fv3util
-from fv3gfs.util.halo_data_transformer import HaloUpdateSpec
+from fv3gfs.util.halo_data_transformer import QuantityHaloSpec
 
 from . import gt4py_utils as utils
 from .typing import FloatFieldIJ, FloatFieldK, Index3D

--- a/profiler/tools/nvtx_markings.py
+++ b/profiler/tools/nvtx_markings.py
@@ -50,35 +50,30 @@ functions_desc = [
         "name": get_name_from_frame,
     },
     {
-        "fn": "halo_update",
-        "file": None,
-        "name": "HaloEx: sync scalar",
-    },  # Synchroneous halo update
-    {
-        "fn": "vector_halo_update",
-        "file": None,
-        "name": "HaloEx: sync vector",
-    },  # Synchroneous vector halo update
-    {
-        "fn": "start_halo_update",
-        "file": None,
-        "name": "HaloEx: async scalar",
-    },  # Asynchroneous halo update
-    {
-        "fn": "start_vector_halo_update",
-        "file": None,
-        "name": "HaloEx: async vector",
-    },  # Asynchroneous vector halo update
-    {
         "fn": "wait",
-        "file": "fv3gfs/util/communicator.py",
-        "name": "HaloEx: unpack and wait",
-    },  # Halo update finish
+        "file": "fv3gfs/util/halo_updater.py",
+        "name": "HaloUpdater.wait",
+    },
     {
-        "fn": "_device_synchronize",
-        "file": "fv3gfs/util/communicator.py",
-        "name": "Pre HaloEx",
-    },  # Synchronize all work prior to halo exchange
+        "fn": "start",
+        "file": "fv3gfs/util/halo_updater.py",
+        "name": "HaloUpdater.start",
+    },
+    {
+        "fn": "async_pack",
+        "file": "fv3gfs/util/halo_data_transformer.py",
+        "name": "HaloDataTrf.async_pack",
+    },
+    {
+        "fn": "async_unpack",
+        "file": "fv3gfs/util/halo_data_transformer.py",
+        "name": "HaloDataTrf.async_unpack",
+    },
+    {
+        "fn": "synchronize",
+        "file": "fv3gfs/util/halo_data_transformer.py",
+        "name": "HaloDataTrf.synchronize",
+    },
 ]
 
 

--- a/tests/savepoint/translate/translate_tracer2d1l.py
+++ b/tests/savepoint/translate/translate_tracer2d1l.py
@@ -2,6 +2,7 @@ import pytest
 
 import fv3core._config as spec
 import fv3core.stencils.tracer_2d_1l
+import fv3core.stencils.fv_dynamics as fv_dynamics
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util as fv3util
 from fv3core.testing import ParallelTranslate
@@ -41,7 +42,7 @@ class TranslateTracer2D1L(ParallelTranslate):
             inputs["tracers"], inputs.pop("nq")
         )
         self.tracer_advection = fv3core.stencils.tracer_2d_1l.TracerAdvection(
-            communicator, spec.namelist
+            communicator, spec.namelist, fv_dynamics.DynamicalCore.NQ
         )
         self.tracer_advection(**inputs)
         inputs[


### PR DESCRIPTION
## Purpose

Integration of the object based API for halo exchange. Functional call are replaced by local HaloUpdater objects build from specification.
The HaloUpdater code lives in `fv3gfs-util` on the following PR: https://github.com/VulcanClimateModeling/fv3gfs-util/pull/79
A temporary function is added to Grid to simplify the construction of the specification descriptor. The aim is to refactor it later when GT4PY provides an interface to query the required low-level memory information needed.

## Code changes:

- Changes to all call to `comm.start_halo_*` and `comm.halo_*` to `HaloUpdater`
- Tracers2D1L requires a new `tracer_count` argument.
- Bundled all the `HaloUpdater` in a subclass in `AcousticDynamics` called `HaloUpdaters`

## Requirements changes:

N/A

## Infrastructure changes:

N/A

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
