### PR TITLE
get venv from central place

### DIFF
--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -84,14 +84,9 @@ echo "creating the venv"
 if [ -d ./venv ] ; then rm -rf venv ; fi
 cd $ROOT_DIR/external/daint_venv/
 if [ -d ./gt4py ] ; then rm -rf gt4py ; fi
-./install.sh $ROOT_DIR/venv
 cd $ROOT_DIR
+$ROOT_DIR/.jenkins/install_virtualenv.sh venv
 source ./venv/bin/activate
-
-# install the local packages
-echo "install requirements..."
-pip install ./external/fv3gfs-util/
-pip install -e .
 pip list
 
 # set the environment


### PR DESCRIPTION
## Purpose

An update to daint_venv broke the standalone-script. This fixes that issue

## Code changes:

Removes some of the burden of the stadalone script to do the virtualenv install and reuses the designed script

## Checklist
Before submitting this PR, please make sure:

- [X] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [X] Docstrings and type hints are added to new and updated routines, as appropriate