### PR TITLE
use NullComm to disable halo updates instead of config option

### DIFF
--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -150,7 +150,7 @@ sed -i "s/<OUTFILE>/run.daint.out\n#SBATCH --hint=nomultithread/g" run.daint.slu
 sed -i "s/00:45:00/01:10:00/g" run.daint.slurm
 sed -i "s/cscsci/normal/g" run.daint.slurm
 sed -i "s/<G2G>/export PYTHONOPTIMIZE=TRUE/g" run.daint.slurm
-sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python $py_args examples/standalone/runfile/dynamics.py --disable_halo_exchange $data_path $timesteps $backend $githash $run_args#g" run.daint.slurm
+sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python $py_args examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash $run_args#g" run.daint.slurm
 # execute on a gpu node
 set +e
 res=$(sbatch -W -C gpu run.daint.slurm 2>&1)
@@ -181,7 +181,7 @@ if [ "${DO_NSYS_RUN}" == "true" ] ; then
     sed -i "s/00:45:00/00:40:00/g" run.nsys.daint.slurm
     sed -i "s/cscsci/normal/g" run.nsys.daint.slurm
     sed -i "s#<G2G>#module load nvidia-nsight-systems/2021.1.1.66-6c5c5cb\nexport PYTHONOPTIMIZE=TRUE#g" run.nsys.daint.slurm
-    sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun nsys profile --force-overwrite=true -o %h.%q{SLURM_NODEID}.%q{SLURM_PROCID}.qdstrm --trace=cuda,mpi,nvtx --mpi-impl=mpich python $ROOT_DIR/profiler/external_profiler.py --nvtx examples/standalone/runfile/dynamics.py --disable_halo_exchange $data_path 3 $backend $githash --disable_json_dump#g" run.nsys.daint.slurm
+    sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun nsys profile --force-overwrite=true -o %h.%q{SLURM_NODEID}.%q{SLURM_PROCID}.qdstrm --trace=cuda,mpi,nvtx --mpi-impl=mpich python $ROOT_DIR/profiler/external_profiler.py --nvtx examples/standalone/runfile/dynamics.py $data_path 3 $backend $githash --disable_json_dump#g" run.nsys.daint.slurm
     # execute on a gpu node
     set +e
     res=$(sbatch -W -C gpu run.nsys.daint.slurm 2>&1)

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -150,7 +150,7 @@ sed -i "s/<OUTFILE>/run.daint.out\n#SBATCH --hint=nomultithread/g" run.daint.slu
 sed -i "s/00:45:00/01:10:00/g" run.daint.slurm
 sed -i "s/cscsci/normal/g" run.daint.slurm
 sed -i "s/<G2G>/export PYTHONOPTIMIZE=TRUE/g" run.daint.slurm
-sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python $py_args examples/standalone/runfile/dynamics.py $data_path $timesteps $backend $githash $run_args#g" run.daint.slurm
+sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun python $py_args examples/standalone/runfile/dynamics.py --disable_halo_exchange $data_path $timesteps $backend $githash $run_args#g" run.daint.slurm
 # execute on a gpu node
 set +e
 res=$(sbatch -W -C gpu run.daint.slurm 2>&1)
@@ -181,7 +181,7 @@ if [ "${DO_NSYS_RUN}" == "true" ] ; then
     sed -i "s/00:45:00/00:40:00/g" run.nsys.daint.slurm
     sed -i "s/cscsci/normal/g" run.nsys.daint.slurm
     sed -i "s#<G2G>#module load nvidia-nsight-systems/2021.1.1.66-6c5c5cb\nexport PYTHONOPTIMIZE=TRUE#g" run.nsys.daint.slurm
-    sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun nsys profile --force-overwrite=true -o %h.%q{SLURM_NODEID}.%q{SLURM_PROCID}.qdstrm --trace=cuda,mpi,nvtx --mpi-impl=mpich python $ROOT_DIR/profiler/external_profiler.py --nvtx examples/standalone/runfile/dynamics.py $data_path 3 $backend $githash --disable_json_dump#g" run.nsys.daint.slurm
+    sed -i "s#<CMD>#export PYTHONPATH=/project/s1053/install/serialbox2_master/gnu/python:\$PYTHONPATH\nsrun nsys profile --force-overwrite=true -o %h.%q{SLURM_NODEID}.%q{SLURM_PROCID}.qdstrm --trace=cuda,mpi,nvtx --mpi-impl=mpich python $ROOT_DIR/profiler/external_profiler.py --nvtx examples/standalone/runfile/dynamics.py --disable_halo_exchange $data_path 3 $backend $githash --disable_json_dump#g" run.nsys.daint.slurm
     # execute on a gpu node
     set +e
     res=$(sbatch -W -C gpu run.nsys.daint.slurm 2>&1)

--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -2,13 +2,13 @@
 
 import copy
 import json
+import os
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
 from typing import Any, Dict, List
 
 import numpy as np
 import serialbox
-import yaml
 from mpi4py import MPI
 
 import fv3core
@@ -37,7 +37,7 @@ def parse_args() -> Namespace:
         "backend",
         type=str,
         action="store",
-        help="path to the namelist",
+        help="gt4py backend to use",
     )
     parser.add_argument(
         "hash",
@@ -182,12 +182,7 @@ if __name__ == "__main__":
 
         spec.set_namelist(args.data_dir + "/input.nml")
 
-        experiment_name = yaml.safe_load(
-            open(
-                args.data_dir + "/input.yml",
-                "r",
-            )
-        )["experiment_name"]
+        experiment_name = os.path.basename(os.path.normpath(args.data_dir))
 
         # set up of helper structures
         serializer = serialbox.Serializer(

--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -14,15 +14,12 @@ from mpi4py import MPI
 import fv3core
 import fv3core._config as spec
 import fv3core.testing
-import fv3core.utils.global_config as global_config
 import fv3gfs.util as util
+from fv3core.utils.null_comm import NullComm
 
 
 def parse_args() -> Namespace:
-    usage = (
-        "usage: python %(prog)s <data_dir> <timesteps> <backend> <hash> <halo_exchange>"
-    )
-    parser = ArgumentParser(usage=usage)
+    parser = ArgumentParser()
 
     parser.add_argument(
         "data_dir",
@@ -182,7 +179,6 @@ if __name__ == "__main__":
         fv3core.set_backend(args.backend)
         fv3core.set_rebuild(False)
         fv3core.set_validate_args(False)
-        global_config.set_do_halo_exchange(not args.disable_halo_exchange)
 
         spec.set_namelist(args.data_dir + "/input.nml")
 
@@ -199,10 +195,10 @@ if __name__ == "__main__":
             args.data_dir,
             "Generator_rank" + str(rank),
         )
-        cube_comm = util.CubedSphereCommunicator(
-            comm,
-            util.CubedSpherePartitioner(util.TilePartitioner(spec.namelist.layout)),
-        )
+        if args.disable_halo_exchange:
+            mpi_comm = NullComm(MPI.COMM_WORLD.Get_rank(), MPI.COMM_WORLD.Get_size())
+        else:
+            mpi_comm = MPI.COMM_WORLD
 
         # get grid from serialized data
         grid_savepoint = serializer.get_savepoint("Grid-Info")[0]
@@ -218,7 +214,7 @@ if __name__ == "__main__":
         # set up grid-dependent helper structures
         layout = spec.namelist.layout
         partitioner = util.CubedSpherePartitioner(util.TilePartitioner(layout))
-        communicator = util.CubedSphereCommunicator(comm, partitioner)
+        communicator = util.CubedSphereCommunicator(mpi_comm, partitioner)
 
         # create a state from serialized data
         savepoint_in = serializer.get_savepoint("FVDynamics-In")[0]
@@ -289,9 +285,9 @@ if __name__ == "__main__":
     # Timings
     if not args.disable_json_dump:
         # Collect times and output statistics in json
-        comm.Barrier()
+        MPI.COMM_WORLD.Barrier()
         collect_data_and_write_to_file(
-            args, comm, hits_per_step, times_per_step, experiment_name
+            args, MPI.COMM_WORLD, hits_per_step, times_per_step, experiment_name
         )
     else:
         # Print a brief summary of timings

--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -2,13 +2,13 @@
 
 import copy
 import json
-import os
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
 from typing import Any, Dict, List
 
 import numpy as np
 import serialbox
+import yaml
 from mpi4py import MPI
 
 import fv3core
@@ -182,7 +182,12 @@ if __name__ == "__main__":
 
         spec.set_namelist(args.data_dir + "/input.nml")
 
-        experiment_name = os.path.basename(os.path.normpath(args.data_dir))
+        experiment_name = yaml.safe_load(
+            open(
+                args.data_dir + "/input.yml",
+                "r",
+            )
+        )["experiment_name"]
 
         # set up of helper structures
         serializer = serialbox.Serializer(

--- a/fv3core/stencils/c2l_ord.py
+++ b/fv3core/stencils/c2l_ord.py
@@ -1,6 +1,5 @@
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
-import fv3core.utils.global_config as global_config
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import FrozenStencil
 from fv3core.utils.grid import axis_offsets
@@ -75,7 +74,7 @@ class CubedToLatLon:
     Fortan name is c2l_ord2
     """
 
-    def __init__(self, grid, namelist, do_halo_update=None):
+    def __init__(self, grid, namelist):
         """
         Initializes stencils to use either 2nd or 4th order of interpolation
         based on namelist setting
@@ -86,10 +85,6 @@ class CubedToLatLon:
             do_halo_update: Optional. If passed, overrides global halo exchange flag
                             and performs a halo update on u and v
         """
-        if do_halo_update is not None:
-            self._do_halo_update = do_halo_update
-        else:
-            self._do_halo_update = global_config.get_do_halo_exchange()
         self._do_ord4 = True
         self.grid = grid
         if namelist.c2l_ord == 2:
@@ -133,7 +128,7 @@ class CubedToLatLon:
             va: y-wind on A-grid (out)
             comm: Cubed-sphere communicator
         """
-        if self._do_halo_update and self._do_ord4:
+        if self._do_ord4:
             comm.vector_halo_update(u, v, n_points=self.grid.halo)
         self._compute_cubed_to_latlon(
             u.storage,

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -4,7 +4,6 @@ from gt4py.gtscript import PARALLEL, computation, interval, log
 
 import fv3core._config as spec
 import fv3core.stencils.moist_cv as moist_cv
-import fv3core.utils.global_config as global_config
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util
@@ -121,8 +120,7 @@ def post_remap(
         if __debug__:
             if grid.rank == 0:
                 print("Del2Cubed")
-        if global_config.get_do_halo_exchange():
-            omega_halo_updater.update([state.omga_quantity])
+        omega_halo_updater.update([state.omga_quantity])
         hyperdiffusion(state.omga, 0.18 * grid.da_min)
 
 
@@ -278,7 +276,6 @@ class DynamicalCore:
         self.comm = comm
         self.grid = spec.grid
         self.namelist = namelist
-        self.do_halo_exchange = global_config.get_do_halo_exchange()
 
         self.tracer_advection = tracer_2d_1l.TracerAdvection(
             comm, namelist, DynamicalCore.NQ

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -6,7 +6,6 @@ from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 import fv3core._config as spec
 import fv3core.stencils.fxadv
 import fv3core.utils
-import fv3core.utils.global_config as global_config
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util
 from fv3core.decorators import FrozenStencil
@@ -127,7 +126,6 @@ class TracerAdvection:
     ):
         self.comm = comm
         self.grid = spec.grid
-        self._do_halo_exchange = global_config.get_do_halo_exchange()
         shape = self.grid.domain_shape_full(add=(1, 1, 1))
         origin = self.grid.compute_origin()
         self._tmp_xfx = utils.make_storage_from_shape(shape, origin)
@@ -246,8 +244,7 @@ class TracerAdvection:
                 n_split,
             )
 
-        if self._do_halo_exchange:
-            self._tracers_halo_updater.update(tracers.values())
+        self._tracers_halo_updater.update(tracers.values())
 
         dp2 = self._tmp_dp
 
@@ -281,7 +278,6 @@ class TracerAdvection:
                     dp2,
                 )
             if not last_call:
-                if self._do_halo_exchange:
-                    self._tracers_halo_updater.update(tracers.values())
+                self._tracers_halo_updater.update(tracers.values())
                 # use variable assignment to avoid a data copy
                 dp1, dp2 = dp2, dp1

--- a/fv3core/utils/global_config.py
+++ b/fv3core/utils/global_config.py
@@ -45,15 +45,6 @@ def get_format_source() -> bool:
     return _FORMAT_SOURCE
 
 
-def set_do_halo_exchange(flag: bool):
-    global _DO_HALO_EXCHANGE
-    _DO_HALO_EXCHANGE = flag
-
-
-def get_do_halo_exchange() -> bool:
-    return _DO_HALO_EXCHANGE
-
-
 def set_device_sync(flag: bool):
     global _DEVICE_SYNC
     _DEVICE_SYNC = flag
@@ -132,6 +123,5 @@ _BACKEND = None
 # if FALSE, caches will be checked and rebuild if code changes
 _REBUILD = getenv_bool("FV3_STENCIL_REBUILD_FLAG", "False")
 _FORMAT_SOURCE = getenv_bool("FV3_STENCIL_FORMAT_SOURCE", "False")
-_DO_HALO_EXCHANGE = True
 _VALIDATE_ARGS = True
 _DEVICE_SYNC = False

--- a/fv3core/utils/null_comm.py
+++ b/fv3core/utils/null_comm.py
@@ -13,9 +13,17 @@ class NullComm:
     'receives' zeros instead of using MPI.
     """
 
-    def __init__(self, rank, total_ranks):
+    def __init__(self, rank, total_ranks, fill_value=0.0):
+        """
+        Args:
+            rank: rank to mock
+            total_ranks: number of total MPI ranks to mock
+            fill_value: fill halos with this value when performing
+                halo updates.
+        """
         self.rank = rank
         self.total_ranks = total_ranks
+        self._fill_value = fill_value
 
     def __repr__(self):
         return f"NullComm(rank={self.rank}, total_ranks={self.total_ranks})"
@@ -34,11 +42,11 @@ class NullComm:
 
     def Scatter(self, sendbuf, recvbuf, root=0, **kwargs):
         if recvbuf is not None:
-            recvbuf[:] = 0.0
+            recvbuf[:] = self._fill_value
 
     def Gather(self, sendbuf, recvbuf, root=0, **kwargs):
         if recvbuf is not None:
-            recvbuf[:] = 0.0
+            recvbuf[:] = self._fill_value
 
     def Send(self, sendbuf, dest, **kwargs):
         pass
@@ -47,7 +55,7 @@ class NullComm:
         return NullAsyncResult()
 
     def Recv(self, recvbuf, source, **kwargs):
-        recvbuf[:] = 0.0
+        recvbuf[:] = self._fill_value
 
     def Irecv(self, recvbuf, source, **kwargs):
         return NullAsyncResult(recvbuf)

--- a/fv3core/utils/null_comm.py
+++ b/fv3core/utils/null_comm.py
@@ -1,11 +1,16 @@
 class NullAsyncResult:
+    def __init__(self, recvbuf=None):
+        self._recvbuf = recvbuf
+
     def wait(self):
-        pass
+        if self._recvbuf is not None:
+            self._recvbuf[:] = 0.0
 
 
 class NullComm:
     """
-    A class with a subset of the mpi4py Comm API, but which does nothing.
+    A class with a subset of the mpi4py Comm API, but which
+    'receives' zeros instead of using MPI.
     """
 
     def __init__(self, rank, total_ranks):
@@ -28,10 +33,12 @@ class NullComm:
         return
 
     def Scatter(self, sendbuf, recvbuf, root=0, **kwargs):
-        pass
+        if recvbuf is not None:
+            recvbuf[:] = 0.0
 
     def Gather(self, sendbuf, recvbuf, root=0, **kwargs):
-        pass
+        if recvbuf is not None:
+            recvbuf[:] = 0.0
 
     def Send(self, sendbuf, dest, **kwargs):
         pass
@@ -40,7 +47,7 @@ class NullComm:
         return NullAsyncResult()
 
     def Recv(self, recvbuf, source, **kwargs):
-        pass
+        recvbuf[:] = 0.0
 
     def Irecv(self, recvbuf, source, **kwargs):
-        return NullAsyncResult()
+        return NullAsyncResult(recvbuf)

--- a/fv3core/utils/null_comm.py
+++ b/fv3core/utils/null_comm.py
@@ -1,0 +1,46 @@
+class NullAsyncResult:
+    def wait(self):
+        pass
+
+
+class NullComm:
+    """
+    A class with a subset of the mpi4py Comm API, but which does nothing.
+    """
+
+    def __init__(self, rank, total_ranks):
+        self.rank = rank
+        self.total_ranks = total_ranks
+
+    def __repr__(self):
+        return f"NullComm(rank={self.rank}, total_ranks={self.total_ranks})"
+
+    def Get_rank(self):
+        return self.rank
+
+    def Get_size(self):
+        return self.total_ranks
+
+    def bcast(self, value, root=0):
+        return value
+
+    def barrier(self):
+        return
+
+    def Scatter(self, sendbuf, recvbuf, root=0, **kwargs):
+        pass
+
+    def Gather(self, sendbuf, recvbuf, root=0, **kwargs):
+        pass
+
+    def Send(self, sendbuf, dest, **kwargs):
+        pass
+
+    def Isend(self, sendbuf, dest, **kwargs):
+        return NullAsyncResult()
+
+    def Recv(self, recvbuf, source, **kwargs):
+        pass
+
+    def Irecv(self, recvbuf, source, **kwargs):
+        return NullAsyncResult()

--- a/fv3core/utils/null_comm.py
+++ b/fv3core/utils/null_comm.py
@@ -10,7 +10,7 @@ class NullAsyncResult:
 class NullComm:
     """
     A class with a subset of the mpi4py Comm API, but which
-    'receives' zeros instead of using MPI.
+    'receives' a fill value (default zero) instead of using MPI.
     """
 
     def __init__(self, rank, total_ranks, fill_value=0.0):


### PR DESCRIPTION
## Purpose

Currently we disable halo updates during compilation by passing a global configuration option. This PR refactors the code to disable these instead  by making use of a mock of the mpi4py comm object which does no communication.

## Code changes:

- Removed `do_halo_exchange` options from several classes
- Added NullComm class in `fv3core.util.null_comm`. This should later be moved to `fv3gfs.util`.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)