### PR TITLE
rename FVSubgridZ to DryConvectiveAdjustment

### DIFF
--- a/examples/wrapped/runfiles/baroclinic_test.py
+++ b/examples/wrapped/runfiles/baroclinic_test.py
@@ -275,7 +275,7 @@ if __name__ == "__main__":
         state["atmosphere_hybrid_b_coordinate"],
         state["surface_geopotential"],
     )
-    fvsubgridz = fv3core.FVSubgridZ(spec.namelist)
+    fvsubgridz = fv3core.DryConvectiveAdjustment(spec.namelist)
     # Step through time
     for i in range(wrapper.get_step_count()):
         print("STEP IS ", i)

--- a/examples/wrapped/runfiles/fv3core_test.py
+++ b/examples/wrapped/runfiles/fv3core_test.py
@@ -266,7 +266,7 @@ if __name__ == "__main__":
         state["surface_geopotential"],
     )
 
-    fvsubgridz = fv3core.FVSubgridZ(spec.namelist)
+    fvsubgridz = fv3core.DryConvectiveAdjustment(spec.namelist)
     # Step through time
     for i in range(wrapper.get_step_count()):
         print("STEP IS ", i)

--- a/fv3core/__init__.py
+++ b/fv3core/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa: F401
 from . import decorators
 from .stencils.fv_dynamics import DynamicalCore
-from .stencils.fv_subgridz import FVSubgridZ
+from .stencils.fv_subgridz import DryConvectiveAdjustment
 from .utils.global_config import (
     get_backend,
     get_rebuild,

--- a/fv3core/stencils/fv_subgridz.py
+++ b/fv3core/stencils/fv_subgridz.py
@@ -724,7 +724,7 @@ def finalize(
         qcld = q0_cld
 
 
-class FVSubgridZ:
+class DryConvectiveAdjustment:
     """
     Corresponds to fv_subgrid_z in Fortran's fv_sg module
     """

--- a/tests/savepoint/translate/translate_fvsubgridz.py
+++ b/tests/savepoint/translate/translate_fvsubgridz.py
@@ -174,7 +174,7 @@ class TranslateFVSubgridZ(ParallelTranslateBaseSlicing):
 
     def compute_parallel(self, inputs, communicator):
         state = self.state_from_inputs(inputs)
-        fvsubgridz = fv_subgridz.FVSubgridZ(
+        fvsubgridz = fv_subgridz.DryConvectiveAdjustment(
             spec.namelist,
         )
         state = SimpleNamespace(**state)


### PR DESCRIPTION
## Purpose

FVSubgridZ was never renamed from its Fortran name to something descriptive, though the docstring referencing the Fortran name was previously added. This PR renames the class as well.

## Code changes:

- Renamed FVSubgridZ to DryConvectiveAdjustment

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
