### PR TITLE
refactor inits except for fv_dynamics, fv_subgridz, and tracer_2d_1l

### DIFF
--- a/fv3core/_config.py
+++ b/fv3core/_config.py
@@ -74,6 +74,49 @@ DEFAULT_BOOL = False
 
 
 @dataclasses.dataclass(frozen=True)
+class SatAdjustConfig:
+    hydrostatic: bool
+    rad_snow: bool
+    rad_rain: bool
+    rad_graupel: bool
+    tintqs: bool
+    sat_adj0: float
+    ql_gen: float
+    qs_mlt: float
+    ql0_max: float
+    t_sub: float
+    qi_gen: float
+    qi_lim: float
+    qi0_max: float
+    dw_ocean: float
+    dw_land: float
+    icloud_f: int
+    cld_min: float
+    tau_i2s: float
+    tau_v2l: float
+    tau_r2g: float
+    tau_l2r: float
+    tau_l2v: float
+    tau_imlt: float
+    tau_smlt: float
+
+
+@dataclasses.dataclass(frozen=True)
+class RemappingConfig:
+    fill: bool
+    kord_tm: int
+    kord_tr: int
+    kord_wz: int
+    kord_mt: int
+    do_sat_adj: bool
+    sat_adjust: SatAdjustConfig
+
+    @property
+    def hydrostatic(self) -> bool:
+        return self.sat_adjust.hydrostatic
+
+
+@dataclasses.dataclass(frozen=True)
 class RiemannConfig:
     p_fac: float
     a_imp: float
@@ -509,6 +552,47 @@ class Namelist:
             d_grid_shallow_water=self.d_grid_shallow_water,
         )
 
+    @property
+    def sat_adjust(self) -> SatAdjustConfig:
+        return SatAdjustConfig(
+            hydrostatic=self.hydrostatic,
+            rad_snow=self.rad_snow,
+            rad_rain=self.rad_rain,
+            rad_graupel=self.rad_graupel,
+            tintqs=self.tintqs,
+            sat_adj0=self.sat_adj0,
+            ql_gen=self.ql_gen,
+            qs_mlt=self.qs_mlt,
+            ql0_max=self.ql0_max,
+            t_sub=self.t_sub,
+            qi_gen=self.qi_gen,
+            qi_lim=self.qi_lim,
+            qi0_max=self.qi0_max,
+            dw_ocean=self.dw_ocean,
+            dw_land=self.dw_land,
+            icloud_f=self.icloud_f,
+            cld_min=self.cld_min,
+            tau_i2s=self.tau_i2s,
+            tau_v2l=self.tau_v2l,
+            tau_r2g=self.tau_r2g,
+            tau_l2r=self.tau_l2r,
+            tau_l2v=self.tau_l2v,
+            tau_imlt=self.tau_imlt,
+            tau_smlt=self.tau_smlt,
+        )
+
+    @property
+    def remapping(self) -> RemappingConfig:
+        return RemappingConfig(
+            fill=self.fill,
+            kord_tm=self.kord_tm,
+            kord_tr=self.kord_tr,
+            kord_wz=self.kord_wz,
+            kord_mt=self.kord_mt,
+            do_sat_adj=self.do_sat_adj,
+            sat_adjust=self.sat_adjust,
+        )
+
 
 namelist = Namelist()
 
@@ -523,7 +607,7 @@ def namelist_to_flatish_dict(nml_input):
         if isinstance(value, dict):
             for subkey, subvalue in value.items():
                 if subkey in flatter_namelist:
-                    raise Exception(
+                    raise ValueError(
                         "Cannot flatten this namelist, duplicate keys: " + subkey
                     )
                 flatter_namelist[subkey] = subvalue

--- a/fv3core/stencils/c2l_ord.py
+++ b/fv3core/stencils/c2l_ord.py
@@ -1,8 +1,9 @@
 from gt4py.gtscript import PARALLEL, computation, horizontal, interval, region
 
+import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import FrozenStencil
-from fv3core.utils.grid import axis_offsets
+from fv3core.utils.grid import GridData, GridIndexing, axis_offsets
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 from fv3gfs.util import CubedSphereCommunicator
 from fv3gfs.util.quantity import Quantity
@@ -74,34 +75,35 @@ class CubedToLatLon:
     Fortan name is c2l_ord2
     """
 
-    def __init__(self, grid, namelist):
+    def __init__(self, grid_indexing: GridIndexing, grid_data: GridData, order: int):
         """
         Initializes stencils to use either 2nd or 4th order of interpolation
         based on namelist setting
         Args:
-            grid: fv3core grid object
-            namelist:
-                c2l_ord: Order of interpolation
-            do_halo_update: Optional. If passed, overrides global halo exchange flag
-                            and performs a halo update on u and v
+            grid_indexing: fv3core grid indexing object
+            grid_data: object with metric terms
+            order: Order of interpolation, must be 2 or 4
         """
-        self._do_ord4 = True
-        self.grid = grid
-        if namelist.c2l_ord == 2:
+        self._n_halo = grid_indexing.n_halo
+        self._dx = grid_data.dx
+        self._dy = grid_data.dy
+        # TODO: define these based on data from grid_data
+        self._a11 = spec.grid.a11
+        self._a12 = spec.grid.a12
+        self._a21 = spec.grid.a21
+        self._a22 = spec.grid.a22
+        if order == 2:
             self._do_ord4 = False
             self._compute_cubed_to_latlon = FrozenStencil(
                 func=c2l_ord2,
-                origin=self.grid.compute_origin(
-                    add=(-1, -1, 0) if self._do_halo_update else (0, 0, 0)
-                ),
-                domain=self.grid.domain_shape_compute(
-                    add=(2, 2, 0) if self._do_halo_update else (0, 0, 0)
-                ),
+                origin=grid_indexing.origin_compute(add=(-1, -1, 0)),
+                domain=grid_indexing.domain_compute(add=(2, 2, 0)),
             )
         else:
-            origin = self.grid.compute_origin()
-            domain = self.grid.domain_shape_compute()
-            ax_offsets = axis_offsets(self.grid, origin, domain)
+            self._do_ord4 = True
+            origin = grid_indexing.origin_compute()
+            domain = grid_indexing.domain_compute()
+            ax_offsets = axis_offsets(grid_indexing, origin, domain)
             self._compute_cubed_to_latlon = FrozenStencil(
                 func=ord4_transform,
                 externals={
@@ -129,16 +131,16 @@ class CubedToLatLon:
             comm: Cubed-sphere communicator
         """
         if self._do_ord4:
-            comm.vector_halo_update(u, v, n_points=self.grid.halo)
+            comm.vector_halo_update(u, v, n_points=self._n_halo)
         self._compute_cubed_to_latlon(
             u.storage,
             v.storage,
-            self.grid.dx,
-            self.grid.dy,
-            self.grid.a11,
-            self.grid.a12,
-            self.grid.a21,
-            self.grid.a22,
+            self._dx,
+            self._dy,
+            self._a11,
+            self._a12,
+            self._a21,
+            self._a22,
             ua,
             va,
         )

--- a/fv3core/stencils/dyn_core.py
+++ b/fv3core/stencils/dyn_core.py
@@ -359,7 +359,9 @@ class AcousticDynamics:
             npz=grid_indexing.domain[2],
         )
         self.nonhydrostatic_pressure_gradient = (
-            nh_p_grad.NonHydrostaticPressureGradient(config.grid_type)
+            nh_p_grad.NonHydrostaticPressureGradient(
+                grid_indexing, grid_data, config.grid_type
+            )
         )
         self._temporaries = dyncore_temporaries(grid_indexing)
         self._temporaries["gz"][:] = HUGE_R

--- a/fv3core/stencils/fillz.py
+++ b/fv3core/stencils/fillz.py
@@ -3,9 +3,9 @@ from typing import Any, Dict
 
 from gt4py.gtscript import FORWARD, PARALLEL, computation, interval
 
-import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import FrozenStencil
+from fv3core.utils.grid import GridIndexing
 from fv3core.utils.typing import FloatField, FloatFieldIJ, IntFieldIJ
 
 
@@ -108,18 +108,18 @@ class FillNegativeTracerValues:
 
     def __init__(
         self,
+        grid_indexing: GridIndexing,
         im: int,
         jm: int,
         km: int,
         nq: int,
     ):
-        grid = spec.grid
         self._nq = nq
         self._fix_tracer_stencil = FrozenStencil(
-            fix_tracer, origin=grid.compute_origin(), domain=(im, jm, km)
+            fix_tracer, origin=grid_indexing.origin_compute(), domain=(im, jm, km)
         )
 
-        shape = grid.domain_shape_full(add=(1, 1, 1))
+        shape = grid_indexing.domain_full(add=(1, 1, 1))
         shape_ij = shape[0:2]
 
         self._dm = utils.make_storage_from_shape(shape, origin=(0, 0, 0))

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -514,6 +514,7 @@ class RemapProfile:
         """
         The constraints on the spline are set by kord and iv.
         Arguments:
+            grid_indexing
             kord: ???
             iv: ???
             i1: The first i-element to compute on

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -3,9 +3,9 @@ from typing import Tuple
 import gt4py.gtscript as gtscript
 from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, interval
 
-import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
 from fv3core.decorators import FrozenStencil
+from fv3core.utils.grid import GridIndexing
 from fv3core.utils.typing import BoolField, FloatField, FloatFieldIJ
 
 
@@ -503,6 +503,7 @@ class RemapProfile:
 
     def __init__(
         self,
+        grid_indexing: GridIndexing,
         kord: int,
         iv: int,
         i1: int,
@@ -521,28 +522,27 @@ class RemapProfile:
             j2: The last j-element to compute on
         """
         assert kord <= 10, f"kord {kord} not implemented."
-        grid = spec.grid
-        full_orig: Tuple[int] = grid.full_origin()
-        km: int = grid.npz
+        full_orig: Tuple[int] = grid_indexing.origin_full()
+        km: int = grid_indexing.domain[2]
         self._kord = kord
 
         self._gam: FloatField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig
+            grid_indexing.domain_full(add=(0, 0, 1)), origin=full_orig
         )
         self._q: FloatField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig
+            grid_indexing.domain_full(add=(0, 0, 1)), origin=full_orig
         )
         self._q_bot: FloatField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig
+            grid_indexing.domain_full(add=(0, 0, 1)), origin=full_orig
         )
         self._extm: BoolField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
+            grid_indexing.domain_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
         )
         self._ext5: BoolField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
+            grid_indexing.domain_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
         )
         self._ext6: BoolField = utils.make_storage_from_shape(
-            grid.domain_shape_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
+            grid_indexing.domain_full(add=(0, 0, 1)), origin=full_orig, dtype=bool
         )
 
         i_extent: int = i2 - i1 + 1

--- a/fv3core/testing/__init__.py
+++ b/fv3core/testing/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F401
 from . import parallel_translate, translate
+from .map_single import MapSingleFactory
 from .parallel_translate import (
     ParallelTranslate,
     ParallelTranslate2Py,

--- a/fv3core/testing/map_single.py
+++ b/fv3core/testing/map_single.py
@@ -1,0 +1,19 @@
+from typing import Dict, Tuple
+
+import fv3core._config as spec
+from fv3core.stencils.map_single import MapSingle
+
+
+class MapSingleFactory:
+    _object_pool: Dict[Tuple[int, ...], MapSingle] = {}
+    """Pool of MapSingle objects."""
+
+    def __call__(
+        self, kord: int, mode: int, i1: int, i2: int, j1: int, j2: int, *args, **kwargs
+    ):
+        key_tuple = (kord, mode, i1, i2, j1, j2)
+        if key_tuple not in self._object_pool:
+            self._object_pool[key_tuple] = MapSingle(
+                spec.grid.grid_indexing, *key_tuple
+            )
+        return self._object_pool[key_tuple](*args, **kwargs)

--- a/tests/main/test_config.py
+++ b/tests/main/test_config.py
@@ -9,6 +9,7 @@ import fv3core._config
 
 
 CONFIG_CLASSES = [
+    fv3core._config.SatAdjustConfig,
     fv3core._config.AcousticDynamicsConfig,
     fv3core._config.RiemannConfig,
     fv3core._config.DGridShallowWaterLagrangianDynamicsConfig,

--- a/tests/savepoint/translate/translate_cubedtolatlon.py
+++ b/tests/savepoint/translate/translate_cubedtolatlon.py
@@ -19,7 +19,10 @@ class TranslateCubedToLatLon(ParallelTranslate2Py):
     def __init__(self, grids):
         super().__init__(grids)
         grid = grids[0]
-        self._base.compute_func = CubedToLatLon(grid, spec.namelist)
+        spec.set_grid(grid)
+        self._base.compute_func = CubedToLatLon(
+            grid.grid_indexing, grid.grid_data, order=spec.namelist.c2l_ord
+        )
         self._base.in_vars["data_vars"] = {"u": {}, "v": {}, "ua": {}, "va": {}}
         self._base.out_vars = {
             "ua": {},

--- a/tests/savepoint/translate/translate_fillz.py
+++ b/tests/savepoint/translate/translate_fillz.py
@@ -56,7 +56,11 @@ class TranslateFillz(TranslateFortranData2Py):
                     pad_field_in_j(value, self.grid.njd)
                 )
         run_fillz = fillz.FillNegativeTracerValues(
-            inputs.pop("im"), inputs.pop("jm"), inputs.pop("km"), inputs.pop("nq")
+            self.grid.grid_indexing,
+            inputs.pop("im"),
+            inputs.pop("jm"),
+            inputs.pop("km"),
+            inputs.pop("nq"),
         )
         run_fillz(**inputs)
         ds = self.grid.default_domain_dict()

--- a/tests/savepoint/translate/translate_map1_ppm_2d.py
+++ b/tests/savepoint/translate/translate_map1_ppm_2d.py
@@ -1,8 +1,12 @@
 import numpy as np
 
 import fv3core.utils.gt4py_utils as utils
-from fv3core.stencils.map_single import MapSingleFactory
-from fv3core.testing import TranslateFortranData2Py, TranslateGrid, pad_field_in_j
+from fv3core.testing import (
+    MapSingleFactory,
+    TranslateFortranData2Py,
+    TranslateGrid,
+    pad_field_in_j,
+)
 
 
 class TranslateSingleJ(TranslateFortranData2Py):

--- a/tests/savepoint/translate/translate_map_scalar_2d.py
+++ b/tests/savepoint/translate/translate_map_scalar_2d.py
@@ -1,7 +1,11 @@
 import fv3core._config as spec
 import fv3core.utils.gt4py_utils as utils
-from fv3core.stencils.map_single import MapSingleFactory
-from fv3core.testing import TranslateFortranData2Py, TranslateGrid, pad_field_in_j
+from fv3core.testing import (
+    MapSingleFactory,
+    TranslateFortranData2Py,
+    TranslateGrid,
+    pad_field_in_j,
+)
 
 
 class TranslateMapScalar_2d(TranslateFortranData2Py):

--- a/tests/savepoint/translate/translate_mapn_tracer_2d.py
+++ b/tests/savepoint/translate/translate_mapn_tracer_2d.py
@@ -42,12 +42,14 @@ class TranslateMapN_Tracer_2d(TranslateFortranData2Py):
         )
         inputs["kord"] = abs(spec.namelist.kord_tr)
         self.compute_func = MapN_Tracer.MapNTracer(
+            self.grid.grid_indexing,
             inputs.pop("kord"),
             inputs.pop("nq"),
             inputs.pop("i1"),
             inputs.pop("i2"),
             inputs.pop("j1"),
             inputs.pop("j2"),
+            fill=spec.namelist.fill,
         )
         self.compute_func(**inputs)
         return self.slice_output(inputs)

--- a/tests/savepoint/translate/translate_neg_adj3.py
+++ b/tests/savepoint/translate/translate_neg_adj3.py
@@ -36,7 +36,11 @@ class TranslateNeg_Adj3(TranslateFortranData2Py):
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
-        compute_fn = AdjustNegativeTracerMixingRatio(self.grid, spec.namelist)
+        compute_fn = AdjustNegativeTracerMixingRatio(
+            self.grid.grid_indexing,
+            spec.namelist.check_negative,
+            spec.namelist.hydrostatic,
+        )
         compute_fn(
             inputs["qvapor"],
             inputs["qliquid"],

--- a/tests/savepoint/translate/translate_nh_p_grad.py
+++ b/tests/savepoint/translate/translate_nh_p_grad.py
@@ -26,7 +26,7 @@ class TranslateNH_P_Grad(TranslateFortranData2Py):
 
     def compute(self, inputs):
         self.compute_func = NH_P_Grad.NonHydrostaticPressureGradient(
-            spec.namelist.grid_type
+            self.grid.grid_indexing, self.grid.grid_data, spec.namelist.grid_type
         )
         self.make_storage_data_input_vars(inputs)
         self.compute_func(**inputs)

--- a/tests/savepoint/translate/translate_remap_profile_2d.py
+++ b/tests/savepoint/translate/translate_remap_profile_2d.py
@@ -54,7 +54,7 @@ class TranslateCS_Profile_2d(TranslateFortranData2Py):
         j1 = 0
         j2 = 0
         self.compute_func = profile.RemapProfile(
-            inputs["kord"], inputs["iv"], i1, i2, j1, j2
+            self.grid.grid_indexing, inputs["kord"], inputs["iv"], i1, i2, j1, j2
         )
         self.make_storage_data_input_vars(inputs)
         if "qs" not in inputs:

--- a/tests/savepoint/translate/translate_remapping.py
+++ b/tests/savepoint/translate/translate_remapping.py
@@ -113,7 +113,11 @@ class TranslateRemapping(TranslateFortranData2Py):
         inputs["wsd"] = wsd_2d
         inputs["q_cld"] = inputs["tracers"]["qcld"]
         l_to_e_obj = LagrangianToEulerian(
-            spec.grid, spec.namelist, inputs["nq"], inputs["pfull"]
+            spec.grid.grid_indexing,
+            spec.namelist,
+            spec.grid.area_64,
+            inputs["nq"],
+            inputs["pfull"],
         )
         l_to_e_obj(**inputs)
         inputs.pop("q_cld")

--- a/tests/savepoint/translate/translate_satadjust3d.py
+++ b/tests/savepoint/translate/translate_satadjust3d.py
@@ -1,3 +1,4 @@
+import fv3core._config as spec
 from fv3core.stencils.saturation_adjustment import SatAdjust3d
 from fv3core.testing import TranslateFortranData2Py
 
@@ -5,7 +6,6 @@ from fv3core.testing import TranslateFortranData2Py
 class TranslateSatAdjust3d(TranslateFortranData2Py):
     def __init__(self, grid):
         super().__init__(grid)
-        cvar = {"axis": 0, "kstart": 3}
         self.in_vars["data_vars"] = {
             "te": {},
             "qvapor": {},
@@ -56,6 +56,11 @@ class TranslateSatAdjust3d(TranslateFortranData2Py):
 
     def compute_from_storage(self, inputs):
         inputs["kmp"] -= 1
-        satadjust3d_obj = SatAdjust3d(inputs["kmp"])
+        satadjust3d_obj = SatAdjust3d(
+            self.grid.grid_indexing,
+            spec.namelist.sat_adjust,
+            self.grid.area_64,
+            inputs["kmp"],
+        )
         satadjust3d_obj(**inputs)
         return inputs


### PR DESCRIPTION
## Purpose

This PR removes global access and minimizes the inits of nearly all remaining routines, except for fv_dynamics, fv_subgridz, and tracer_2d_1l.

## Code changes:

- Refactored init routines in remapping.py, neg_adj3.py, c2l_ord.py, map_single.py, remap_profile.py, mapn_tracer.py, saturation_adjustment.py, fillz.py, and nh_p_grad.py to use new GridIndexing, GridData, and configuration classes, avoid using global state, and take in minimal arguments.
- Added configuration classes RemappingConfig and SatAdjustConfig

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
