### PR TITLE
add halo update of phis to wrapper runfiles

### DIFF
--- a/examples/wrapped/runfiles/baroclinic_test.py
+++ b/examples/wrapped/runfiles/baroclinic_test.py
@@ -268,6 +268,7 @@ if __name__ == "__main__":
     n_tracers = 6
 
     state = wrapper.get_state(allocator=allocator, names=initial_names)
+    cube_comm.halo_update(state["surface_geopotential"])
     dycore = fv3core.DynamicalCore(
         cube_comm,
         spec.namelist,

--- a/examples/wrapped/runfiles/fv3core_test.py
+++ b/examples/wrapped/runfiles/fv3core_test.py
@@ -258,6 +258,7 @@ if __name__ == "__main__":
     n_tracers = 6
 
     state = wrapper.get_state(allocator=allocator, names=initial_names)
+    cube_comm.halo_update(state["surface_geopotential"])
     dycore = fv3core.DynamicalCore(
         cube_comm,
         spec.namelist,


### PR DESCRIPTION
## Purpose

A previous PR removed a halo update of phis at the start of fv_dynamics, which should have been instead placed in the wrapper runfiles after getting a halo-less phis from the fv3gfs-wrapper. This PR adds the halo update in to those runfiles.

## Code changes:

- Added halo update of phis to wrapper runfiles

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes