### PR TITLE
[WIP] Stencil Merger

### DIFF
--- a/GT4PY_VERSION.txt
+++ b/GT4PY_VERSION.txt
@@ -1,1 +1,1 @@
-v30
+develop-v34

--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -80,12 +80,14 @@ def get_namespace(arg_specs, state):
 _stencil_merger = StencilMerger()
 
 
-def clear_stencils():
+def enable_merge_stencils():
+    _stencil_merger.enabled = True
     _stencil_merger.clear()
 
 
-def merge_stencils():
+def disable_merge_stencils():
     _stencil_merger.merge()
+    _stencil_merger.enabled = False
 
 
 class FrozenStencil(StencilInterface):
@@ -125,7 +127,9 @@ class FrozenStencil(StencilInterface):
         if externals is None:
             externals = {}
 
-        self.build_info: Dict[str, Any] = {}
+        self.build_info: Optional[Dict[str, Any]] = (
+            {} if _stencil_merger.enabled else None
+        )
         self.definition_func: Callable = func
 
         self.stencil_object: gt4py.StencilObject = gtscript.stencil(
@@ -154,7 +158,8 @@ class FrozenStencil(StencilInterface):
 
         self._written_fields = get_written_fields(self.stencil_object.field_info)
 
-        _stencil_merger.add(self)
+        if _stencil_merger.enabled:
+            _stencil_merger.add(self)
 
     def __call__(self, *args, **kwargs) -> None:
         stencil_object = self.stencil_object

--- a/fv3core/stencils/neg_adj3.py
+++ b/fv3core/stencils/neg_adj3.py
@@ -3,7 +3,11 @@ from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
-from fv3core.decorators import FrozenStencil, clear_stencils, merge_stencils
+from fv3core.decorators import (
+    FrozenStencil,
+    disable_merge_stencils,
+    enable_merge_stencils,
+)
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -322,7 +326,7 @@ class AdjustNegativeTracerMixingRatio:
             domain=grid_indexing.domain_compute(),
         )
 
-        clear_stencils()
+        enable_merge_stencils()
         self._fix_neg_water = FrozenStencil(
             func=fix_neg_water,
             origin=grid_indexing.origin_compute(),
@@ -338,7 +342,7 @@ class AdjustNegativeTracerMixingRatio:
             origin=grid_indexing.origin_compute(),
             domain=grid_indexing.domain_compute(),
         )
-        merge_stencils()
+        disable_merge_stencils()
 
     def __call__(
         self,

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -4,7 +4,7 @@ import gt4py.gtscript as gtscript
 from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import fv3core.utils.gt4py_utils as utils
-from fv3core.decorators import FrozenStencil
+from fv3core.decorators import FrozenStencil, clear_stencils, merge_stencils
 from fv3core.utils.grid import GridIndexing
 from fv3core.utils.typing import BoolField, FloatField, FloatFieldIJ
 
@@ -552,6 +552,8 @@ class RemapProfile:
         domain: Tuple[int, int, int] = (i_extent, j_extent, km)
         domain_extend: Tuple[int, int, int] = (i_extent, j_extent, km + 1)
 
+        clear_stencils()
+
         self._set_initial_values = FrozenStencil(
             func=set_initial_vals,
             externals={"iv": iv, "kord": abs(kord)},
@@ -572,6 +574,8 @@ class RemapProfile:
             origin=origin,
             domain=domain,
         )
+
+        merge_stencils()
 
     def __call__(
         self,

--- a/fv3core/stencils/remap_profile.py
+++ b/fv3core/stencils/remap_profile.py
@@ -4,7 +4,11 @@ import gt4py.gtscript as gtscript
 from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import fv3core.utils.gt4py_utils as utils
-from fv3core.decorators import FrozenStencil, clear_stencils, merge_stencils
+from fv3core.decorators import (
+    FrozenStencil,
+    disable_merge_stencils,
+    enable_merge_stencils,
+)
 from fv3core.utils.grid import GridIndexing
 from fv3core.utils.typing import BoolField, FloatField, FloatFieldIJ
 
@@ -552,7 +556,7 @@ class RemapProfile:
         domain: Tuple[int, int, int] = (i_extent, j_extent, km)
         domain_extend: Tuple[int, int, int] = (i_extent, j_extent, km + 1)
 
-        clear_stencils()
+        enable_merge_stencils()
 
         self._set_initial_values = FrozenStencil(
             func=set_initial_vals,
@@ -575,7 +579,7 @@ class RemapProfile:
             domain=domain,
         )
 
-        merge_stencils()
+        disable_merge_stencils()
 
     def __call__(
         self,

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -15,7 +15,11 @@ from gt4py.gtscript import (
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core._config import RiemannConfig
-from fv3core.decorators import FrozenStencil, clear_stencils, merge_stencils
+from fv3core.decorators import (
+    FrozenStencil,
+    disable_merge_stencils,
+    enable_merge_stencils,
+)
 from fv3core.stencils.sim1_solver import sim1_solver
 from fv3core.utils.grid import GridIndexing
 from fv3core.utils.typing import FloatField, FloatFieldIJ
@@ -121,7 +125,7 @@ class RiemannSolver3:
         self._tmp_peln_run = utils.make_storage_from_shape(shape, riemorigin)
         self._tmp_gm = utils.make_storage_from_shape(shape, riemorigin)
 
-        clear_stencils()
+        enable_merge_stencils()
         self._precompute_stencil = FrozenStencil(
             precompute,
             origin=riemorigin,
@@ -138,7 +142,7 @@ class RiemannSolver3:
             origin=riemorigin,
             domain=domain,
         )
-        merge_stencils()
+        disable_merge_stencils()
 
     def __call__(
         self,

--- a/fv3core/stencils/riem_solver3.py
+++ b/fv3core/stencils/riem_solver3.py
@@ -15,8 +15,8 @@ from gt4py.gtscript import (
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 from fv3core._config import RiemannConfig
-from fv3core.decorators import FrozenStencil
-from fv3core.stencils.sim1_solver import Sim1Solver
+from fv3core.decorators import FrozenStencil, clear_stencils, merge_stencils
+from fv3core.stencils.sim1_solver import sim1_solver
 from fv3core.utils.grid import GridIndexing
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
@@ -31,7 +31,7 @@ def precompute(
     zh: FloatField,
     q_con: FloatField,
     pem: FloatField,
-    peln: FloatField,
+    peln_run: FloatField,
     pk3: FloatField,
     gm: FloatField,
     dz: FloatField,
@@ -46,25 +46,23 @@ def precompute(
     with computation(FORWARD):
         with interval(0, 1):
             pem = ptop
-            peln = peln1
+            peln_run = peln1
             pk3 = ptk
             peg = ptop
-            pelng = peln1
         with interval(1, None):
             # TODO consolidate with riem_solver_c, same functions, math functions
             pem = pem[0, 0, -1] + dm[0, 0, -1]
-            peln = log(pem)
+            peln_run = log(pem)
             # Excluding contribution from condensates
             # peln used during remap; pk3 used only for p_grad
             peg = peg[0, 0, -1] + dm[0, 0, -1] * (1.0 - q_con[0, 0, -1])
-            pelng = log(peg)
             # interface pk is using constant akap
-            pk3 = exp(constants.KAPPA * peln)
+            pk3 = exp(constants.KAPPA * peln_run)
     with computation(PARALLEL), interval(...):
         gm = 1.0 / (1.0 - cappa)
-        dm = dm * constants.RGRAV
+        dm *= constants.RGRAV
     with computation(PARALLEL), interval(0, -1):
-        pm = (peg[0, 0, 1] - peg) / (pelng[0, 0, 1] - pelng)
+        pm = (peg[0, 0, 1] - peg) / (log(peg[0, 0, 1]) - log(peg))
         dz = zh[0, 0, 1] - zh
 
 
@@ -110,27 +108,27 @@ class RiemannSolver3:
     """
 
     def __init__(self, grid_indexing: GridIndexing, config: RiemannConfig):
-        self._sim1_solve = Sim1Solver(
-            config.p_fac,
-            grid_indexing.isc,
-            grid_indexing.iec,
-            grid_indexing.jsc,
-            grid_indexing.jec,
-            grid_indexing.domain[2] + 1,
-        )
         if config.a_imp <= 0.999:
             raise NotImplementedError("a_imp <= 0.999 is not implemented")
         riemorigin = grid_indexing.origin_compute()
         domain = grid_indexing.domain_compute(add=(0, 0, 1))
         shape = grid_indexing.max_shape
+        self._p_fac = config.p_fac
         self._tmp_dm = utils.make_storage_from_shape(shape, riemorigin)
         self._tmp_pe_init = utils.make_storage_from_shape(shape, riemorigin)
         self._tmp_pm = utils.make_storage_from_shape(shape, riemorigin)
         self._tmp_pem = utils.make_storage_from_shape(shape, riemorigin)
         self._tmp_peln_run = utils.make_storage_from_shape(shape, riemorigin)
         self._tmp_gm = utils.make_storage_from_shape(shape, riemorigin)
+
+        clear_stencils()
         self._precompute_stencil = FrozenStencil(
             precompute,
+            origin=riemorigin,
+            domain=domain,
+        )
+        self._compute_sim1_solve = FrozenStencil(
+            func=sim1_solver,
             origin=riemorigin,
             domain=domain,
         )
@@ -140,6 +138,7 @@ class RiemannSolver3:
             origin=riemorigin,
             domain=domain,
         )
+        merge_stencils()
 
     def __call__(
         self,
@@ -211,18 +210,21 @@ class RiemannSolver3:
             ptk,
         )
 
-        self._sim1_solve(
-            dt,
-            self._tmp_gm,
-            cappa,
-            pe,
-            self._tmp_dm,
-            self._tmp_pm,
-            self._tmp_pem,
+        self._compute_sim1_solve(
             w,
+            self._tmp_dm,
+            self._tmp_gm,
             delz,
             pt,
+            self._tmp_pm,
+            pe,
+            self._tmp_pem,
             wsd,
+            cappa,
+            dt,
+            2.0 * dt * dt,
+            1.0 / dt,
+            self._p_fac,
         )
 
         self._finalize_stencil(

--- a/fv3core/stencils/riem_solver_c.py
+++ b/fv3core/stencils/riem_solver_c.py
@@ -4,7 +4,11 @@ from gt4py.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval, l
 
 import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
-from fv3core.decorators import FrozenStencil, clear_stencils, merge_stencils
+from fv3core.decorators import (
+    FrozenStencil,
+    disable_merge_stencils,
+    enable_merge_stencils,
+)
 from fv3core.stencils.sim1_solver import sim1_solver
 from fv3core.utils.grid import GridIndexing
 from fv3core.utils.typing import FloatField, FloatFieldIJ
@@ -84,7 +88,7 @@ class RiemannSolverC:
         self._pm = utils.make_storage_from_shape(shape, origin)
         self._pfac = p_fac
 
-        clear_stencils()
+        enable_merge_stencils()
         self._precompute_stencil = FrozenStencil(
             precompute,
             origin=origin,
@@ -100,7 +104,7 @@ class RiemannSolverC:
             origin=origin,
             domain=domain,
         )
-        merge_stencils()
+        disable_merge_stencils()
 
     def __call__(
         self,

--- a/fv3core/utils/stencil_merger.py
+++ b/fv3core/utils/stencil_merger.py
@@ -1,0 +1,241 @@
+import abc
+from collections import OrderedDict
+from typing import Any, Dict, List, Mapping, Set, Tuple, Union
+
+import gt4py
+from gt4py.definitions import BuildOptions
+from gt4py.ir import ArgumentInfo, StencilDefinition, VarDecl
+from gt4py.stencil_builder import StencilBuilder
+from gt4py.stencil_object import StencilObject
+
+from fv3core.utils.typing import Index3D
+
+
+class Singleton(type):
+    _instances: Dict[type, "Singleton"] = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class StencilInterface(abc.ABC):
+    def __init__(self):
+        self.origin: Union[Index3D, Mapping[str, Tuple[int, ...]]] = None
+        self.domain: Index3D = None
+        self.build_info: Dict[str, Any] = {}
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def argument_names(self) -> Tuple[str, ...]:
+        pass
+
+    @abc.abstractmethod
+    def set_argument_names(self, new_names: Tuple[str, ...]) -> None:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def field_origins(self) -> Dict[str, Tuple[int, ...]]:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def written_fields(self) -> List[str]:
+        pass
+
+
+def stencil_exists(stencil_group, stencil):
+    for other_stencil in stencil_group:
+        if stencil.name == other_stencil.name:
+            return True
+    return False
+
+
+class StencilMerger(object, metaclass=Singleton):
+    def __init__(self):
+        self._stencil_groups: List[List[StencilInterface]] = []
+        self._merged_groups: Dict[int, List[str]] = {}
+        self._merged_stencils: Dict[int, StencilInterface] = {}
+        self._saved_args: Dict[str, Dict[str, Any]] = {}
+
+    def clear(self) -> None:
+        self._stencil_groups.clear()
+
+    def add(self, stencil: StencilInterface) -> None:
+        assert "def_ir" in stencil.build_info
+        if not self._stencil_groups:
+            self._stencil_groups.append([])
+
+        stencil_group = self._stencil_groups[-1]
+        if stencil_group and (
+            stencil.origin != stencil_group[-1].origin
+            or stencil.domain != stencil_group[-1].domain
+            or stencil_exists(stencil_group, stencil)
+        ):
+            stencil_group = []
+            self._stencil_groups.append(stencil_group)
+
+        stencil_group.append(stencil)
+
+    def is_merged(self, stencil: StencilInterface) -> bool:
+        for merged_names in self._merged_groups.values():
+            if stencil.name in merged_names:
+                return True
+        return False
+
+    def merged_position(self, stencil: StencilInterface) -> Tuple[int, int, int]:
+        for group_id, merged_names in self._merged_groups.items():
+            merged_index = merged_names.index(stencil.name)
+            if merged_index >= 0:
+                is_last = int(merged_index == len(merged_names) - 1)
+                return (group_id, merged_index, is_last)
+        return (-1, -1, 0)
+
+    def merged_stencil(self, group_id: int) -> "StencilObject":
+        return self._merged_stencils[group_id]
+
+    def merge_args(self, group_id: int) -> Tuple[Tuple[Any, ...], Dict[Any, Any]]:
+        all_arg_names = self._stencil_groups[group_id][0].argument_names
+        merged_args: List[Any] = [None] * len(all_arg_names)
+        merged_kwargs: Dict[Any, Any] = {}
+
+        stencil_names = self._merged_groups[group_id]
+        for stencil_name in stencil_names:
+            saved_args = self._saved_args[stencil_name]
+            merged_kwargs.update(saved_args["kwargs"])
+
+            for arg_index, arg_name in enumerate(saved_args["arg_names"]):
+                merged_index = all_arg_names.index(arg_name)
+                merged_args[merged_index] = saved_args["args"][arg_index]
+
+        return tuple(merged_args), merged_kwargs
+
+    def save_args(self, stencil: StencilInterface, *args, **kwargs) -> None:
+        self._saved_args[stencil.name].update({"args": args, "kwargs": kwargs})
+
+    def merge(self) -> None:
+        self._merged_groups.clear()
+        for group_id, stencil_group in enumerate(self._stencil_groups):
+            if len(stencil_group) > 1:
+                for stencil in stencil_group:
+                    self._saved_args[stencil.name] = dict(
+                        arg_names=stencil.argument_names, args=[], kwargs={}
+                    )
+
+                top_stencil = stencil_group[0]
+                top_ir = top_stencil.build_info["def_ir"]
+
+                self._merged_groups[group_id] = [top_stencil.name]
+                for next_stencil in stencil_group[1:]:
+                    next_ir = next_stencil.build_info["def_ir"]
+                    top_ir = self._merge_irs(top_ir, next_ir)
+
+                    top_stencil.set_argument_names(
+                        tuple([arg.name for arg in top_ir.api_signature])
+                    )
+                    top_stencil.field_origins.update(next_stencil.field_origins)
+                    top_stencil.written_fields.extend(
+                        [
+                            written_field
+                            for written_field in next_stencil.written_fields
+                            if written_field not in top_stencil.written_fields
+                        ]
+                    )
+
+                    self._merged_groups[group_id].append(next_stencil.name)
+
+                self._stencil_groups[group_id] = [top_stencil]
+
+        self._rebuild()
+
+    def _rebuild(self):
+        for group_id, stencil_group in enumerate(self._stencil_groups):
+            if group_id in self._merged_groups:
+                top_stencil = stencil_group[0]
+                stencil_object = top_stencil.stencil_object
+                backend_class = gt4py.backend.from_name(stencil_object.backend)
+                def_ir = top_stencil.build_info["def_ir"]
+
+                stencil_options = stencil_object.options
+                stencil_options["name"] = def_ir.name.split(".")[-1]
+                stencil_options.pop("_impl_opts")
+
+                builder = StencilBuilder(
+                    top_stencil.definition_func,
+                    backend=backend_class,
+                    options=BuildOptions(**stencil_options),
+                )
+                builder.definition_ir = def_ir
+                builder.externals = def_ir.externals
+
+                stencil_class = builder.build()
+                self._merged_stencils[group_id] = stencil_class()
+
+    def _merge_irs(
+        self, dest_ir: StencilDefinition, source_ir: StencilDefinition
+    ) -> StencilDefinition:
+        dest_ir.name = self._merge_names(dest_ir.name, source_ir.name)
+        dest_ir.computations.extend(source_ir.computations)
+        dest_ir.externals.update(source_ir.externals)
+        dest_ir.api_fields = self._merge_named_lists(
+            dest_ir.api_fields, source_ir.api_fields
+        )
+        dest_params: List[VarDecl] = self._merge_named_lists(
+            dest_ir.parameters, source_ir.parameters
+        )
+        param_names = set([param.name for param in dest_params])
+        dest_ir.parameters = dest_params
+        dest_ir.api_signature = self._merge_api_signatures(
+            dest_ir.api_signature, source_ir.api_signature, param_names
+        )
+
+        return dest_ir
+
+    def _merge_names(self, dest_name: str, source_name: str) -> str:
+        items = dest_name.split(".")
+        module_name = ".".join(items[0:-1])
+        dest_name = items[-1]
+        source_name = source_name.split(".")[-1]
+        return f"{module_name}.{dest_name}__{source_name}"
+
+    def _merge_named_lists(
+        self,
+        dest_list: List[ArgumentInfo],
+        source_list: List[ArgumentInfo],
+    ) -> List[object]:
+        dest_items = OrderedDict({item.name: item for item in dest_list})
+        for item in source_list:
+            if item.name not in dest_items:
+                dest_items[item.name] = item
+
+        return list(dest_items.values())
+
+    def _merge_api_signatures(
+        self,
+        dest_list: List[ArgumentInfo],
+        source_list: List[ArgumentInfo],
+        param_names: Set[str],
+    ) -> List[object]:
+        dest_fields: Dict[str, ArgumentInfo] = OrderedDict()
+        dest_params: Dict[str, ArgumentInfo] = OrderedDict()
+        for item in dest_list:
+            dest_dict = dest_params if item.name in param_names else dest_fields
+            dest_dict[item.name] = item
+
+        for item in source_list:
+            dest_dict = dest_params if item.name in param_names else dest_fields
+            if item.name not in dest_dict:
+                dest_dict[item.name] = item
+
+        new_api = dest_fields
+        for param_name in dest_params:
+            new_api[param_name] = dest_params[param_name]
+
+        return list(new_api.values())

--- a/fv3core/utils/stencil_merger.py
+++ b/fv3core/utils/stencil_merger.py
@@ -64,6 +64,7 @@ class StencilMerger(object, metaclass=Singleton):
         self._merged_groups: Dict[int, List[str]] = {}
         self._merged_stencils: Dict[int, StencilInterface] = {}
         self._saved_args: Dict[str, Dict[str, Any]] = {}
+        self.enabled: bool = False
 
     def clear(self) -> None:
         self._stencil_groups.clear()

--- a/tests/main/test_stencil_merger.py
+++ b/tests/main/test_stencil_merger.py
@@ -1,0 +1,86 @@
+from typing import Tuple
+
+import numpy as np
+import pytest
+from gt4py.gtscript import PARALLEL, computation, interval, stencil
+
+from fv3core.decorators import clear_stencils, merge_stencils
+from fv3core.utils.global_config import set_backend
+from fv3core.utils.gt4py_utils import make_storage_from_shape_uncached
+from fv3core.utils.mpi import MPI
+from fv3core.utils.typing import FloatField
+
+
+def copy_stencil(q_in: FloatField, q_out: FloatField):
+    with computation(PARALLEL), interval(...):
+        q_out = q_in
+
+
+def add1_stencil(q_out: FloatField):
+    with computation(PARALLEL), interval(...):
+        q_out += 1.0
+
+
+def setup_data_vars(num_storages: int = 3, init_val: float = 1.0):
+    shape = (7, 7, 3)
+    storages = []
+    for n in range(num_storages):
+        storage = make_storage_from_shape_uncached(shape)
+        storage[:] = init_val
+        storages.append(storage)
+
+    return tuple(storages)
+
+
+@pytest.mark.sequential
+@pytest.mark.skipif(
+    MPI is not None and MPI.COMM_WORLD.Get_size() > 1,
+    reason="Running in parallel with mpi",
+)
+@pytest.mark.parametrize("backend", ("numpy", "gtx86"))
+@pytest.mark.parametrize("rebuild", (True, False))
+@pytest.mark.parametrize("do_merge", (False, True))
+def test_stencil_merger(backend: str, rebuild: bool, do_merge: bool):
+    set_backend(backend)
+
+    q_in, q_out, q_ref = setup_data_vars()
+    q_ref[1:3, 1:3, :] = 2.0
+
+    origin = (1, 1, 0)
+    domain = (2, 2, 3)
+
+    q_out = run_stencil_test(q_in, q_out, origin, domain, backend, rebuild, do_merge)
+    assert np.array_equal(q_out, q_ref)
+
+
+def run_stencil_test(
+    q_in: FloatField,
+    q_out: FloatField,
+    origin: Tuple[int, ...],
+    domain: Tuple[int, ...],
+    backend: str,
+    rebuild: bool,
+    do_merge: bool,
+):
+    if do_merge:
+        clear_stencils()
+
+    copy_object = stencil(
+        definition=copy_stencil,
+        backend=backend,
+        rebuild=rebuild,
+    )
+
+    add1_object = stencil(
+        definition=add1_stencil,
+        backend=backend,
+        rebuild=rebuild,
+    )
+
+    if do_merge:
+        merge_stencils()
+
+    copy_object(q_in, q_out, origin=origin, domain=domain)
+    add1_object(q_out, origin=origin, domain=domain)
+
+    return q_out

--- a/tests/main/test_stencil_merger.py
+++ b/tests/main/test_stencil_merger.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from gt4py.gtscript import PARALLEL, computation, interval, stencil
 
-from fv3core.decorators import clear_stencils, merge_stencils
+from fv3core.decorators import disable_merge_stencils, enable_merge_stencils
 from fv3core.utils.global_config import set_backend
 from fv3core.utils.gt4py_utils import make_storage_from_shape_uncached
 from fv3core.utils.mpi import MPI
@@ -63,7 +63,7 @@ def run_stencil_test(
     do_merge: bool,
 ):
     if do_merge:
-        clear_stencils()
+        enable_merge_stencils()
 
     copy_object = stencil(
         definition=copy_stencil,
@@ -78,7 +78,7 @@ def run_stencil_test(
     )
 
     if do_merge:
-        merge_stencils()
+        disable_merge_stencils()
 
     copy_object(q_in, q_out, origin=origin, domain=domain)
     add1_object(q_out, origin=origin, domain=domain)

--- a/tests/main/test_stencil_wrapper.py
+++ b/tests/main/test_stencil_wrapper.py
@@ -218,7 +218,7 @@ def test_frozen_stencil_kwargs_passed_to_init(
             externals={},
         )
     mock_stencil.assert_called_once_with(
-        definition=copy_stencil, externals={}, **config.stencil_kwargs
+        definition=copy_stencil, externals={}, build_info=None, **config.stencil_kwargs
     )
 
 


### PR DESCRIPTION
## Purpose

This PR implements a prototype of an automated stencil merging pass for `gt4py` stencils in `fv3core`. Stencils to be potentially merged are marked in the `__init__` methods of `fv3core` classes, with the start of merge sections denoted by a call to `clear_stencils` and the end with `merge_stencils` where the stencil merging is performed. Arguments to stencils invoked in the `__call__` methods are then collected by the `FrozenStencil` calls, and delivered when the last stencil within a merged group is called.

## Code changes:

- Add `StencilMerger` class with merging logic
- Add `build_info` and `definition_func` attributes to `FrozenStencil`
- Add `_stencil_merger` objects to `decorators`
- Add stencil merging code to `FrozenStencil`
- Add `StencilInterface` that `FrozenStencil` implements to prevent circular imports and to satisfy `mypy` constarints
- Add merging code to `neg_adj3`, `remap_profile`, `riem_solver3`, and `riem_solver_c`

## Requirements changes:

- Requires at least the `develop-v34` branch of `gt4py` that exposes methods to modify the definition IR and externals of the `StencilBuilder` class

## Checklist

Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
