### PR TITLE
remove halo update of phis at start of dynamics step

### DIFF
--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -352,11 +352,6 @@ class DynamicalCore:
             self.grid, namelist, DynamicalCore.NQ, self._pfull
         )
 
-        phis_spec = self.grid.get_halo_update_spec(
-            phis.data.shape, phis.origin, utils.halo, phis.dims
-        )
-        self._phis_halo_updater = self.comm.get_scalar_halo_updater([phis_spec])
-
         full_xyz_spec = self.grid.get_halo_update_spec(
             self.grid.domain_shape_full(add=(1, 1, 1)),
             self.grid.compute_origin(),
@@ -419,8 +414,6 @@ class DynamicalCore:
         state.ak = self._ak
         state.bk = self._bk
         last_step = False
-        if self.do_halo_exchange:
-            self._phis_halo_updater.update([state.phis_quantity])
         compute_preamble(
             state,
             self.grid,


### PR DESCRIPTION
## Purpose

The dynamics step currently halo updates surface geopotential (phis) each timestep, even though it is a constant. This PR removes the halo update entirely, since phis is already halo updated by its initialization code.

## Code changes:

- Removed halo update of phis at the start of DynamicalCore.step_dynamics


## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes
