### PR TITLE
Revert decorator change

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -136,28 +136,24 @@ class FrozenStencil:
             len(self._argument_names) > 0
         ), "A stencil with no arguments? You may be double decorating"
 
-        self._field_origins: Dict[str, Tuple[int, ...]] = {}
+        field_info = self.stencil_object.field_info
+        self._field_origins: Dict[str, Tuple[int, ...]] = compute_field_origins(
+            field_info, self.origin
+        )
         """mapping from field names to field origins"""
 
-        self._stencil_run_kwargs: Dict[str, Any] = {}
+        self._stencil_run_kwargs: Dict[str, Any] = {
+            "_origin_": self._field_origins,
+            "_domain_": self.domain,
+        }
 
-        self._written_fields: List[str] = []
+        self._written_fields: List[str] = get_written_fields(field_info)
 
     def __call__(
         self,
         *args,
         **kwargs,
     ) -> None:
-        if not self._field_origins:
-            # Defer stencil object access until first call for distributed compilation
-            field_info = self.stencil_object.field_info
-            self._field_origins = compute_field_origins(field_info, self.origin)
-            self._stencil_run_kwargs = {
-                "_origin_": self._field_origins,
-                "_domain_": self.domain,
-            }
-            self._written_fields = get_written_fields(field_info)
-
         if self.stencil_config.validate_args:
             if __debug__ and "origin" in kwargs:
                 raise TypeError("origin cannot be passed to FrozenStencil call")

--- a/fv3core/utils/future_stencil.py
+++ b/fv3core/utils/future_stencil.py
@@ -207,7 +207,7 @@ def future_stencil(
 
     def _decorator(func):
         device_sync = kwargs.pop("device_sync", None)
-        backend_opts = {"device_sync": device_sync} if device_sync else {}
+        backend_opts = {"device_sync": device_sync} if device_sync is not None else {}
         builder = (
             StencilBuilder(func)
             .with_backend(backend)

--- a/fv3core/utils/future_stencil.py
+++ b/fv3core/utils/future_stencil.py
@@ -255,7 +255,6 @@ class FutureStencil:
         self._timeout = timeout
         self._node_id: int = MPI.COMM_WORLD.Get_rank() if MPI else 0
         self._stencil_object: Optional[StencilObject] = None
-        self._finished: bool = False
 
     @classmethod
     def clear(cls):
@@ -267,8 +266,6 @@ class FutureStencil:
 
     @property
     def stencil_object(self) -> StencilObject:
-        if self._finished:
-            raise RuntimeError("FutureStencil already called!")
         if self._stencil_object is None:
             self._wait_for_stencil()
         return self._stencil_object
@@ -341,7 +338,6 @@ class FutureStencil:
         # Assign wrapper's stencil_object (e.g,. FrozenStencil) if provided...
         if self._wrapper:
             self._wrapper.stencil_object = self._stencil_object
-            self._finished = True
 
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         return self.stencil_object(*args, **kwargs)

--- a/fv3core/utils/future_stencil.py
+++ b/fv3core/utils/future_stencil.py
@@ -255,6 +255,7 @@ class FutureStencil:
         self._timeout = timeout
         self._node_id: int = MPI.COMM_WORLD.Get_rank() if MPI else 0
         self._stencil_object: Optional[StencilObject] = None
+        self._finished: bool = False
 
     @classmethod
     def clear(cls):
@@ -266,6 +267,8 @@ class FutureStencil:
 
     @property
     def stencil_object(self) -> StencilObject:
+        if self._finished:
+            raise RuntimeError("FutureStencil already called!")
         if self._stencil_object is None:
             self._wait_for_stencil()
         return self._stencil_object
@@ -338,6 +341,7 @@ class FutureStencil:
         # Assign wrapper's stencil_object (e.g,. FrozenStencil) if provided...
         if self._wrapper:
             self._wrapper.stencil_object = self._stencil_object
+            self._finished = True
 
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         return self.stencil_object(*args, **kwargs)


### PR DESCRIPTION
## Purpose

This PR moves the `stencil_object.field_info` accesses back to the `FrozenStencil.__init__` method from `FrozenStencil.__call__` that was an attempt to make the `future_stencil` code more asynchronous, as the change had a potentially negative impact on GPU performance according to CI.

## Code changes:

- Move `stencil_object.field_info` access back to `FrozenStencil.__init__` from `FrozenStencil.__call__`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
