### PR TITLE
Switch MPICH to _not_ use  shared memory in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,15 @@ COPY tests /fv3core/tests
 COPY setup.py setup.cfg README.md /fv3core/
 COPY docker/entrypoint.sh /entrypoint.sh
 
+# Docker hard limits shared memory usage. MPICH for oversubscribed situation
+# uses shared mem for most of its comunication operations,
+# which leads to a sigbus crash.
+# Both of those (for version <3.2 and >3.2) will force mpich to go
+# through the network stack instead of using the shared nemory
+# The cost is a slower runtime
+ENV MPIR_CVAR_NOLOCAL=1
+ENV MPIR_CVAR_CH3_NOLOCAL=1
+
 RUN chmod +x /entrypoint.sh && \
     /entrypoint.sh
 


### PR DESCRIPTION
## Purpose

Docker hard limits shared memory usage.
MPICH for oversubscribed situation uses shared mem for most of its communication operations, which leads to a sigbus crash.

## Code changes:

Using `MPIR_CVAR_NOLOCAL=1` (mpich >3.2) and `MPIR_CVAR_CH3_NOLOCAL=1` (mpich<3.2)
forces mpich to go through the network stack instead of using the shared memory.

The cost is a slower runtime.

## Requirements changes:

N/A

## Infrastructure changes:

N/A

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes