### PR TITLE
refactor TracerAdvection to have minimal init

### DIFF
--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -8,7 +8,7 @@ import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util
 from fv3core.decorators import ArgSpec, FrozenStencil, get_namespace
-from fv3core.stencils import tracer_2d_1l, fvtp2d
+from fv3core.stencils import fvtp2d, tracer_2d_1l
 from fv3core.stencils.basic_operations import copy_defn
 from fv3core.stencils.c2l_ord import CubedToLatLon
 from fv3core.stencils.del2cubed import HyperdiffusionDamping

--- a/fv3core/stencils/fv_dynamics.py
+++ b/fv3core/stencils/fv_dynamics.py
@@ -8,7 +8,7 @@ import fv3core.utils.global_constants as constants
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util
 from fv3core.decorators import ArgSpec, FrozenStencil, get_namespace
-from fv3core.stencils import tracer_2d_1l
+from fv3core.stencils import tracer_2d_1l, fvtp2d
 from fv3core.stencils.basic_operations import copy_defn
 from fv3core.stencils.c2l_ord import CubedToLatLon
 from fv3core.stencils.del2cubed import HyperdiffusionDamping
@@ -277,8 +277,15 @@ class DynamicalCore:
         self.grid = spec.grid
         self.namelist = namelist
 
+        tracer_transport = fvtp2d.FiniteVolumeTransport(
+            grid_indexing=spec.grid.grid_indexing,
+            grid_data=spec.grid.grid_data,
+            damping_coefficients=spec.grid.damping_coefficients,
+            grid_type=spec.grid.grid_type,
+            hord=spec.namelist.hord_tr,
+        )
         self.tracer_advection = tracer_2d_1l.TracerAdvection(
-            comm, namelist, DynamicalCore.NQ
+            spec.grid.grid_indexing, tracer_transport, comm, DynamicalCore.NQ
         )
         self._ak = ak.storage
         self._bk = bk.storage

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -1,3 +1,4 @@
+from fv3core.utils.grid import DampingCoefficients, GridData, GridIndexing
 import math
 
 import gt4py.gtscript as gtscript
@@ -122,12 +123,13 @@ class TracerAdvection:
     """
 
     def __init__(
-        self, comm: fv3gfs.util.CubedSphereCommunicator, namelist, tracers_count
+        self, grid_indexing: GridIndexing, transport: FiniteVolumeTransport, comm: fv3gfs.util.CubedSphereCommunicator, tracer_count
     ):
+        self._tracer_count = tracer_count
         self.comm = comm
         self.grid = spec.grid
-        shape = self.grid.domain_shape_full(add=(1, 1, 1))
-        origin = self.grid.compute_origin()
+        shape = grid_indexing.domain_full(add=(1, 1, 1))
+        origin = grid_indexing.origin_compute()
         self._tmp_xfx = utils.make_storage_from_shape(shape, origin)
         self._tmp_yfx = utils.make_storage_from_shape(shape, origin)
         self._tmp_fx = utils.make_storage_from_shape(shape, origin)
@@ -139,7 +141,7 @@ class TracerAdvection:
         )
 
         ax_offsets = fv3core.utils.axis_offsets(
-            self.grid, self.grid.full_origin(), self.grid.domain_shape_full()
+            self.grid, grid_indexing.origin_full(), grid_indexing.domain_full()
         )
         local_axis_offsets = {}
         for axis_offset_name, axis_offset_value in ax_offsets.items():
@@ -148,35 +150,29 @@ class TracerAdvection:
 
         self._flux_compute = FrozenStencil(
             flux_compute,
-            origin=self.grid.full_origin(),
-            domain=self.grid.domain_shape_full(add=(1, 1, 0)),
+            origin=grid_indexing.origin_full(),
+            domain=grid_indexing.domain_full(add=(1, 1, 0)),
             externals=local_axis_offsets,
         )
         self._cmax_multiply_by_frac = FrozenStencil(
             cmax_multiply_by_frac,
-            origin=self.grid.full_origin(),
-            domain=self.grid.domain_shape_full(add=(1, 1, 0)),
+            origin=grid_indexing.origin_full(),
+            domain=grid_indexing.domain_full(add=(1, 1, 0)),
             externals=local_axis_offsets,
         )
         self._dp_fluxadjustment = FrozenStencil(
             dp_fluxadjustment,
-            origin=self.grid.compute_origin(),
-            domain=self.grid.domain_shape_compute(),
+            origin=grid_indexing.origin_compute(),
+            domain=grid_indexing.domain_compute(),
             externals=local_axis_offsets,
         )
         self._q_adjust = FrozenStencil(
             q_adjust,
-            origin=self.grid.compute_origin(),
-            domain=self.grid.domain_shape_compute(),
+            origin=grid_indexing.origin_compute(),
+            domain=grid_indexing.domain_compute(),
             externals=local_axis_offsets,
         )
-        self.finite_volume_transport = FiniteVolumeTransport(
-            grid_indexing=self.grid.grid_indexing,
-            grid_data=self.grid.grid_data,
-            damping_coefficients=self.grid.damping_coefficients,
-            grid_type=self.grid.grid_type,
-            hord=namelist.hord_tr,
-        )
+        self.finite_volume_transport: FiniteVolumeTransport = transport
         # If use AllReduce, will need something like this:
         # self._tmp_cmax = utils.make_storage_from_shape(shape, origin)
         # self._cmax_1 = FrozenStencil(cmax_stencil1)
@@ -185,10 +181,15 @@ class TracerAdvection:
         # Setup halo updater for tracers
         tracer_halo_spec = self.grid.get_halo_update_spec(shape, origin, utils.halo)
         self._tracers_halo_updater = self.comm.get_scalar_halo_updater(
-            [tracer_halo_spec] * tracers_count
+            [tracer_halo_spec] * tracer_count
         )
 
     def __call__(self, tracers, dp1, mfxd, mfyd, cxd, cyd, mdt):
+        if len(tracers) != self._tracer_count:
+            raise ValueError(
+                f"incorrect number of tracers, {self._tracer_count} was "
+                f"specified on init but {len(tracers)} were passed"
+            )
         # start HALO update on q (in dyn_core in fortran -- just has started when
         # this function is called...)
         self._flux_compute(
@@ -208,18 +209,18 @@ class TracerAdvection:
 
         # # TODO for if we end up using the Allreduce and compute cmax globally
         # (or locally). For now, hardcoded.
-        # split = int(self.grid.npz / 6)
+        # split = int(grid_indexing.domain[2] / 6)
         # self._cmax_1(
-        #     cxd, cyd, self._tmp_cmax, origin=self.grid.compute_origin(),
-        #     domain=(self.grid.nic, self.grid.njc, split)
+        #     cxd, cyd, self._tmp_cmax, origin=grid_indexing.origin_compute(),
+        #     domain=(grid_indexing.domain[0], self.grid_indexing.domain[1], split)
         # )
         # self._cmax_2(
         #     cxd,
         #     cyd,
         #     self.grid.sin_sg5,
         #     self._tmp_cmax,
-        #     origin=(self.grid.is_, self.grid.js, split),
-        #     domain=(self.grid.nic, self.grid.njc, self.grid.npz - split + 1),
+        #     origin=(grid_indexing.isc, self.grid_indexing.jsc, split),
+        #     domain=(grid_indexing.domain[0], self.grid_indexing.domain[1], grid_indexing.domain[2] - split + 1),
         # )
         # cmax_flat = np.amax(self._tmp_cmax, axis=(0, 1))
         # # cmax_flat is a gt4py storage still, but of dimension [npz+1]...
@@ -257,7 +258,7 @@ class TracerAdvection:
                 self.grid.rarea,
                 dp2,
             )
-            for qname, q in tracers.items():
+            for q in tracers.values():
                 self.finite_volume_transport(
                     q.storage,
                     cxd,

--- a/fv3core/stencils/tracer_2d_1l.py
+++ b/fv3core/stencils/tracer_2d_1l.py
@@ -1,4 +1,3 @@
-from fv3core.utils.grid import DampingCoefficients, GridData, GridIndexing
 import math
 
 import gt4py.gtscript as gtscript
@@ -11,6 +10,7 @@ import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util
 from fv3core.decorators import FrozenStencil
 from fv3core.stencils.fvtp2d import FiniteVolumeTransport
+from fv3core.utils.grid import GridIndexing
 from fv3core.utils.typing import FloatField, FloatFieldIJ
 
 
@@ -123,7 +123,11 @@ class TracerAdvection:
     """
 
     def __init__(
-        self, grid_indexing: GridIndexing, transport: FiniteVolumeTransport, comm: fv3gfs.util.CubedSphereCommunicator, tracer_count
+        self,
+        grid_indexing: GridIndexing,
+        transport: FiniteVolumeTransport,
+        comm: fv3gfs.util.CubedSphereCommunicator,
+        tracer_count,
     ):
         self._tracer_count = tracer_count
         self.comm = comm
@@ -220,7 +224,11 @@ class TracerAdvection:
         #     self.grid.sin_sg5,
         #     self._tmp_cmax,
         #     origin=(grid_indexing.isc, self.grid_indexing.jsc, split),
-        #     domain=(grid_indexing.domain[0], self.grid_indexing.domain[1], grid_indexing.domain[2] - split + 1),
+        #     domain=(
+        #         grid_indexing.domain[0],
+        #         self.grid_indexing.domain[1],
+        #         grid_indexing.domain[2] - split + 1
+        #     ),
         # )
         # cmax_flat = np.amax(self._tmp_cmax, axis=(0, 1))
         # # cmax_flat is a gt4py storage still, but of dimension [npz+1]...

--- a/tests/savepoint/translate/translate_tracer2d1l.py
+++ b/tests/savepoint/translate/translate_tracer2d1l.py
@@ -2,8 +2,8 @@ import pytest
 
 import fv3core._config as spec
 import fv3core.stencils.fv_dynamics as fv_dynamics
-import fv3core.stencils.tracer_2d_1l
 import fv3core.stencils.fvtp2d
+import fv3core.stencils.tracer_2d_1l
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util as fv3util
 from fv3core.testing import ParallelTranslate
@@ -50,7 +50,10 @@ class TranslateTracer2D1L(ParallelTranslate):
             hord=spec.namelist.hord_tr,
         )
         self.tracer_advection = fv3core.stencils.tracer_2d_1l.TracerAdvection(
-            self.grid.grid_indexing, transport, communicator, fv_dynamics.DynamicalCore.NQ
+            self.grid.grid_indexing,
+            transport,
+            communicator,
+            fv_dynamics.DynamicalCore.NQ,
         )
         self.tracer_advection(**inputs)
         inputs[

--- a/tests/savepoint/translate/translate_tracer2d1l.py
+++ b/tests/savepoint/translate/translate_tracer2d1l.py
@@ -3,6 +3,7 @@ import pytest
 import fv3core._config as spec
 import fv3core.stencils.fv_dynamics as fv_dynamics
 import fv3core.stencils.tracer_2d_1l
+import fv3core.stencils.fvtp2d
 import fv3core.utils.gt4py_utils as utils
 import fv3gfs.util as fv3util
 from fv3core.testing import ParallelTranslate
@@ -41,8 +42,15 @@ class TranslateTracer2D1L(ParallelTranslate):
         inputs["tracers"] = self.get_advected_tracer_dict(
             inputs["tracers"], inputs.pop("nq")
         )
+        transport = fv3core.stencils.fvtp2d.FiniteVolumeTransport(
+            grid_indexing=spec.grid.grid_indexing,
+            grid_data=spec.grid.grid_data,
+            damping_coefficients=spec.grid.damping_coefficients,
+            grid_type=spec.grid.grid_type,
+            hord=spec.namelist.hord_tr,
+        )
         self.tracer_advection = fv3core.stencils.tracer_2d_1l.TracerAdvection(
-            communicator, spec.namelist, fv_dynamics.DynamicalCore.NQ
+            self.grid.grid_indexing, transport, communicator, fv_dynamics.DynamicalCore.NQ
         )
         self.tracer_advection(**inputs)
         inputs[


### PR DESCRIPTION
## Purpose

This PR refactors the init of TracerAdvection to take in only what it needs, and avoid using global state. Almost all configuration settings passed were actually configuration for FiniteVolumeTransport, so these were collapsed down to a FiniteVolumeTransport object passed at init. 

## Code changes:

- Refactored initialization signature of TracerAdvection
- informative Exception now gets raised at call time of TracerAdvection if a different number of tracers is passed than was specified at init

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes
